### PR TITLE
Make a port's child actually die when we stop it

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
@@ -251,13 +251,24 @@ defmodule Raxol.Symphony.PortReaper do
   # costing the full grace.
   defp signal(:unavailable, _target, _flag), do: {:error, :unavailable}
 
-  defp signal({:exe, path}, target, flag) do
-    run_signal(path, [flag, signal_arg(target)])
-  end
-
-  # `kill(1)` is a separate package (`procps` on Debian) that slim images leave
-  # out, while `bash` is already a hard dependency of every call site -- both
-  # spawn their child through it. Its builtin `kill` does the same job.
+  # Signals go through bash's `kill` BUILTIN, never `kill(1)`.
+  #
+  # procps-ng's `kill` -- `/usr/bin/kill` on Debian and Ubuntu, which is what CI
+  # runs -- takes a negative pid in its own argv slot, does NOTHING with it, and
+  # exits 0. Measured on linux/aarch64 with the group live:
+  # `System.cmd(kill, ["-KILL", "-57"])` returned `{"", 0}` and both members
+  # were still running afterwards. That is the worst failure available to this
+  # module, a reap that reports success and reaps nothing, and the exit status
+  # gives away none of it. `kill -s KILL -- -57` is no way out either: procps
+  # has no `--` and answers with a usage error.
+  #
+  # macOS's `/bin/kill` handles the same argv correctly, which is exactly why
+  # this was green on a developer machine and red on Linux CI.
+  #
+  # The builtin is POSIX about negative pids on both, and bash is already a hard
+  # dependency of every call site -- `Session.start/5` and
+  # `Workspace.execute_script/3` each spawn their child through it -- so where
+  # bash is missing there is no port child to reap in the first place.
   #
   # Arguments are passed positionally rather than interpolated into the script,
   # so nothing about the target can be read as shell.
@@ -278,15 +289,9 @@ defmodule Raxol.Symphony.PortReaper do
   end
 
   defp signaller do
-    case System.find_executable("kill") do
-      path when is_binary(path) ->
-        {:exe, path}
-
-      nil ->
-        case System.find_executable("bash") do
-          path when is_binary(path) -> {:bash, path}
-          nil -> :unavailable
-        end
+    case System.find_executable("bash") do
+      path when is_binary(path) -> {:bash, path}
+      nil -> :unavailable
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
@@ -10,7 +10,11 @@ defmodule Raxol.Symphony.PortReaper do
 
   Capture a target with `capture/1` while the port is still open, then either
   `kill/1` (we have given up on the work) or `await_exit/2` (let it go quietly
-  first, then insist).
+  first, then insist). `close/1` is the matching port teardown.
+
+  `watch/1` covers the case no `try/after` can: a caller killed with an
+  untrappable exit never runs its own cleanup, so the reap has to live in a
+  process that survives it.
 
   The remote counterpart is `Raxol.Symphony.Ssh.reap_on_disconnect/2`, which
   does the same job on the far side of an ssh connection with `set -m` and a
@@ -29,6 +33,29 @@ defmodule Raxol.Symphony.PortReaper do
   """
   @type target :: {:group, pos_integer()} | {:pid, pos_integer()} | :none
 
+  @typedoc "Handle returned by `watch/1`, to be handed back to `release/1`."
+  @type watcher :: pid() | :none
+
+  @typedoc """
+  Why a reap could not be carried out.
+
+  `:unavailable` is the one that matters: it means we could not run a signal at
+  all, so nothing was verified and nothing was killed. It must never be
+  reported as success -- a caller that is about to delete the target's working
+  directory is relying on the difference.
+  """
+  @type reason :: :unavailable
+
+  # A pid of 0 means "my own process group" and 1 means "everything I am
+  # allowed to signal". Neither is ever a port child, and either one turned
+  # into a group kill takes the VM (or the host) with it. `capture/1` cannot
+  # produce them, but `kill/1` and `await_exit/2` are public and this module
+  # exists precisely to not assume that.
+  defguardp is_signallable(target)
+            when is_tuple(target) and tuple_size(target) == 2 and
+                   elem(target, 0) in [:group, :pid] and
+                   is_integer(elem(target, 1)) and elem(target, 1) > 1
+
   @poll_ms 50
 
   @doc """
@@ -42,9 +69,33 @@ defmodule Raxol.Symphony.PortReaper do
   @spec capture(port()) :: target()
   def capture(port) when is_port(port) do
     case Port.info(port, :os_pid) do
-      nil -> :none
-      {:os_pid, os_pid} -> classify(os_pid)
+      # `:os_pid` is `:undefined` for a port that did not spawn a process, and
+      # the atom would otherwise flow all the way into an argv.
+      {:os_pid, os_pid} when is_integer(os_pid) and os_pid > 1 -> classify(os_pid)
+      _ -> :none
     end
+  end
+
+  @doc """
+  Close `port` if it is still open.
+
+  The child can exit on its own between the decision to stop it and the close.
+  `:exit_status` then closes the port for us, and `Port.close/1` raises on an
+  already-closed port.
+  """
+  @spec close(port()) :: :ok
+  def close(port) when is_port(port) do
+    case :erlang.port_info(port) do
+      :undefined ->
+        :ok
+
+      _ ->
+        Port.close(port)
+        :ok
+    end
+  rescue
+    # The port can close between the check above and the call: same outcome.
+    ArgumentError -> :ok
   end
 
   @doc """
@@ -52,23 +103,13 @@ defmodule Raxol.Symphony.PortReaper do
 
   For callers that have already stopped waiting, where a process that traps
   SIGTERM must not get to keep running anyway.
+
+  Returns `{:error, :unavailable}` when there is no way to send a signal on
+  this system, which is NOT the same as the target being gone.
   """
-  @spec kill(target()) :: :ok
+  @spec kill(target()) :: :ok | {:error, reason()}
   def kill(:none), do: :ok
-
-  def kill(target) do
-    case signal(target, "-KILL") do
-      {:ok, _} ->
-        :ok
-
-      {:error, reason} ->
-        Logger.warning(
-          "symphony.port_reaper.kill_failed target=#{inspect(target)} reason=#{inspect(reason)}"
-        )
-
-        :ok
-    end
-  end
+  def kill(target) when is_signallable(target), do: do_kill(signaller(), target)
 
   @doc """
   Wait up to `grace_ms` for the target to exit on its own, then SIGKILL it.
@@ -78,27 +119,126 @@ defmodule Raxol.Symphony.PortReaper do
   to flush and exit on its own terms. The kill is the backstop for the two
   cases EOF does not cover -- a child that never reads stdin, and the tool
   subprocesses that outlive a parent which DID exit cleanly.
-  """
-  @spec await_exit(target(), non_neg_integer()) :: :ok
-  def await_exit(:none, _grace_ms), do: :ok
 
-  def await_exit(target, grace_ms) do
+  Note the target was captured before the port closed, so across a long
+  `grace_ms` there is a window in which the group could drain and the OS recycle
+  the pid onto something unrelated. `kill/1` before the close avoids that
+  entirely and is the right call wherever the EOF is not wanted.
+  """
+  @spec await_exit(target(), non_neg_integer()) :: :ok | {:error, reason()}
+  def await_exit(:none, grace_ms) when is_integer(grace_ms) and grace_ms >= 0, do: :ok
+
+  def await_exit(target, grace_ms)
+      when is_signallable(target) and is_integer(grace_ms) and grace_ms >= 0 do
     deadline = System.monotonic_time(:millisecond) + grace_ms
-    poll_until_gone(target, deadline)
+
+    # Resolved once rather than per poll: this loop runs every 50ms and each
+    # resolution is a full PATH scan.
+    poll_until_gone(signaller(), target, deadline)
   end
 
-  defp poll_until_gone(target, deadline) do
-    cond do
-      not alive?(target) ->
+  @doc """
+  Reap `target` if the calling process dies before calling `release/1`.
+
+  `try/after` does not run when a process is taken down by an untrappable exit,
+  and that is how the orchestrator tears workers down (`stop_run`, stall
+  detection, reconcile-kill). Cleanup that has to survive that cannot live in
+  the dying process, so this spawns an unlinked one: it monitors the caller and
+  kills the target on `:DOWN`.
+
+  SIGKILL with no grace, unlike `await_exit/2`. An untrappable exit means the
+  caller was abandoned rather than shut down -- nothing is left to read a clean
+  exit's output, and the workspace may be removed next.
+
+  The window this leaves is the mirror of `await_exit/2`'s: if the child exits
+  on its own and the owner is killed much later, the captured target may by then
+  name something else. Callers that finish normally close that by calling
+  `release/1`.
+  """
+  @spec watch(target()) :: watcher()
+  def watch(:none), do: :none
+
+  def watch(target) when is_signallable(target) do
+    owner = self()
+
+    spawn(fn ->
+      ref = Process.monitor(owner)
+
+      receive do
+        # Signals from one process are ordered, so a `release/1` sent before the
+        # owner dies always arrives ahead of the `:DOWN`.
+        {:release, ^owner} ->
+          :ok
+
+        {:DOWN, ^ref, :process, ^owner, reason} ->
+          Logger.warning(
+            "symphony.port_reaper.owner_died target=#{inspect(target)} " <>
+              "reason=#{inspect(reason)} action=killed"
+          )
+
+          kill(target)
+      end
+    end)
+  end
+
+  @doc """
+  Stand down a watcher: the caller has reaped the target itself.
+  """
+  @spec release(watcher() | nil) :: :ok
+  def release(:none), do: :ok
+  def release(nil), do: :ok
+
+  def release(watcher) when is_pid(watcher) do
+    send(watcher, {:release, self()})
+    :ok
+  end
+
+  defp poll_until_gone(signaller, target, deadline) do
+    case signal(signaller, target, "-0") do
+      # Nothing signallable is left, which is the whole question.
+      :gone ->
         :ok
 
-      System.monotonic_time(:millisecond) >= deadline ->
-        Logger.debug("symphony.port_reaper.grace_expired target=#{inspect(target)}")
-        kill(target)
+      {:error, :unavailable} = err ->
+        err
 
-      true ->
-        Process.sleep(@poll_ms)
-        poll_until_gone(target, deadline)
+      :ok ->
+        keep_waiting(signaller, target, deadline)
+    end
+  end
+
+  defp keep_waiting(signaller, target, deadline) do
+    if System.monotonic_time(:millisecond) >= deadline do
+      # Operationally interesting: reaching here means the child ignored the
+      # EOF or left subprocesses behind, which is a fact about the child worth
+      # seeing at the default log level.
+      Logger.warning("symphony.port_reaper.grace_expired target=#{inspect(target)} action=killed")
+
+      do_kill(signaller, target)
+    else
+      Process.sleep(@poll_ms)
+      poll_until_gone(signaller, target, deadline)
+    end
+  end
+
+  defp do_kill(signaller, target) do
+    case signal(signaller, target, "-KILL") do
+      :ok ->
+        :ok
+
+      # Already gone. Routine: the whole point of the grace is that the target
+      # usually exits inside it, and the workspace path kills into a live race.
+      :gone ->
+        Logger.debug("symphony.port_reaper.already_gone target=#{inspect(target)}")
+        :ok
+
+      {:error, :unavailable} = err ->
+        Logger.warning(
+          "symphony.port_reaper.kill_unavailable target=#{inspect(target)} " <>
+            "detail=no_kill_executable_and_no_bash"
+        )
+
+        err
     end
   end
 
@@ -109,21 +249,43 @@ defmodule Raxol.Symphony.PortReaper do
   # A zombie answers "alive" here, since it still holds its pid. `erl_child_setup`
   # reaps its own children promptly, so that resolves on its own rather than
   # costing the full grace.
-  defp alive?(:none), do: false
+  defp signal(:unavailable, _target, _flag), do: {:error, :unavailable}
 
-  defp alive?(target) do
-    match?({:ok, _}, signal(target, "-0"))
+  defp signal({:exe, path}, target, flag) do
+    run_signal(path, [flag, signal_arg(target)])
   end
 
-  defp signal(target, flag) do
-    case System.find_executable("kill") do
-      nil ->
-        {:error, :no_kill_executable}
+  # `kill(1)` is a separate package (`procps` on Debian) that slim images leave
+  # out, while `bash` is already a hard dependency of every call site -- both
+  # spawn their child through it. Its builtin `kill` does the same job.
+  #
+  # Arguments are passed positionally rather than interpolated into the script,
+  # so nothing about the target can be read as shell.
+  defp signal({:bash, path}, target, flag) do
+    run_signal(path, ["-c", ~s(kill "$1" "$2"), "raxol-port-reaper", flag, signal_arg(target)])
+  end
 
-      kill_path ->
-        case System.cmd(kill_path, [flag, signal_arg(target)], stderr_to_stdout: true) do
-          {output, 0} -> {:ok, output}
-          {output, status} -> {:error, {status, String.trim(output)}}
+  defp run_signal(path, args) do
+    case System.cmd(path, args, stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {_output, _status} -> :gone
+    end
+  rescue
+    # The executable resolved a moment ago and cannot be run now.
+    e in [ErlangError, ArgumentError] ->
+      Logger.debug("symphony.port_reaper.signal_raised error=#{inspect(e)}")
+      {:error, :unavailable}
+  end
+
+  defp signaller do
+    case System.find_executable("kill") do
+      path when is_binary(path) ->
+        {:exe, path}
+
+      nil ->
+        case System.find_executable("bash") do
+          path when is_binary(path) -> {:bash, path}
+          nil -> :unavailable
         end
     end
   end
@@ -142,19 +304,43 @@ defmodule Raxol.Symphony.PortReaper do
   # not a group leader shares the BEAM's own group, and the group kill would
   # take the VM down with it. The `{:pid, _}` fallback loses the descendants and
   # keeps the VM.
+  #
+  # Falling back is safe but not free -- it silently drops the descendants --
+  # so it says so rather than degrading quietly.
   defp classify(os_pid) do
-    if group_leader?(os_pid), do: {:group, os_pid}, else: {:pid, os_pid}
+    case process_group(os_pid) do
+      {:ok, ^os_pid} ->
+        {:group, os_pid}
+
+      {:ok, pgid} ->
+        warn_no_group_kill(os_pid, "not_group_leader pgid=#{pgid}")
+        {:pid, os_pid}
+
+      :error ->
+        warn_no_group_kill(os_pid, "pgid_unavailable")
+        {:pid, os_pid}
+    end
+  end
+
+  defp warn_no_group_kill(os_pid, reason) do
+    Logger.warning(
+      "symphony.port_reaper.no_group_kill os_pid=#{os_pid} reason=#{reason} " <>
+        "detail=descendants_will_survive"
+    )
   end
 
   # A `ps` that is missing, fails, or answers something unparseable resolves the
   # same conservative way, for the same reason.
-  defp group_leader?(os_pid) do
+  defp process_group(os_pid) do
     with ps_path when is_binary(ps_path) <- System.find_executable("ps"),
          {output, 0} <-
-           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true) do
-      String.trim(output) == "#{os_pid}"
+           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true),
+         {pgid, ""} <- output |> String.trim() |> Integer.parse() do
+      {:ok, pgid}
     else
-      _ -> false
+      _ -> :error
     end
+  rescue
+    _ -> :error
   end
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
@@ -39,12 +39,14 @@ defmodule Raxol.Symphony.PortReaper do
   @typedoc """
   Why a reap could not be carried out.
 
-  `:unavailable` is the one that matters: it means we could not run a signal at
-  all, so nothing was verified and nothing was killed. It must never be
-  reported as success -- a caller that is about to delete the target's working
-  directory is relying on the difference.
+  Neither may be reported as success: a caller that is about to delete the
+  target's working directory is relying on the difference.
+
+  `:unavailable` means no signal could be run at all, so nothing was verified
+  and nothing was killed. `:refused` means the kernel rejected the signal
+  (EPERM) -- the target is demonstrably still there, and still running.
   """
-  @type reason :: :unavailable
+  @type reason :: :unavailable | :refused
 
   # A pid of 0 means "my own process group" and 1 means "everything I am
   # allowed to signal". Neither is ever a port child, and either one turned
@@ -61,10 +63,14 @@ defmodule Raxol.Symphony.PortReaper do
   @doc """
   Read the signal target off a live port.
 
-  Call this BEFORE closing the port. Once the child has exited, `ps` answers
-  nothing about it, and the process group its orphans are still in is no longer
-  recoverable -- a process group outlives its leader, which is exactly the case
-  worth reaping.
+  Call this BEFORE closing the port. `Port.info/2` is the only thing that knows
+  the child's pid, and a closed port has forgotten it, so from then on the
+  process group the orphans are still in is unrecoverable -- and a group
+  outliving its leader is exactly the case worth reaping.
+
+  `:none` means the PORT is closed. It does not mean nothing is running. A
+  caller that can reach a closed port should keep the target it captured while
+  the port was open and fall back to that.
   """
   @spec capture(port()) :: target()
   def capture(port) when is_port(port) do
@@ -122,8 +128,15 @@ defmodule Raxol.Symphony.PortReaper do
 
   Note the target was captured before the port closed, so across a long
   `grace_ms` there is a window in which the group could drain and the OS recycle
-  the pid onto something unrelated. `kill/1` before the close avoids that
-  entirely and is the right call wherever the EOF is not wanted.
+  the pid onto something unrelated. `kill/1` before the close narrows that
+  window and is the right call wherever the EOF is not wanted, but it does not
+  close it: a port stays open for as long as ANY descendant holds the inherited
+  stdout, so the child can already be dead and reaped while `Port.info/2` still
+  reports its pid.
+
+  Nothing pid-based can close that window. What bounds it is that a group id
+  cannot be recycled while the group still has a member, so a stale target can
+  only mislead once the reap has nothing left to do anyway.
   """
   @spec await_exit(target(), non_neg_integer()) :: :ok | {:error, reason()}
   def await_exit(:none, grace_ms) when is_integer(grace_ms) and grace_ms >= 0, do: :ok
@@ -199,7 +212,9 @@ defmodule Raxol.Symphony.PortReaper do
       :gone ->
         :ok
 
-      {:error, :unavailable} = err ->
+      # Waiting cannot fix either of these, and both mean the target may still
+      # be running, so they are answered now rather than at the deadline.
+      {:error, _reason} = err ->
         err
 
       :ok ->
@@ -232,15 +247,18 @@ defmodule Raxol.Symphony.PortReaper do
         Logger.debug("symphony.port_reaper.already_gone target=#{inspect(target)}")
         :ok
 
-      {:error, :unavailable} = err ->
+      {:error, reason} = err ->
         Logger.warning(
-          "symphony.port_reaper.kill_unavailable target=#{inspect(target)} " <>
-            "detail=no_kill_executable_and_no_bash"
+          "symphony.port_reaper.kill_failed target=#{inspect(target)} " <>
+            "reason=#{inspect(reason)} detail=#{unreaped_detail(reason)}"
         )
 
         err
     end
   end
+
+  defp unreaped_detail(:unavailable), do: "no_bash_on_path"
+  defp unreaped_detail(:refused), do: "kernel_refused_the_signal_target_still_running"
 
   # `kill -0` reports whether anything signallable is left. Against a GROUP that
   # is the question worth asking: the leader can be gone while an orphaned tool
@@ -276,16 +294,43 @@ defmodule Raxol.Symphony.PortReaper do
     run_signal(path, ["-c", ~s(kill "$1" "$2"), "raxol-port-reaper", flag, signal_arg(target)])
   end
 
+  # The builtin exits 1 for EVERY failure, so the status alone cannot tell
+  # "already dead" (ESRCH) from "the kernel refused" (EPERM). Only the errno
+  # text can, and it is read with the locale pinned to C: macOS libc does not
+  # translate `strerror` at all, but glibc does, and CI is glibc.
   defp run_signal(path, args) do
-    case System.cmd(path, args, stderr_to_stdout: true) do
+    case System.cmd(path, args, stderr_to_stdout: true, env: [{"LC_ALL", "C"}, {"LANG", "C"}]) do
       {_output, 0} -> :ok
-      {_output, _status} -> :gone
+      {output, _status} -> classify_failure(output)
     end
   rescue
     # The executable resolved a moment ago and cannot be run now.
     e in [ErlangError, ArgumentError] ->
       Logger.debug("symphony.port_reaper.signal_raised error=#{inspect(e)}")
       {:error, :unavailable}
+  end
+
+  # EPERM is matched POSITIVELY and ESRCH is the default, rather than the other
+  # way round, because the two are not equally likely and the failure directions
+  # are not equally cheap.
+  #
+  # "Already gone" is the routine answer -- the whole point of the grace is that
+  # the target usually exits inside it. A refusal needs something in the port
+  # child's own process group that this uid may not signal, which takes a setuid
+  # binary in a hook. So an unrecognised message degrades to exactly the
+  # behaviour this module had before the distinction existed, instead of turning
+  # every routine reap into a spurious "could not reap" warning ahead of an
+  # `rm_rf` -- and, through `classify/1`, into a group target for a group that
+  # is not there.
+  #
+  # The distinction is diagnostics. Nothing about whether a reap actually lands
+  # depends on getting it right.
+  defp classify_failure(output) do
+    if output =~ ~r/operation not permitted/i do
+      {:error, :refused}
+    else
+      :gone
+    end
   end
 
   defp signaller do
@@ -310,19 +355,44 @@ defmodule Raxol.Symphony.PortReaper do
   # take the VM down with it. The `{:pid, _}` fallback loses the descendants and
   # keeps the VM.
   #
+  # The check is a `kill -0` against the GROUP rather than a `ps` read of the
+  # child's pgid, and that is load-bearing rather than a tidy-up.
+  #
+  # A process group's id is the pid of its leader, and that pid stays allocated
+  # for as long as the group has any member at all. So "group `os_pid` answers
+  # a signal" can only be true if the process holding pid `os_pid` -- our child,
+  # since the port is open -- is the one that led it. A child that is NOT a
+  # group leader has no group under its own id, the probe says so, and the
+  # fallback keeps the VM. The BEAM's own group is unreachable here by
+  # construction rather than by inspection.
+  #
+  # `ps` could not answer this at all in the case that matters most. A hook that
+  # backgrounds a child and exits leaves the port OPEN -- ERTS withholds the
+  # exit status until the inherited stdout reaches EOF and the orphan is still
+  # holding it -- while `Port.info/2` goes on reporting the dead parent's pid.
+  # `ps -o pgid= -p <dead pid>` fails there, which classified the live group as
+  # `{:pid, <corpse>}`, SIGKILLed a pid nobody owns, and reported success while
+  # the orphan the reap exists for kept running. It was also the module's only
+  # dependency on a `ps` that busybox does not implement.
+  #
   # Falling back is safe but not free -- it silently drops the descendants --
   # so it says so rather than degrading quietly.
   defp classify(os_pid) do
-    case process_group(os_pid) do
-      {:ok, ^os_pid} ->
+    case signal(signaller(), {:group, os_pid}, "-0") do
+      :ok ->
         {:group, os_pid}
 
-      {:ok, pgid} ->
-        warn_no_group_kill(os_pid, "not_group_leader pgid=#{pgid}")
+      # EPERM is an existence proof: the kernel can only refuse a signal to
+      # something that is there.
+      {:error, :refused} ->
+        {:group, os_pid}
+
+      :gone ->
+        warn_no_group_kill(os_pid, "no_process_group_under_that_id")
         {:pid, os_pid}
 
-      :error ->
-        warn_no_group_kill(os_pid, "pgid_unavailable")
+      {:error, :unavailable} ->
+        warn_no_group_kill(os_pid, "no_bash_to_probe_with")
         {:pid, os_pid}
     end
   end
@@ -332,20 +402,5 @@ defmodule Raxol.Symphony.PortReaper do
       "symphony.port_reaper.no_group_kill os_pid=#{os_pid} reason=#{reason} " <>
         "detail=descendants_will_survive"
     )
-  end
-
-  # A `ps` that is missing, fails, or answers something unparseable resolves the
-  # same conservative way, for the same reason.
-  defp process_group(os_pid) do
-    with ps_path when is_binary(ps_path) <- System.find_executable("ps"),
-         {output, 0} <-
-           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true),
-         {pgid, ""} <- output |> String.trim() |> Integer.parse() do
-      {:ok, pgid}
-    else
-      _ -> :error
-    end
-  rescue
-    _ -> :error
   end
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
@@ -1,0 +1,160 @@
+defmodule Raxol.Symphony.PortReaper do
+  @moduledoc """
+  Stop the OS process behind a `Port`, and the descendants it spawned.
+
+  `Port.close/1` releases the BEAM-side port and signals NOTHING. What becomes
+  of the child is entirely the child's business: one that reads its stdin sees
+  EOF and usually exits, one that does not simply keeps running, and in BOTH
+  cases the subprocesses it spawned are untouched and outlive it. A caller that
+  needs the work actually stopped has to signal it.
+
+  Capture a target with `capture/1` while the port is still open, then either
+  `kill/1` (we have given up on the work) or `await_exit/2` (let it go quietly
+  first, then insist).
+
+  The remote counterpart is `Raxol.Symphony.Ssh.reap_on_disconnect/2`, which
+  does the same job on the far side of an ssh connection with `set -m` and a
+  group kill inside bash.
+  """
+
+  require Logger
+
+  @typedoc """
+  What may safely be signalled.
+
+  `{:group, pgid}` when the child leads its own process group, so its
+  descendants come with it. `{:pid, os_pid}` when it does not, in which case
+  only the child itself can be signalled. `:none` when the child is already
+  gone.
+  """
+  @type target :: {:group, pos_integer()} | {:pid, pos_integer()} | :none
+
+  @poll_ms 50
+
+  @doc """
+  Read the signal target off a live port.
+
+  Call this BEFORE closing the port. Once the child has exited, `ps` answers
+  nothing about it, and the process group its orphans are still in is no longer
+  recoverable -- a process group outlives its leader, which is exactly the case
+  worth reaping.
+  """
+  @spec capture(port()) :: target()
+  def capture(port) when is_port(port) do
+    case Port.info(port, :os_pid) do
+      nil -> :none
+      {:os_pid, os_pid} -> classify(os_pid)
+    end
+  end
+
+  @doc """
+  SIGKILL the target now.
+
+  For callers that have already stopped waiting, where a process that traps
+  SIGTERM must not get to keep running anyway.
+  """
+  @spec kill(target()) :: :ok
+  def kill(:none), do: :ok
+
+  def kill(target) do
+    case signal(target, "-KILL") do
+      {:ok, _} ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "symphony.port_reaper.kill_failed target=#{inspect(target)} reason=#{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
+
+  @doc """
+  Wait up to `grace_ms` for the target to exit on its own, then SIGKILL it.
+
+  For a clean shutdown, where closing the port has already delivered the EOF a
+  well-behaved stdio child treats as "shut down": that child should be allowed
+  to flush and exit on its own terms. The kill is the backstop for the two
+  cases EOF does not cover -- a child that never reads stdin, and the tool
+  subprocesses that outlive a parent which DID exit cleanly.
+  """
+  @spec await_exit(target(), non_neg_integer()) :: :ok
+  def await_exit(:none, _grace_ms), do: :ok
+
+  def await_exit(target, grace_ms) do
+    deadline = System.monotonic_time(:millisecond) + grace_ms
+    poll_until_gone(target, deadline)
+  end
+
+  defp poll_until_gone(target, deadline) do
+    cond do
+      not alive?(target) ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        Logger.debug("symphony.port_reaper.grace_expired target=#{inspect(target)}")
+        kill(target)
+
+      true ->
+        Process.sleep(@poll_ms)
+        poll_until_gone(target, deadline)
+    end
+  end
+
+  # `kill -0` reports whether anything signallable is left. Against a GROUP that
+  # is the question worth asking: the leader can be gone while an orphaned tool
+  # subprocess keeps the group alive.
+  #
+  # A zombie answers "alive" here, since it still holds its pid. `erl_child_setup`
+  # reaps its own children promptly, so that resolves on its own rather than
+  # costing the full grace.
+  defp alive?(:none), do: false
+
+  defp alive?(target) do
+    match?({:ok, _}, signal(target, "-0"))
+  end
+
+  defp signal(target, flag) do
+    case System.find_executable("kill") do
+      nil ->
+        {:error, :no_kill_executable}
+
+      kill_path ->
+        case System.cmd(kill_path, [flag, signal_arg(target)], stderr_to_stdout: true) do
+          {output, 0} -> {:ok, output}
+          {output, status} -> {:error, {status, String.trim(output)}}
+        end
+    end
+  end
+
+  defp signal_arg({:group, pgid}), do: "-#{pgid}"
+  defp signal_arg({:pid, os_pid}), do: "#{os_pid}"
+
+  # Signal the process GROUP wherever it is safe to, because killing only the
+  # child leaves its descendants running: still doing work, and still holding
+  # the inherited stdout pipe, so a reader waiting on EOF blocks for the
+  # command's full natural runtime after the supposed kill.
+  #
+  # `erl_child_setup` gives a spawned port child a process group of its own, so
+  # `kill -KILL -PID` reaches its descendants and nothing else. That is CHECKED
+  # rather than assumed, because the failure mode is not subtle: a child that is
+  # not a group leader shares the BEAM's own group, and the group kill would
+  # take the VM down with it. The `{:pid, _}` fallback loses the descendants and
+  # keeps the VM.
+  defp classify(os_pid) do
+    if group_leader?(os_pid), do: {:group, os_pid}, else: {:pid, os_pid}
+  end
+
+  # A `ps` that is missing, fails, or answers something unparseable resolves the
+  # same conservative way, for the same reason.
+  defp group_leader?(os_pid) do
+    with ps_path when is_binary(ps_path) <- System.find_executable("ps"),
+         {output, 0} <-
+           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true) do
+      String.trim(output) == "#{os_pid}"
+    else
+      _ -> false
+    end
+  end
+end

--- a/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
@@ -19,6 +19,25 @@ defmodule Raxol.Symphony.PortReaper do
   The remote counterpart is `Raxol.Symphony.Ssh.reap_on_disconnect/2`, which
   does the same job on the far side of an ssh connection with `set -m` and a
   group kill inside bash.
+
+  ## Relationship to `Raxol.Agent.Interrupt`
+
+  That module solves the same OS problem for the agent's shell tool and answers
+  it differently: it proves group leadership by reading `pgid` out of `ps` and
+  requiring `pgid == os_pid`, where this probes with `kill -0` against the group.
+
+  The difference is not cosmetic. `ps` cannot see a corpse, so when a hook
+  backgrounds a child and exits -- the commonest leak shape, and the one that
+  keeps the port open while `Port.info/2` still names the dead parent -- the
+  `ps` read fails and the group is never found. `Interrupt` has a
+  `descendants_of/1` sweep that covers some of that through ppid linkage, which
+  a reparented orphan is also invisible to. It additionally interpolates the pid
+  into a shell string rather than passing it positionally, and depends on a `ps`
+  that busybox does not implement.
+
+  Consolidating onto this module is worth doing and is NOT done here: it is a
+  different package with its own tests, and `raxol_symphony` takes `raxol_agent`
+  only as an optional dependency.
   """
 
   require Logger
@@ -39,14 +58,25 @@ defmodule Raxol.Symphony.PortReaper do
   @typedoc """
   Why a reap could not be carried out.
 
-  Neither may be reported as success: a caller that is about to delete the
+  NONE of these may be reported as success: a caller that is about to delete the
   target's working directory is relying on the difference.
 
-  `:unavailable` means no signal could be run at all, so nothing was verified
-  and nothing was killed. `:refused` means the kernel rejected the signal
-  (EPERM) -- the target is demonstrably still there, and still running.
+  `:unavailable` -- no signal could be run at all (no bash), so nothing was
+  verified and nothing was killed.
+
+  `:refused` -- the kernel rejected the signal (EPERM). The target is
+  demonstrably still there, and still running.
+
+  `:spawn_failed` -- bash resolved but could not be run this time. Transient by
+  nature (a fork that hit `EAGAIN` under process-table pressure is the case that
+  matters, and process-table pressure is exactly when a leaked-process reaper is
+  most needed), so it is RETRIED rather than answered.
+
+  `:unknown` -- the signal failed with something this does not recognise. Not
+  reported as `:gone`, because "the message was not one I know" is not evidence
+  that the target exited.
   """
-  @type reason :: :unavailable | :refused
+  @type reason :: :unavailable | :refused | :spawn_failed | :unknown
 
   # A pid of 0 means "my own process group" and 1 means "everything I am
   # allowed to signal". Neither is ever a port child, and either one turned
@@ -59,6 +89,12 @@ defmodule Raxol.Symphony.PortReaper do
                    is_integer(elem(target, 1)) and elem(target, 1) > 1
 
   @poll_ms 50
+
+  # `kill/1` answers immediately, so a transient fork failure has no deadline to
+  # be retried against the way `await_exit/2`'s poll does. Small on purpose: this
+  # is covering an `EAGAIN`, not waiting anything out.
+  @kill_attempts 3
+  @retry_ms 25
 
   @doc """
   Read the signal target off a live port.
@@ -134,9 +170,16 @@ defmodule Raxol.Symphony.PortReaper do
   stdout, so the child can already be dead and reaped while `Port.info/2` still
   reports its pid.
 
-  Nothing pid-based can close that window. What bounds it is that a group id
-  cannot be recycled while the group still has a member, so a stale target can
-  only mislead once the reap has nothing left to do anyway.
+  Nothing pid-based can close that window. What BOUNDS it is that a group id
+  cannot be recycled while the group still has a member -- so for as long as
+  there is anything to kill, the target is exact.
+
+  That is a bound, not a guarantee of harmlessness, and the difference matters
+  for anything holding a target across a long idle period. Once the group HAS
+  drained its id is free for reuse, and a reap fired then is not a no-op: it is
+  a `SIGKILL` at whatever unrelated process group now carries that id. This
+  function is safe because it probes with `kill -0` and stops at `:gone` before
+  signalling anything; a caller that skips the probe does not inherit that.
   """
   @spec await_exit(target(), non_neg_integer()) :: :ok | {:error, reason()}
   def await_exit(:none, grace_ms) when is_integer(grace_ms) and grace_ms >= 0, do: :ok
@@ -163,10 +206,15 @@ defmodule Raxol.Symphony.PortReaper do
   caller was abandoned rather than shut down -- nothing is left to read a clean
   exit's output, and the workspace may be removed next.
 
-  The window this leaves is the mirror of `await_exit/2`'s: if the child exits
-  on its own and the owner is killed much later, the captured target may by then
-  name something else. Callers that finish normally close that by calling
-  `release/1`.
+  The window this leaves is the mirror of `await_exit/2`'s, and unlike that one
+  it is NOT probed away: `kill/1` signals whatever the captured target names. If
+  the child exits on its own, its group drains, and the owner is killed long
+  enough afterwards for the OS to have recycled the pgid, the reap lands on an
+  unrelated process group. Callers that finish normally close that window by
+  calling `release/1`; hold a watcher across a long idle period and it reopens.
+
+  The watcher also reaps when it is SHUT DOWN, not only when its owner dies, so
+  a supervised teardown of the tree does not leak the trees below it.
   """
   @spec watch(target()) :: watcher()
   def watch(:none), do: :none
@@ -174,28 +222,79 @@ defmodule Raxol.Symphony.PortReaper do
   def watch(target) when is_signallable(target) do
     owner = self()
 
-    spawn(fn ->
-      ref = Process.monitor(owner)
+    spawn_watcher(fn -> watch_loop(owner, target) end)
+  end
 
-      receive do
-        # Signals from one process are ordered, so a `release/1` sent before the
-        # owner dies always arrives ahead of the `:DOWN`.
-        {:release, ^owner} ->
-          :ok
+  # Under `Raxol.Symphony.TaskSupervisor` when the tree is up, and a bare
+  # `spawn/1` when it is not (tests, and embedders that use `Session` without the
+  # supervisor).
+  #
+  # The supervised form is what makes shutdown reaping possible at all: a task is
+  # linked to its Task.Supervisor but NOT to the caller, which is exactly the
+  # lifetime a watcher wants. A bare unlinked `spawn/1` receives no exit signal
+  # from anything, so it cannot be told the VM is going away -- it is a fallback,
+  # not an equivalent, and a deployment running without the tree still leaks its
+  # in-flight trees on restart.
+  #
+  # `TaskSupervisor` is FIRST in the supervisor's child list, and children
+  # terminate in reverse order, so watchers are torn down after the workers whose
+  # targets they are covering.
+  defp spawn_watcher(fun) do
+    case Process.whereis(Raxol.Symphony.TaskSupervisor) do
+      nil ->
+        spawn(fun)
 
-        {:DOWN, ^ref, :process, ^owner, reason} ->
-          Logger.warning(
-            "symphony.port_reaper.owner_died target=#{inspect(target)} " <>
-              "reason=#{inspect(reason)} action=killed"
-          )
+      _sup ->
+        case Task.Supervisor.start_child(Raxol.Symphony.TaskSupervisor, fun) do
+          {:ok, pid} -> pid
+          # Racing the tree going down, or at capacity. An unsupervised watcher
+          # still covers the owner-death case, which is the common one.
+          _other -> spawn(fun)
+        end
+    end
+  end
 
-          kill(target)
-      end
-    end)
+  defp watch_loop(owner, target) do
+    # Trapped so a supervised shutdown arrives as a message rather than killing
+    # the watcher outright: an orchestrator restart would otherwise abandon every
+    # tree in flight.
+    Process.flag(:trap_exit, true)
+    ref = Process.monitor(owner)
+
+    receive do
+      # NOT pinned to `owner`. Holding the watcher pid IS the authority to stand
+      # it down, and pinning made `release/1` silently no-op whenever the process
+      # calling it was not the one that called `watch/1` -- leaving a watcher
+      # armed to SIGKILL a target its caller had already reaped, with nothing
+      # anywhere reporting that the disarm had failed.
+      {:release, _from} ->
+        :ok
+
+      {:DOWN, ^ref, :process, ^owner, reason} ->
+        Logger.warning(
+          "symphony.port_reaper.owner_died target=#{inspect(target)} " <>
+            "reason=#{inspect(reason)} action=killed"
+        )
+
+        kill(target)
+
+      # The supervisor is going down and taking this with it. Reaching here means
+      # the owner is still alive, so nothing else is going to reap the target.
+      {:EXIT, _from, reason} ->
+        Logger.warning(
+          "symphony.port_reaper.watcher_shutdown target=#{inspect(target)} " <>
+            "reason=#{inspect(reason)} action=killed"
+        )
+
+        kill(target)
+    end
   end
 
   @doc """
   Stand down a watcher: the caller has reaped the target itself.
+
+  Any process holding the watcher pid may call this, not only the one that
+  called `watch/1`.
   """
   @spec release(watcher() | nil) :: :ok
   def release(:none), do: :ok
@@ -212,8 +311,15 @@ defmodule Raxol.Symphony.PortReaper do
       :gone ->
         :ok
 
-      # Waiting cannot fix either of these, and both mean the target may still
-      # be running, so they are answered now rather than at the deadline.
+      # Could not fork bash this time. Giving up here would abandon the reap
+      # under process-table pressure -- the one condition that both causes this
+      # and makes a leaked process tree matter -- so it is retried on the same
+      # deadline as a target that is simply still running.
+      {:error, :spawn_failed} ->
+        keep_waiting(signaller, target, deadline)
+
+      # Waiting cannot fix these, and each means the target may still be
+      # running, so they are answered now rather than at the deadline.
       {:error, _reason} = err ->
         err
 
@@ -236,7 +342,9 @@ defmodule Raxol.Symphony.PortReaper do
     end
   end
 
-  defp do_kill(signaller, target) do
+  defp do_kill(signaller, target), do: do_kill(signaller, target, @kill_attempts)
+
+  defp do_kill(signaller, target, attempts_left) do
     case signal(signaller, target, "-KILL") do
       :ok ->
         :ok
@@ -246,6 +354,12 @@ defmodule Raxol.Symphony.PortReaper do
       :gone ->
         Logger.debug("symphony.port_reaper.already_gone target=#{inspect(target)}")
         :ok
+
+      # `kill/1` has no deadline to retry against, so it carries its own small
+      # budget rather than reporting a fork failure as an unreaped target.
+      {:error, :spawn_failed} when attempts_left > 1 ->
+        Process.sleep(@retry_ms)
+        do_kill(signaller, target, attempts_left - 1)
 
       {:error, reason} = err ->
         Logger.warning(
@@ -259,6 +373,8 @@ defmodule Raxol.Symphony.PortReaper do
 
   defp unreaped_detail(:unavailable), do: "no_bash_on_path"
   defp unreaped_detail(:refused), do: "kernel_refused_the_signal_target_still_running"
+  defp unreaped_detail(:spawn_failed), do: "could_not_run_bash_target_not_verified"
+  defp unreaped_detail(:unknown), do: "unrecognised_kill_failure_target_not_verified"
 
   # `kill -0` reports whether anything signallable is left. Against a GROUP that
   # is the question worth asking: the leader can be gone while an orphaned tool
@@ -298,38 +414,48 @@ defmodule Raxol.Symphony.PortReaper do
   # "already dead" (ESRCH) from "the kernel refused" (EPERM). Only the errno
   # text can, and it is read with the locale pinned to C: macOS libc does not
   # translate `strerror` at all, but glibc does, and CI is glibc.
+  #
+  # `BASH_ENV` and `ENV` are unset for the same reason the target is passed
+  # positionally. Bash sources `$BASH_ENV` for NON-INTERACTIVE shells, `bash -c`
+  # included, so inheriting it hands whatever set it arbitrary execution -- once
+  # per capture, once per stop, and once per poll of every grace window. Passing
+  # the target safely is not worth much if the interpreter reading it was
+  # configured by someone else.
   defp run_signal(path, args) do
-    case System.cmd(path, args, stderr_to_stdout: true, env: [{"LC_ALL", "C"}, {"LANG", "C"}]) do
+    env = [{"BASH_ENV", nil}, {"ENV", nil}, {"LC_ALL", "C"}, {"LANG", "C"}]
+
+    case System.cmd(path, args, stderr_to_stdout: true, env: env) do
       {_output, 0} -> :ok
       {output, _status} -> classify_failure(output)
     end
   rescue
-    # The executable resolved a moment ago and cannot be run now.
+    # bash resolved a moment ago and cannot be run now. A fork that hit EAGAIN
+    # under process-table pressure is the case worth surviving -- that pressure
+    # is exactly when a leaked-process reaper is most needed -- so this is
+    # retriable rather than terminal.
     e in [ErlangError, ArgumentError] ->
       Logger.debug("symphony.port_reaper.signal_raised error=#{inspect(e)}")
-      {:error, :unavailable}
+      {:error, :spawn_failed}
   end
 
-  # EPERM is matched POSITIVELY and ESRCH is the default, rather than the other
-  # way round, because the two are not equally likely and the failure directions
-  # are not equally cheap.
+  # ESRCH is matched POSITIVELY and anything unrecognised is an error, rather
+  # than the other way round.
   #
-  # "Already gone" is the routine answer -- the whole point of the grace is that
-  # the target usually exits inside it. A refusal needs something in the port
-  # child's own process group that this uid may not signal, which takes a setuid
-  # binary in a hook. So an unrecognised message degrades to exactly the
-  # behaviour this module had before the distinction existed, instead of turning
-  # every routine reap into a spurious "could not reap" warning ahead of an
-  # `rm_rf` -- and, through `classify/1`, into a group target for a group that
-  # is not there.
+  # The two mistakes do not cost the same. A false `:refused` logs a warning. A
+  # false `:gone` reports a SUCCESSFUL REAP to a caller that is about to `rm_rf`
+  # the directory the process is still writing into -- the exact failure the
+  # moduledoc calls the worst one available here, so defaulting to it was
+  # building it in.
   #
-  # The distinction is diagnostics. Nothing about whether a reap actually lands
-  # depends on getting it right.
+  # Two real failures that reach this and are not EPERM: a seccomp or LSM filter
+  # answers EACCES, whose text is "Permission denied" and not "Operation not
+  # permitted"; and a bash whose builtin rejects the flag answers with a usage
+  # error. Neither is evidence that the target exited.
   defp classify_failure(output) do
-    if output =~ ~r/operation not permitted/i do
-      {:error, :refused}
-    else
-      :gone
+    cond do
+      output =~ ~r/no such process/i -> :gone
+      output =~ ~r/operation not permitted/i -> {:error, :refused}
+      true -> {:error, :unknown}
     end
   end
 
@@ -391,8 +517,11 @@ defmodule Raxol.Symphony.PortReaper do
         warn_no_group_kill(os_pid, "no_process_group_under_that_id")
         {:pid, os_pid}
 
-      {:error, :unavailable} ->
-        warn_no_group_kill(os_pid, "no_bash_to_probe_with")
+      # Could not prove a group is there. The narrow target is the safe
+      # direction -- it loses the descendants, where a group kill against a
+      # group that is not ours would not be recoverable at all.
+      {:error, reason} ->
+        warn_no_group_kill(os_pid, "group_probe_failed_#{reason}")
         {:pid, os_pid}
     end
   end

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
@@ -63,6 +63,13 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   # far side on disconnect -- but that path costs a poll interval and reaps the
   # remote codex with a signal instead of letting it exit on the EOF, so it is
   # worth waiting to avoid.
+  #
+  # Longer than the 5s a `Task.Supervisor` child gets to shut down, which is
+  # deliberate. A worker torn down with the tree is killed outright and never
+  # reaches this `after` at all -- `PortReaper.watch/1` is what reaps then, and
+  # it is supervised so that shutdown reaches it. Shortening this to fit inside
+  # the shutdown window would buy nothing there and would SIGKILL healthy ssh
+  # clients on every ordinary stop.
   @remote_stop_grace_ms 10_000
 
   # ---------------------------------------------------------------------------
@@ -201,7 +208,7 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
       stop_port(
         port,
         Map.get(session, :stop_grace_ms) || @stop_grace_ms,
-        Map.get(session, :reap_target, :none)
+        reap_target(session)
       )
 
     # Released last: until the reap has actually happened the watcher is the
@@ -247,6 +254,30 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
 
   defp current_or_captured(:none, captured_at_start), do: captured_at_start
   defp current_or_captured(current, _captured_at_start), do: current
+
+  # `stop/1` runs in the `after` of every codex run, and an exception raised
+  # there discards whatever `run_turns` was returning or raising. `PortReaper`'s
+  # signal functions guard their target and raise on anything outside it -- which
+  # is right at that layer, since a bad target there means signalling pid 0 or 1
+  # -- so a session map from an unexpected source is normalised here instead of
+  # being handed straight through.
+  defp reap_target(session) do
+    case Map.get(session, :reap_target, :none) do
+      {kind, id} = target when kind in [:group, :pid] and is_integer(id) and id > 1 ->
+        target
+
+      :none ->
+        :none
+
+      other ->
+        Logger.warning(
+          "symphony.runners.codex.bad_reap_target target=#{inspect(other)} " <>
+            "detail=session_stopped_without_fallback_reap"
+        )
+
+        :none
+    end
+  end
 
   # ---------------------------------------------------------------------------
   # Handshake

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
@@ -18,6 +18,7 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
 
   require Logger
 
+  alias Raxol.Symphony.PortReaper
   alias Raxol.Symphony.Runners.Codex.{Framing, Protocol}
   alias Raxol.Symphony.Ssh
   alias Raxol.Symphony.Worker.HostSpec
@@ -42,6 +43,12 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
 
   @port_line_bytes 1_048_576
   @default_turn_id 100
+
+  # How long a codex gets to act on the EOF `stop/1` delivers before it is
+  # killed. Long enough for a clean app-server shutdown, short enough that it
+  # cannot stall the orchestrator's `after` block -- and the ordinary case does
+  # not spend it, since polling stops the moment the process group drains.
+  @stop_grace_ms 2_000
 
   # ---------------------------------------------------------------------------
   # Public API
@@ -117,11 +124,36 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   end
 
   @doc """
-  Closes the Port and drains any residual messages.
+  Closes the Port, reaps whatever the session left running, and drains any
+  residual messages.
+
+  Closing the port delivers the EOF a stdio server treats as "shut down", and a
+  codex that is reading its stdin exits on it. That covers the ordinary case and
+  only the ordinary case, so it is not the whole of stopping a session:
+
+    * a codex that is NOT reading stdin -- wedged, or busy inside a turn --
+      never sees the EOF and keeps running.
+    * the tool subprocesses codex spawned are not its stdin's business at all.
+      They survive a parent that exited perfectly cleanly, reparented to init,
+      still holding the workspace open. Measured: parent gone, orphan still
+      running.
+
+  So the EOF is given first and a group kill backs it up. The grace window is
+  what keeps a well-behaved codex on the clean path -- it gets to flush and exit
+  on its own terms, and the kill only reaches a session that would otherwise
+  have been left behind.
   """
   @spec stop(session() | port()) :: :ok
   def stop(%{port: port}), do: stop(port)
-  def stop(port) when is_port(port), do: close_port(port)
+
+  def stop(port) when is_port(port) do
+    # Captured while the port is still open: after the child exits, the process
+    # group its orphans are in can no longer be read back off anything.
+    reaper = PortReaper.capture(port)
+    close_port(port)
+    PortReaper.await_exit(reaper, @stop_grace_ms)
+  end
+
   def stop(_), do: :ok
 
   # ---------------------------------------------------------------------------

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
@@ -30,6 +30,7 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
           required(:policy) => map(),
           required(:turn_id) => pos_integer(),
           optional(:reaper) => PortReaper.watcher(),
+          optional(:reap_target) => PortReaper.target(),
           optional(:stop_grace_ms) => non_neg_integer()
         }
 
@@ -92,7 +93,13 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
     # untrappable exit skips `stop/1` entirely -- and the orchestrator tears
     # workers down exactly that way (`stop_run`, stall detection,
     # reconcile-kill), so `try/after` never runs.
-    reaper = PortReaper.watch(PortReaper.capture(port))
+    #
+    # The target is kept as well as watched. It is readable only while the port
+    # is open, and the paths that need it most are the ones where it no longer
+    # is: a codex that exits on its own closes its own port, and `stop/1` then
+    # has nothing left to capture.
+    target = PortReaper.capture(port)
+    reaper = PortReaper.watch(target)
 
     with :ok <- send_initialize(port, policy.read_timeout_ms),
          {:ok, thread_id} <- send_thread_start(port, workspace, policy) do
@@ -104,13 +111,16 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
          policy: policy,
          turn_id: @default_turn_id,
          reaper: reaper,
+         reap_target: target,
          stop_grace_ms: grace_ms
        }}
     else
       {:error, _} = err ->
         # A handshake that fails has still left a codex running, and only a
-        # session that was built ever reaches `stop/1`.
-        stop_port(port, grace_ms)
+        # session that was built ever reaches `stop/1`. The usual reason to be
+        # here is a codex that died answering `initialize`, which has already
+        # closed the port -- so the captured target is the only one there is.
+        stop_port(port, grace_ms, target)
         PortReaper.release(reaper)
         err
     end
@@ -187,7 +197,12 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   """
   @spec stop(session() | port()) :: :ok
   def stop(%{port: port} = session) do
-    result = stop_port(port, Map.get(session, :stop_grace_ms) || @stop_grace_ms)
+    result =
+      stop_port(
+        port,
+        Map.get(session, :stop_grace_ms) || @stop_grace_ms,
+        Map.get(session, :reap_target, :none)
+      )
 
     # Released last: until the reap has actually happened the watcher is the
     # only thing still covering us if this process dies mid-stop.
@@ -195,14 +210,25 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
     result
   end
 
-  def stop(port) when is_port(port), do: stop_port(port, @stop_grace_ms)
+  # A bare port has no start-up target to fall back on, so a codex that has
+  # already closed its own port takes its orphans with it unreaped. Callers with
+  # a session map do not have that gap.
+  def stop(port) when is_port(port), do: stop_port(port, @stop_grace_ms, :none)
 
   def stop(_), do: :ok
 
-  defp stop_port(port, grace_ms) do
-    # Captured while the port is still open: after the child exits, the process
-    # group its orphans are in can no longer be read back off anything.
-    target = PortReaper.capture(port)
+  defp stop_port(port, grace_ms, captured_at_start) do
+    # Re-read while the port is open, since that answer is current. It is only
+    # available while the port IS open, though: every path where the codex exits
+    # on its own -- `{:error, {:port_exit, _}}` out of either receive loop, and
+    # the handshake failures -- gets here with the port already closed by the
+    # VM, and `capture/1` can only answer `:none`.
+    #
+    # Falling back to what start-up captured is what makes those paths reap at
+    # all. Its staleness is bounded the same way the watcher's is: a group id
+    # cannot be recycled while the group still has a member, so the fallback is
+    # exact for as long as there is anything to kill.
+    target = current_or_captured(PortReaper.capture(port), captured_at_start)
     close_port(port)
 
     case PortReaper.await_exit(target, grace_ms) do
@@ -218,6 +244,9 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
         :ok
     end
   end
+
+  defp current_or_captured(:none, captured_at_start), do: captured_at_start
+  defp current_or_captured(current, _captured_at_start), do: current
 
   # ---------------------------------------------------------------------------
   # Handshake

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
@@ -24,11 +24,13 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   alias Raxol.Symphony.Worker.HostSpec
 
   @type session :: %{
-          port: port(),
-          thread_id: binary(),
-          workspace: Path.t(),
-          policy: map(),
-          turn_id: pos_integer()
+          required(:port) => port(),
+          required(:thread_id) => binary(),
+          required(:workspace) => Path.t(),
+          required(:policy) => map(),
+          required(:turn_id) => pos_integer(),
+          optional(:reaper) => PortReaper.watcher(),
+          optional(:stop_grace_ms) => non_neg_integer()
         }
 
   @type policy :: %{
@@ -50,6 +52,18 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   # not spend it, since polling stops the moment the process group drains.
   @stop_grace_ms 2_000
 
+  # A remote session's port child is the local `ssh` client, and `ssh` does NOT
+  # exit on stdin EOF. Its clean teardown is a round trip: the EOF crosses the
+  # network, the remote codex exits, the remote `wait` returns, `ssh` follows.
+  # A local-sized budget SIGKILLs a perfectly well-behaved client partway
+  # through that.
+  #
+  # Nothing is stranded either way -- `Ssh.reap_on_disconnect/2` catches the
+  # far side on disconnect -- but that path costs a poll interval and reaps the
+  # remote codex with a signal instead of letting it exit on the EOF, so it is
+  # worth waiting to avoid.
+  @remote_stop_grace_ms 10_000
+
   # ---------------------------------------------------------------------------
   # Public API
   # ---------------------------------------------------------------------------
@@ -66,8 +80,21 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   def start(workspace, command, %{} = policy, env \\ [], host \\ nil)
       when is_binary(workspace) and is_binary(command) and is_list(env) do
     with {:ok, bash} <- find_bash(),
-         {:ok, port} <- open_port(host, bash, command, workspace, env),
-         :ok <- send_initialize(port, policy.read_timeout_ms),
+         {:ok, port} <- open_port(host, bash, command, workspace, env) do
+      handshake(port, workspace, policy, host)
+    end
+  end
+
+  defp handshake(port, workspace, policy, host) do
+    grace_ms = stop_grace_ms(host)
+
+    # Watched from the moment the child exists, because from here on an
+    # untrappable exit skips `stop/1` entirely -- and the orchestrator tears
+    # workers down exactly that way (`stop_run`, stall detection,
+    # reconcile-kill), so `try/after` never runs.
+    reaper = PortReaper.watch(PortReaper.capture(port))
+
+    with :ok <- send_initialize(port, policy.read_timeout_ms),
          {:ok, thread_id} <- send_thread_start(port, workspace, policy) do
       {:ok,
        %{
@@ -75,13 +102,24 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
          thread_id: thread_id,
          workspace: workspace,
          policy: policy,
-         turn_id: @default_turn_id
+         turn_id: @default_turn_id,
+         reaper: reaper,
+         stop_grace_ms: grace_ms
        }}
     else
       {:error, _} = err ->
+        # A handshake that fails has still left a codex running, and only a
+        # session that was built ever reaches `stop/1`.
+        stop_port(port, grace_ms)
+        PortReaper.release(reaper)
         err
     end
   end
+
+  @doc false
+  @spec stop_grace_ms(HostSpec.t() | nil) :: pos_integer()
+  def stop_grace_ms(nil), do: @stop_grace_ms
+  def stop_grace_ms(%HostSpec{}), do: @remote_stop_grace_ms
 
   @doc """
   Drives one turn against an active session.
@@ -141,20 +179,45 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   So the EOF is given first and a group kill backs it up. The grace window is
   what keeps a well-behaved codex on the clean path -- it gets to flush and exit
   on its own terms, and the kill only reaches a session that would otherwise
-  have been left behind.
+  have been left behind. A remote session gets a longer one, since `ssh` does
+  not exit on EOF and its clean teardown is a network round trip.
+
+  This is the ordinary path. It does not run at all when the caller is killed
+  outright, which is what `PortReaper.watch/1` covers.
   """
   @spec stop(session() | port()) :: :ok
-  def stop(%{port: port}), do: stop(port)
+  def stop(%{port: port} = session) do
+    result = stop_port(port, Map.get(session, :stop_grace_ms) || @stop_grace_ms)
 
-  def stop(port) when is_port(port) do
-    # Captured while the port is still open: after the child exits, the process
-    # group its orphans are in can no longer be read back off anything.
-    reaper = PortReaper.capture(port)
-    close_port(port)
-    PortReaper.await_exit(reaper, @stop_grace_ms)
+    # Released last: until the reap has actually happened the watcher is the
+    # only thing still covering us if this process dies mid-stop.
+    PortReaper.release(Map.get(session, :reaper))
+    result
   end
 
+  def stop(port) when is_port(port), do: stop_port(port, @stop_grace_ms)
+
   def stop(_), do: :ok
+
+  defp stop_port(port, grace_ms) do
+    # Captured while the port is still open: after the child exits, the process
+    # group its orphans are in can no longer be read back off anything.
+    target = PortReaper.capture(port)
+    close_port(port)
+
+    case PortReaper.await_exit(target, grace_ms) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning(
+          "symphony.runners.codex.session_unreaped target=#{inspect(target)} " <>
+            "reason=#{inspect(reason)}"
+        )
+
+        :ok
+    end
+  end
 
   # ---------------------------------------------------------------------------
   # Handshake
@@ -397,20 +460,8 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   end
 
   defp close_port(port) do
-    case :erlang.port_info(port) do
-      :undefined ->
-        :ok
-
-      _ ->
-        try do
-          Port.close(port)
-        rescue
-          ArgumentError -> :ok
-        end
-
-        flush(port)
-        :ok
-    end
+    PortReaper.close(port)
+    flush(port)
   end
 
   defp flush(port) do

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -754,34 +754,33 @@ defmodule Raxol.Symphony.Workspace do
         # that, a hook that leaks a process per timeout leaks one per retry, and
         # the orchestrator retries.
         #
-        # Captured before the close, killed after it: `PortReaper.capture/1`
-        # needs a live child to read the target off.
+        # Killed BEFORE the close, not after. While the port is open the child's
+        # pid is still ours -- `erl_child_setup` has not reaped it, so the OS
+        # cannot recycle it -- and signalling into that window is the only way
+        # to be sure the pid still names our hook. Nothing here is waiting on
+        # the child's output, so there is no reason to hand it an EOF first.
         #
         # SIGKILL outright, where the remote deadline sends SIGTERM. There the
         # status is read back (`@killed_by_deadline`); here nothing reads it, we
         # have already stopped waiting, and the workspace may be deleted next.
-        reaper = PortReaper.capture(port)
-        close_port(port)
-        PortReaper.kill(reaper)
+        target = PortReaper.capture(port)
+        reaped = PortReaper.kill(target)
+        PortReaper.close(port)
         flush_port_messages(port)
+        warn_if_unreaped(reaped, target)
         {:error, :timeout}
     end
   end
 
-  # The kill can land before this runs, and closing an already-closed port
-  # raises.
-  defp close_port(port) do
-    case :erlang.port_info(port) do
-      :undefined ->
-        :ok
+  # `remove/3` may `rm_rf` this workspace next, so a kill we could not carry out
+  # is not a detail to swallow: the hook is still in there writing to it.
+  defp warn_if_unreaped(:ok, _target), do: :ok
 
-      _ ->
-        try do
-          Port.close(port)
-        rescue
-          ArgumentError -> :ok
-        end
-    end
+  defp warn_if_unreaped({:error, reason}, target) do
+    Logger.warning(
+      "symphony.workspace.hook_unreaped target=#{inspect(target)} reason=#{inspect(reason)} " <>
+        "detail=hook_may_still_be_running"
+    )
   end
 
   defp flush_port_messages(port) do

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -747,11 +747,103 @@ defmodule Raxol.Symphony.Workspace do
         {:error, {:exit, status, IO.iodata_to_binary(Enum.reverse(acc))}}
     after
       timeout_ms ->
-        # Port.close kills the OS process via SIGKILL when :exit_status was
-        # requested. Drain the message queue to avoid leaks.
-        Port.close(port)
+        kill_spawned_process(port)
+        close_port(port)
         flush_port_messages(port)
         {:error, :timeout}
+    end
+  end
+
+  # Giving up on a hook does not stop it.
+  #
+  # `Port.close/1` releases the BEAM-side port and signals nothing, so the hook
+  # runs on. `before_remove` is the sharp case: `remove/3` then `rm_rf`s the
+  # workspace out from under a hook still writing to it, and `after_create`'s
+  # failure path has the same shape. Past that, a hook that leaks a process per
+  # timeout leaks one per retry, and the orchestrator retries.
+  #
+  # This is the local half of the mistake the remote deadline in
+  # `Ssh.reap_on_disconnect/2` fixed on the host.
+  defp kill_spawned_process(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} -> kill_process_tree(os_pid)
+      # Exited between the timer firing and this call: nothing left to signal.
+      nil -> :ok
+    end
+  end
+
+  defp kill_process_tree(os_pid) do
+    case System.find_executable("kill") do
+      nil ->
+        Logger.warning(
+          "symphony.workspace.hook_kill_skipped os_pid=#{os_pid} reason=no_kill_executable"
+        )
+
+        :ok
+
+      kill_path ->
+        run_kill(kill_path, os_pid, signal_target(os_pid))
+    end
+  end
+
+  # SIGKILL, where the remote deadline sends SIGTERM. There the status is read
+  # back (`@killed_by_deadline`); here nothing reads it, we have already stopped
+  # waiting, and the workspace may be deleted next -- so a hook that traps TERM
+  # must not get to keep running.
+  defp run_kill(kill_path, os_pid, target) do
+    case System.cmd(kill_path, ["-KILL", target], stderr_to_stdout: true) do
+      {_output, 0} ->
+        :ok
+
+      {output, status} ->
+        Logger.warning(
+          "symphony.workspace.hook_kill_failed os_pid=#{os_pid} target=#{target} " <>
+            "status=#{status} output=#{truncate_for_log(output)}"
+        )
+
+        :ok
+    end
+  end
+
+  # Signal the process GROUP, for the reason the remote half does: killing only
+  # the hook leaves its children running, doing work past the timeout and still
+  # holding the inherited stdout pipe.
+  #
+  # `erl_child_setup` gives a spawned port child a process group of its own, so
+  # `kill -KILL -PID` reaches its descendants and nothing else. That is checked
+  # rather than assumed, because the failure mode is not subtle: a child that is
+  # NOT a group leader shares the BEAM's group, and the group kill would take
+  # down the orchestrator itself. The bare-pid fallback loses the hook's
+  # children and keeps the VM.
+  defp signal_target(os_pid) do
+    if group_leader?(os_pid), do: "-#{os_pid}", else: "#{os_pid}"
+  end
+
+  # A `ps` that is missing, fails, or answers something unparseable is treated
+  # as "not a leader" -- the conservative answer, for the same reason.
+  defp group_leader?(os_pid) do
+    with ps_path when is_binary(ps_path) <- System.find_executable("ps"),
+         {output, 0} <-
+           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true) do
+      String.trim(output) == "#{os_pid}"
+    else
+      _ -> false
+    end
+  end
+
+  # The kill can land before this runs, and closing an already-closed port
+  # raises.
+  defp close_port(port) do
+    case :erlang.port_info(port) do
+      :undefined ->
+        :ok
+
+      _ ->
+        try do
+          Port.close(port)
+        rescue
+          ArgumentError -> :ok
+        end
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -754,11 +754,18 @@ defmodule Raxol.Symphony.Workspace do
         # that, a hook that leaks a process per timeout leaks one per retry, and
         # the orchestrator retries.
         #
-        # Killed BEFORE the close, not after. While the port is open the child's
-        # pid is still ours -- `erl_child_setup` has not reaped it, so the OS
-        # cannot recycle it -- and signalling into that window is the only way
-        # to be sure the pid still names our hook. Nothing here is waiting on
-        # the child's output, so there is no reason to hand it an EOF first.
+        # Killed BEFORE the close, not after. Nothing here is waiting on the
+        # child's output, so there is no reason to hand it an EOF and then wait
+        # out a grace; killing first is the narrowest window available.
+        #
+        # Narrowest, not zero. An open port does NOT prove the pid is still
+        # ours: ERTS withholds the exit status until the inherited stdout
+        # reaches EOF, so a hook that backgrounds a child and exits leaves the
+        # port open indefinitely while `Port.info/2` goes on naming a pid that
+        # has already been reaped. What keeps the reap correct there is
+        # `PortReaper.capture/1` resolving the target against the process GROUP
+        # rather than that pid -- a group id cannot be recycled while the group
+        # still has a member, which is precisely when there is work to do.
         #
         # SIGKILL outright, where the remote deadline sends SIGTERM. There the
         # status is read back (`@killed_by_deadline`); here nothing reads it, we

--- a/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/workspace.ex
@@ -42,7 +42,7 @@ defmodule Raxol.Symphony.Workspace do
 
   require Logger
 
-  alias Raxol.Symphony.{Config, PathSafety, Ssh}
+  alias Raxol.Symphony.{Config, PathSafety, PortReaper, Ssh}
   alias Raxol.Symphony.Worker.HostSpec
 
   # Distinctive enough that a login banner or profile chatter on the remote
@@ -747,87 +747,24 @@ defmodule Raxol.Symphony.Workspace do
         {:error, {:exit, status, IO.iodata_to_binary(Enum.reverse(acc))}}
     after
       timeout_ms ->
-        kill_spawned_process(port)
+        # Giving up on a hook does not stop it. `Port.close/1` signals nothing,
+        # so the hook runs on -- and `before_remove` is the sharp case, since
+        # `remove/3` then `rm_rf`s the workspace out from under a hook still
+        # writing to it. `after_create`'s failure path has the same shape. Past
+        # that, a hook that leaks a process per timeout leaks one per retry, and
+        # the orchestrator retries.
+        #
+        # Captured before the close, killed after it: `PortReaper.capture/1`
+        # needs a live child to read the target off.
+        #
+        # SIGKILL outright, where the remote deadline sends SIGTERM. There the
+        # status is read back (`@killed_by_deadline`); here nothing reads it, we
+        # have already stopped waiting, and the workspace may be deleted next.
+        reaper = PortReaper.capture(port)
         close_port(port)
+        PortReaper.kill(reaper)
         flush_port_messages(port)
         {:error, :timeout}
-    end
-  end
-
-  # Giving up on a hook does not stop it.
-  #
-  # `Port.close/1` releases the BEAM-side port and signals nothing, so the hook
-  # runs on. `before_remove` is the sharp case: `remove/3` then `rm_rf`s the
-  # workspace out from under a hook still writing to it, and `after_create`'s
-  # failure path has the same shape. Past that, a hook that leaks a process per
-  # timeout leaks one per retry, and the orchestrator retries.
-  #
-  # This is the local half of the mistake the remote deadline in
-  # `Ssh.reap_on_disconnect/2` fixed on the host.
-  defp kill_spawned_process(port) do
-    case Port.info(port, :os_pid) do
-      {:os_pid, os_pid} -> kill_process_tree(os_pid)
-      # Exited between the timer firing and this call: nothing left to signal.
-      nil -> :ok
-    end
-  end
-
-  defp kill_process_tree(os_pid) do
-    case System.find_executable("kill") do
-      nil ->
-        Logger.warning(
-          "symphony.workspace.hook_kill_skipped os_pid=#{os_pid} reason=no_kill_executable"
-        )
-
-        :ok
-
-      kill_path ->
-        run_kill(kill_path, os_pid, signal_target(os_pid))
-    end
-  end
-
-  # SIGKILL, where the remote deadline sends SIGTERM. There the status is read
-  # back (`@killed_by_deadline`); here nothing reads it, we have already stopped
-  # waiting, and the workspace may be deleted next -- so a hook that traps TERM
-  # must not get to keep running.
-  defp run_kill(kill_path, os_pid, target) do
-    case System.cmd(kill_path, ["-KILL", target], stderr_to_stdout: true) do
-      {_output, 0} ->
-        :ok
-
-      {output, status} ->
-        Logger.warning(
-          "symphony.workspace.hook_kill_failed os_pid=#{os_pid} target=#{target} " <>
-            "status=#{status} output=#{truncate_for_log(output)}"
-        )
-
-        :ok
-    end
-  end
-
-  # Signal the process GROUP, for the reason the remote half does: killing only
-  # the hook leaves its children running, doing work past the timeout and still
-  # holding the inherited stdout pipe.
-  #
-  # `erl_child_setup` gives a spawned port child a process group of its own, so
-  # `kill -KILL -PID` reaches its descendants and nothing else. That is checked
-  # rather than assumed, because the failure mode is not subtle: a child that is
-  # NOT a group leader shares the BEAM's group, and the group kill would take
-  # down the orchestrator itself. The bare-pid fallback loses the hook's
-  # children and keeps the VM.
-  defp signal_target(os_pid) do
-    if group_leader?(os_pid), do: "-#{os_pid}", else: "#{os_pid}"
-  end
-
-  # A `ps` that is missing, fails, or answers something unparseable is treated
-  # as "not a leader" -- the conservative answer, for the same reason.
-  defp group_leader?(os_pid) do
-    with ps_path when is_binary(ps_path) <- System.find_executable("ps"),
-         {output, 0} <-
-           System.cmd(ps_path, ["-o", "pgid=", "-p", "#{os_pid}"], stderr_to_stdout: true) do
-      String.trim(output) == "#{os_pid}"
-    else
-      _ -> false
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
@@ -244,6 +244,61 @@ defmodule Raxol.Symphony.PortReaperTest do
              "the watcher must outlive the owner it is cleaning up after"
     end
 
+    test "stands down when released by a process other than the owner" do
+      # Holding the watcher pid is the authority to disarm it. Pinning the
+      # release to the owner made `release/1` a silent no-op from anywhere else,
+      # which leaves a watcher armed to SIGKILL a target the caller has already
+      # reaped -- and `release/1` cannot report that it failed.
+      test_pid = self()
+
+      owner =
+        spawn(fn ->
+          port = open_child("echo ready; sleep 30")
+          {:group, pgid} = target = PortReaper.capture(port)
+          send(test_pid, {:spawned, pgid, PortReaper.watch(target)})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:spawned, pgid, watcher}, @wait_ms
+
+      # Released from the TEST process, not from `owner`.
+      assert :ok = PortReaper.release(watcher)
+      assert wait_until(fn -> not Process.alive?(watcher) end)
+
+      Process.exit(owner, :kill)
+      refute wait_until(fn -> not alive?("-#{pgid}") end, 500)
+
+      PortReaper.kill({:group, pgid})
+    end
+
+    test "reaps when the watcher itself is shut down" do
+      # An orchestrator restart tears the supervision tree down while its workers
+      # are still alive, so the owner-death path never fires. A watcher that just
+      # dies with the tree abandons the process tree it was covering.
+      test_pid = self()
+
+      owner =
+        spawn(fn ->
+          port = open_child("echo ready; sleep 30")
+          {:group, pgid} = target = PortReaper.capture(port)
+          send(test_pid, {:spawned, pgid, PortReaper.watch(target)})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:spawned, pgid, watcher}, @wait_ms
+      assert alive?("-#{pgid}")
+
+      # What a supervisor sends a child on the way down. The owner stays alive
+      # throughout, so only the shutdown path can account for the reap.
+      Process.exit(watcher, :shutdown)
+
+      assert wait_until(fn -> not alive?("-#{pgid}") end),
+             "a watcher taken down with its tree still has to reap first"
+
+      assert Process.alive?(owner)
+      Process.exit(owner, :kill)
+    end
+
     test "stands down after release/1" do
       test_pid = self()
 

--- a/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
@@ -49,15 +49,20 @@ defmodule Raxol.Symphony.PortReaperTest do
     end
   end
 
-  # Resolved rather than hardcoded to /bin/kill, which slim images do not have.
-  # Deliberately not the module's own resolution: a test oracle that shares the
-  # implementation's lookup cannot catch the implementation losing it.
-  defp kill_exe do
-    System.find_executable("kill") || "/bin/kill"
-  end
-
+  # Spelled out here rather than routed through `PortReaper`, so the oracle
+  # cannot agree with the implementation by sharing its bug -- but through bash's
+  # `kill` BUILTIN, because `kill(1)` is not an oracle at all on Linux. procps-ng
+  # answers `kill -0 -<pgid>` with exit 0 whether or not the group exists, so an
+  # oracle built on it reports every process alive forever and turns every
+  # `refute alive?` red for the wrong reason.
   defp alive?(target) do
-    {_out, status} = System.cmd(kill_exe(), ["-0", target], stderr_to_stdout: true)
+    {_out, status} =
+      System.cmd(
+        System.find_executable("bash"),
+        ["-c", ~s(kill "$1" "$2"), "reaper-test-oracle", "-0", target],
+        stderr_to_stdout: true
+      )
+
     status == 0
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
@@ -1,0 +1,137 @@
+defmodule Raxol.Symphony.PortReaperTest do
+  @moduledoc """
+  `Port.close/1` signals nothing, so what a port's child does next is the
+  child's own business. These drive the three behaviours that fall out of that,
+  against real spawned processes:
+
+    * a child that reads stdin exits on the EOF a close delivers
+    * a child that does not read stdin ignores it entirely
+    * a tool subprocess survives a parent that exited cleanly
+
+  Liveness is asked of the OS (`kill -0`) rather than inferred from a witness
+  file, since the question is whether a process is still running, not whether it
+  got as far as some side effect.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.PortReaper
+
+  # Mirrors `Runners.Codex.Session.base_port_opts/0`: no `:in`, so stdin is a
+  # live pipe and closing the port is what delivers EOF.
+  defp open_child(script) do
+    port =
+      Port.open(
+        {:spawn_executable, System.find_executable("bash")},
+        [
+          :binary,
+          :exit_status,
+          :stderr_to_stdout,
+          :hide,
+          {:line, 1_048_576},
+          {:cd, System.tmp_dir!()},
+          {:args, ["-lc", script]}
+        ]
+      )
+
+    # Let bash get as far as spawning whatever the script spawns.
+    Process.sleep(300)
+    port
+  end
+
+  defp alive?(target) do
+    {_out, status} = System.cmd("/bin/kill", ["-0", target], stderr_to_stdout: true)
+    status == 0
+  end
+
+  defp close(port) do
+    Port.close(port)
+  rescue
+    ArgumentError -> :ok
+  end
+
+  describe "capture/1" do
+    test "reports the child as its own process group leader" do
+      port = open_child("sleep 30")
+
+      assert {:group, pgid} = PortReaper.capture(port)
+      assert {:os_pid, ^pgid} = Port.info(port, :os_pid)
+
+      close(port)
+      PortReaper.kill({:group, pgid})
+    end
+
+    test "is :none once the port is closed" do
+      port = open_child("sleep 30")
+      target = PortReaper.capture(port)
+      close(port)
+      PortReaper.kill(target)
+
+      assert PortReaper.capture(port) == :none
+    end
+  end
+
+  describe "kill/1" do
+    test "kills a child that never reads stdin" do
+      port = open_child("sleep 30")
+      target = PortReaper.capture(port)
+      {:group, pgid} = target
+
+      close(port)
+      assert alive?("-#{pgid}"), "closing the port must not be what stops it"
+
+      assert :ok = PortReaper.kill(target)
+      Process.sleep(200)
+      refute alive?("-#{pgid}")
+    end
+
+    test "is a no-op for :none" do
+      assert :ok = PortReaper.kill(:none)
+    end
+  end
+
+  describe "await_exit/2" do
+    test "reaps a tool subprocess that outlived a cleanly exited parent" do
+      # The codex shape: the app-server exits on EOF, the tool it spawned does
+      # not, and the group outlives its leader.
+      port = open_child("( sleep 30 ) & cat > /dev/null")
+      {:group, pgid} = target = PortReaper.capture(port)
+
+      close(port)
+      Process.sleep(400)
+
+      refute alive?("#{pgid}"), "the parent should have exited on EOF"
+      assert alive?("-#{pgid}"), "the orphaned tool should still hold the group"
+
+      assert :ok = PortReaper.await_exit(target, 1_000)
+      refute alive?("-#{pgid}")
+    end
+
+    test "returns as soon as a well-behaved child exits, without spending the grace" do
+      port = open_child("cat > /dev/null")
+      {:group, pgid} = target = PortReaper.capture(port)
+
+      close(port)
+
+      elapsed =
+        wall_ms(fn ->
+          assert :ok = PortReaper.await_exit(target, 10_000)
+        end)
+
+      refute alive?("-#{pgid}")
+
+      # Bounded well under the grace: the point is that a clean exit is detected
+      # rather than waited out. Generous enough not to be a timing race.
+      assert elapsed < 5_000
+    end
+
+    test "is a no-op for :none" do
+      assert :ok = PortReaper.await_exit(:none, 10_000)
+    end
+  end
+
+  defp wall_ms(fun) do
+    started = System.monotonic_time(:millisecond)
+    fun.()
+    System.monotonic_time(:millisecond) - started
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
@@ -1,23 +1,32 @@
 defmodule Raxol.Symphony.PortReaperTest do
   @moduledoc """
   `Port.close/1` signals nothing, so what a port's child does next is the
-  child's own business. These drive the three behaviours that fall out of that,
+  child's own business. These drive the behaviours that fall out of that,
   against real spawned processes:
 
     * a child that reads stdin exits on the EOF a close delivers
     * a child that does not read stdin ignores it entirely
     * a tool subprocess survives a parent that exited cleanly
+    * an owner killed outright never runs its own cleanup
 
   Liveness is asked of the OS (`kill -0`) rather than inferred from a witness
   file, since the question is whether a process is still running, not whether it
-  got as far as some side effect.
+  got as far as some side effect. Every wait is a poll against a deadline, not a
+  fixed sleep, so a loaded machine makes these slower rather than red.
   """
   use ExUnit.Case, async: true
 
   alias Raxol.Symphony.PortReaper
 
+  @wait_ms 5_000
+
   # Mirrors `Runners.Codex.Session.base_port_opts/0`: no `:in`, so stdin is a
   # live pipe and closing the port is what delivers EOF.
+  #
+  # `script` must `echo ready` once it has spawned whatever it is going to
+  # spawn -- placed by the script, since where it goes is the point: a test of
+  # orphaned subprocesses that proceeds before the fork proves nothing. Waiting
+  # on that line rather than on a duration is what keeps these off the clock.
   defp open_child(script) do
     port =
       Port.open(
@@ -33,25 +42,51 @@ defmodule Raxol.Symphony.PortReaperTest do
         ]
       )
 
-    # Let bash get as far as spawning whatever the script spawns.
-    Process.sleep(300)
-    port
+    receive do
+      {^port, {:data, {:eol, "ready"}}} -> port
+    after
+      @wait_ms -> flunk("child never signalled ready")
+    end
+  end
+
+  # Resolved rather than hardcoded to /bin/kill, which slim images do not have.
+  # Deliberately not the module's own resolution: a test oracle that shares the
+  # implementation's lookup cannot catch the implementation losing it.
+  defp kill_exe do
+    System.find_executable("kill") || "/bin/kill"
   end
 
   defp alive?(target) do
-    {_out, status} = System.cmd("/bin/kill", ["-0", target], stderr_to_stdout: true)
+    {_out, status} = System.cmd(kill_exe(), ["-0", target], stderr_to_stdout: true)
     status == 0
   end
 
+  defp wait_until(fun, timeout_ms \\ @wait_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    poll_until(fun, deadline)
+  end
+
+  defp poll_until(fun, deadline) do
+    cond do
+      fun.() ->
+        true
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        false
+
+      true ->
+        Process.sleep(20)
+        poll_until(fun, deadline)
+    end
+  end
+
   defp close(port) do
-    Port.close(port)
-  rescue
-    ArgumentError -> :ok
+    PortReaper.close(port)
   end
 
   describe "capture/1" do
     test "reports the child as its own process group leader" do
-      port = open_child("sleep 30")
+      port = open_child("echo ready; sleep 30")
 
       assert {:group, pgid} = PortReaper.capture(port)
       assert {:os_pid, ^pgid} = Port.info(port, :os_pid)
@@ -61,7 +96,7 @@ defmodule Raxol.Symphony.PortReaperTest do
     end
 
     test "is :none once the port is closed" do
-      port = open_child("sleep 30")
+      port = open_child("echo ready; sleep 30")
       target = PortReaper.capture(port)
       close(port)
       PortReaper.kill(target)
@@ -70,22 +105,43 @@ defmodule Raxol.Symphony.PortReaperTest do
     end
   end
 
+  describe "close/1" do
+    test "is idempotent" do
+      port = open_child("echo ready; sleep 30")
+      target = PortReaper.capture(port)
+
+      assert :ok = PortReaper.close(port)
+      assert :ok = PortReaper.close(port)
+
+      PortReaper.kill(target)
+    end
+  end
+
   describe "kill/1" do
     test "kills a child that never reads stdin" do
-      port = open_child("sleep 30")
-      target = PortReaper.capture(port)
-      {:group, pgid} = target
+      port = open_child("echo ready; sleep 30")
+      {:group, pgid} = target = PortReaper.capture(port)
 
       close(port)
       assert alive?("-#{pgid}"), "closing the port must not be what stops it"
 
       assert :ok = PortReaper.kill(target)
-      Process.sleep(200)
-      refute alive?("-#{pgid}")
+      assert wait_until(fn -> not alive?("-#{pgid}") end)
     end
 
     test "is a no-op for :none" do
       assert :ok = PortReaper.kill(:none)
+    end
+
+    # pid 0 is "my own process group" and pid 1 is "everything I may signal".
+    # Turned into a group kill either one takes the VM or the host down, and
+    # nothing about that failure is recoverable, so it is refused at the door
+    # rather than trusted to only ever be reached via `capture/1`.
+    test "refuses a target that would signal the VM or the world" do
+      for pid <- [0, 1], kind <- [:group, :pid] do
+        assert_raise FunctionClauseError, fn -> PortReaper.kill({kind, pid}) end
+        assert_raise FunctionClauseError, fn -> PortReaper.await_exit({kind, pid}, 0) end
+      end
     end
   end
 
@@ -93,39 +149,95 @@ defmodule Raxol.Symphony.PortReaperTest do
     test "reaps a tool subprocess that outlived a cleanly exited parent" do
       # The codex shape: the app-server exits on EOF, the tool it spawned does
       # not, and the group outlives its leader.
-      port = open_child("( sleep 30 ) & cat > /dev/null")
+      port = open_child("( sleep 30 ) & echo ready; cat > /dev/null")
       {:group, pgid} = target = PortReaper.capture(port)
 
       close(port)
-      Process.sleep(400)
 
-      refute alive?("#{pgid}"), "the parent should have exited on EOF"
+      assert wait_until(fn -> not alive?("#{pgid}") end),
+             "the parent should have exited on EOF"
+
       assert alive?("-#{pgid}"), "the orphaned tool should still hold the group"
 
-      assert :ok = PortReaper.await_exit(target, 1_000)
+      assert :ok = PortReaper.await_exit(target, @wait_ms)
       refute alive?("-#{pgid}")
     end
 
     test "returns as soon as a well-behaved child exits, without spending the grace" do
-      port = open_child("cat > /dev/null")
+      port = open_child("echo ready; cat > /dev/null")
       {:group, pgid} = target = PortReaper.capture(port)
 
       close(port)
 
       elapsed =
         wall_ms(fn ->
-          assert :ok = PortReaper.await_exit(target, 10_000)
+          assert :ok = PortReaper.await_exit(target, 30_000)
         end)
 
-      refute alive?("-#{pgid}")
+      assert wait_until(fn -> not alive?("-#{pgid}") end)
 
       # Bounded well under the grace: the point is that a clean exit is detected
       # rather than waited out. Generous enough not to be a timing race.
-      assert elapsed < 5_000
+      assert elapsed < 10_000
     end
 
     test "is a no-op for :none" do
       assert :ok = PortReaper.await_exit(:none, 10_000)
+    end
+  end
+
+  describe "watch/1" do
+    test "reaps the target when the owner is killed outright" do
+      # `Process.exit(pid, :kill)` does not run `try/after`, which is how the
+      # orchestrator tears down workers -- so the reap cannot live in the owner.
+      test_pid = self()
+
+      owner =
+        spawn(fn ->
+          port = open_child("echo ready; sleep 30")
+          {:group, pgid} = target = PortReaper.capture(port)
+          PortReaper.watch(target)
+          send(test_pid, {:spawned, pgid})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:spawned, pgid}, @wait_ms
+      assert alive?("-#{pgid}")
+
+      Process.exit(owner, :kill)
+
+      assert wait_until(fn -> not alive?("-#{pgid}") end),
+             "the watcher must outlive the owner it is cleaning up after"
+    end
+
+    test "stands down after release/1" do
+      test_pid = self()
+
+      owner =
+        spawn(fn ->
+          port = open_child("echo ready; sleep 30")
+          {:group, pgid} = target = PortReaper.capture(port)
+          watcher = PortReaper.watch(target)
+          PortReaper.release(watcher)
+          send(test_pid, {:spawned, pgid, watcher})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:spawned, pgid, watcher}, @wait_ms
+      assert wait_until(fn -> not Process.alive?(watcher) end)
+
+      Process.exit(owner, :kill)
+
+      # A released watcher is gone, so nothing reaps: the caller took ownership.
+      refute wait_until(fn -> not alive?("-#{pgid}") end, 500)
+
+      PortReaper.kill({:group, pgid})
+    end
+
+    test "is a no-op for :none" do
+      assert PortReaper.watch(:none) == :none
+      assert PortReaper.release(:none) == :ok
+      assert PortReaper.release(nil) == :ok
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/port_reaper_test.exs
@@ -100,6 +100,32 @@ defmodule Raxol.Symphony.PortReaperTest do
       PortReaper.kill({:group, pgid})
     end
 
+    test "resolves the group when the parent has exited but its orphan holds the port open" do
+      # The commonest leak shape: the hook backgrounds a child and exits. ERTS
+      # withholds the exit status until the inherited stdout reaches EOF and the
+      # orphan is still holding it, so the port stays OPEN while `Port.info/2`
+      # goes on naming a pid that has already been reaped.
+      #
+      # Resolving the target off that pid -- asking `ps` for its pgid -- fails,
+      # because `ps` cannot see a corpse. Resolving it off the process GROUP
+      # succeeds, because the group is what is still running.
+      port = open_child("( sleep 30 ) & echo ready; exit 0")
+      {:os_pid, os_pid} = Port.info(port, :os_pid)
+
+      assert wait_until(fn -> not alive?("#{os_pid}") end),
+             "the parent should have exited on its own"
+
+      assert alive?("-#{os_pid}"), "the orphan should still hold the group"
+      assert Port.info(port, :os_pid) == {:os_pid, os_pid}, "the port should still be open"
+
+      assert {:group, ^os_pid} = target = PortReaper.capture(port)
+
+      assert :ok = PortReaper.kill(target)
+      assert wait_until(fn -> not alive?("-#{os_pid}") end)
+
+      close(port)
+    end
+
     test "is :none once the port is closed" do
       port = open_child("echo ready; sleep 30")
       target = PortReaper.capture(port)
@@ -164,8 +190,11 @@ defmodule Raxol.Symphony.PortReaperTest do
 
       assert alive?("-#{pgid}"), "the orphaned tool should still hold the group"
 
+      # Polled, not asserted outright: `await_exit/2` returns once the SIGKILL
+      # has been ACCEPTED, and a killed group member stays in the group until it
+      # is reaped, so the transition is not synchronous with the return.
       assert :ok = PortReaper.await_exit(target, @wait_ms)
-      refute alive?("-#{pgid}")
+      assert wait_until(fn -> not alive?("-#{pgid}") end)
     end
 
     test "returns as soon as a well-behaved child exits, without spending the grace" do

--- a/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
@@ -55,10 +55,20 @@ defmodule Raxol.Symphony.Runners.Codex.SessionStopTest do
     })
   end
 
-  defp kill_exe, do: System.find_executable("kill") || "/bin/kill"
-
+  # Spelled out here rather than routed through `PortReaper`, so the oracle
+  # cannot agree with the implementation by sharing its bug -- but through bash's
+  # `kill` BUILTIN, because `kill(1)` is not an oracle at all on Linux. procps-ng
+  # answers `kill -0 -<pgid>` with exit 0 whether or not the group exists, so an
+  # oracle built on it reports every process alive forever and turns every
+  # `refute alive?` red for the wrong reason.
   defp alive?(target) do
-    {_out, status} = System.cmd(kill_exe(), ["-0", target], stderr_to_stdout: true)
+    {_out, status} =
+      System.cmd(
+        System.find_executable("bash"),
+        ["-c", ~s(kill "$1" "$2"), "reaper-test-oracle", "-0", target],
+        stderr_to_stdout: true
+      )
+
     status == 0
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
@@ -1,15 +1,21 @@
 defmodule Raxol.Symphony.Runners.Codex.SessionStopTest do
   @moduledoc """
   `Session.stop/1` runs in the `after` block of every codex run, so whatever it
-  fails to clean up is left behind once per run.
+  fails to clean up is left behind once per run -- and it does not run at all
+  when the run is killed outright, which is how the orchestrator tears workers
+  down (`stop_run`, stall detection, reconcile-kill).
 
   Closing the port delivers EOF, which stops a codex that is reading stdin and
-  nothing else. These drive the two cases it does not cover, against real
-  processes standing in for the app-server and the tools it spawns.
+  nothing else. These drive the cases it does not cover, against real processes
+  standing in for the app-server and the tools it spawns.
   """
   use ExUnit.Case, async: true
 
+  alias Raxol.Symphony.PortReaper
   alias Raxol.Symphony.Runners.Codex.Session
+
+  @fake_codex Path.expand("../../../../support/fake_codex.sh", __DIR__)
+  @wait_ms 5_000
 
   defp open_session_port(script) do
     port =
@@ -26,42 +32,145 @@ defmodule Raxol.Symphony.Runners.Codex.SessionStopTest do
         ]
       )
 
-    Process.sleep(300)
+    # Waits on the script's own announcement, placed after whatever it spawns.
+    receive do
+      {^port, {:data, {:eol, "ready"}}} -> :ok
+    after
+      @wait_ms -> flunk("child never signalled ready")
+    end
+
     {:os_pid, os_pid} = Port.info(port, :os_pid)
     {port, os_pid}
   end
 
+  defp policy(overrides \\ []) do
+    Enum.into(overrides, %{
+      approval_policy: "never",
+      thread_sandbox: "danger-full-access",
+      turn_sandbox_policy: %{},
+      read_timeout_ms: 2_000,
+      turn_timeout_ms: 5_000,
+      auto_approve?: true,
+      dynamic_tools: []
+    })
+  end
+
+  defp kill_exe, do: System.find_executable("kill") || "/bin/kill"
+
   defp alive?(target) do
-    {_out, status} = System.cmd("/bin/kill", ["-0", target], stderr_to_stdout: true)
+    {_out, status} = System.cmd(kill_exe(), ["-0", target], stderr_to_stdout: true)
     status == 0
+  end
+
+  # A signal is delivered, not awaited: `kill` returns once the kernel has taken
+  # it, and the target is a zombie until `erl_child_setup` reaps it. Polling for
+  # the transition beats asserting it has already happened.
+  defp wait_until(fun, timeout_ms \\ @wait_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    poll_until(fun, deadline)
+  end
+
+  defp poll_until(fun, deadline) do
+    cond do
+      fun.() ->
+        true
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        false
+
+      true ->
+        Process.sleep(20)
+        poll_until(fun, deadline)
+    end
   end
 
   test "stops a session that is not reading stdin" do
     # Wedged, or busy inside a turn: the EOF lands on a codex that never looks.
-    {port, os_pid} = open_session_port("sleep 30")
+    {port, os_pid} = open_session_port("echo ready; sleep 30")
 
     assert :ok = Session.stop(port)
 
-    refute alive?("-#{os_pid}")
+    assert wait_until(fn -> not alive?("-#{os_pid}") end)
   end
 
   test "reaps the tool subprocesses a cleanly exited codex left behind" do
-    {port, os_pid} = open_session_port("( sleep 30 ) & cat > /dev/null")
+    {port, os_pid} = open_session_port("( sleep 30 ) & echo ready; cat > /dev/null")
 
     assert :ok = Session.stop(port)
 
-    refute alive?("-#{os_pid}"),
+    assert wait_until(fn -> not alive?("-#{os_pid}") end),
            "the app-server exits on EOF, but its tool subprocess does not"
   end
 
   test "accepts a session map and a already-dead port" do
-    {port, os_pid} = open_session_port("sleep 30")
+    {port, os_pid} = open_session_port("echo ready; sleep 30")
 
     assert :ok = Session.stop(%{port: port})
-    refute alive?("-#{os_pid}")
+    assert wait_until(fn -> not alive?("-#{os_pid}") end)
 
     # Stopping twice must not raise on the already-closed port.
     assert :ok = Session.stop(port)
     assert :ok = Session.stop(nil)
+  end
+
+  test "reaps the session when the owning process is killed outright" do
+    # `Process.exit(pid, :kill)` does not run `try/after`, so the `after
+    # Session.stop(session)` in `Codex.do_run/3` never fires. The orchestrator
+    # tears workers down that way on all three of its teardown paths, and the
+    # stall path is the one that matters -- it fires precisely when codex is
+    # wedged, which is the case EOF cannot reach.
+    test_pid = self()
+
+    owner =
+      spawn(fn ->
+        {:ok, session} =
+          Session.start(
+            System.tmp_dir!(),
+            @fake_codex,
+            policy(),
+            [{~c"FAKE_CODEX_SPAWN_SECONDS", ~c"30"}]
+          )
+
+        {:os_pid, os_pid} = Port.info(session.port, :os_pid)
+        send(test_pid, {:started, os_pid})
+        Process.sleep(:infinity)
+      end)
+
+    assert_receive {:started, os_pid}, @wait_ms
+    assert alive?("-#{os_pid}")
+
+    Process.exit(owner, :kill)
+
+    assert wait_until(fn -> not alive?("-#{os_pid}") end),
+           "the reap has to survive a caller that cannot run its own cleanup"
+  end
+
+  @tag :tmp_dir
+  test "reaps a codex whose handshake never completed", %{tmp_dir: tmp_dir} do
+    # Only a session that was successfully built ever reaches `stop/1`, so a
+    # codex that fails to answer `initialize` was left running.
+    pgid_file = Path.join(tmp_dir, "pgid")
+    command = "( sleep 30 ) & echo $$ > #{pgid_file}; sleep 30"
+
+    assert {:error, _} = Session.start(tmp_dir, command, policy(read_timeout_ms: 500))
+
+    assert wait_until(fn -> File.exists?(pgid_file) end)
+    pgid = pgid_file |> File.read!() |> String.trim()
+
+    assert wait_until(fn -> not alive?("-#{pgid}") end)
+  end
+
+  test "a remote session waits longer than a local one before insisting" do
+    # `ssh` does not exit on stdin EOF -- its clean teardown is a network round
+    # trip -- so a local-sized grace SIGKILLs a well-behaved client partway
+    # through one.
+    local = Session.stop_grace_ms(nil)
+    remote = Session.stop_grace_ms(%Raxol.Symphony.Worker.HostSpec{host: "worker-1"})
+
+    assert remote > local
+  end
+
+  test "release/1 tolerates a session built without a watcher" do
+    assert :ok = PortReaper.release(nil)
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
@@ -112,6 +112,32 @@ defmodule Raxol.Symphony.Runners.Codex.SessionStopTest do
            "the app-server exits on EOF, but its tool subprocess does not"
   end
 
+  test "reaps the orphans of a codex that exited on its own and closed the port" do
+    # codex pipes its exec-tool output rather than sharing the port's stdout, so
+    # an orphan does NOT keep the port open: the exit status arrives, the VM
+    # closes the port, and `stop/1` finds nothing left to capture. This is the
+    # `{:error, {:port_exit, _}}` path out of both receive loops, and the
+    # handshake failures take the same shape.
+    #
+    # The target captured at start-up is the only one that still names the
+    # group, so the session has to carry it forward.
+    {port, os_pid} =
+      open_session_port("( sleep 30 >/dev/null 2>&1 </dev/null ) & echo ready; sleep 0.5; exit 0")
+
+    assert {:group, ^os_pid} = target = PortReaper.capture(port)
+
+    assert wait_until(fn -> Port.info(port, :os_pid) == nil end),
+           "the codex exiting should have closed its own port"
+
+    assert PortReaper.capture(port) == :none
+    assert alive?("-#{os_pid}"), "the orphaned tool subprocess should still be running"
+
+    assert :ok = Session.stop(%{port: port, reap_target: target})
+
+    assert wait_until(fn -> not alive?("-#{os_pid}") end),
+           "a closed port must fall back to the target captured at start-up"
+  end
+
   test "accepts a session map and a already-dead port" do
     {port, os_pid} = open_session_port("echo ready; sleep 30")
 

--- a/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/codex/session_stop_test.exs
@@ -1,0 +1,67 @@
+defmodule Raxol.Symphony.Runners.Codex.SessionStopTest do
+  @moduledoc """
+  `Session.stop/1` runs in the `after` block of every codex run, so whatever it
+  fails to clean up is left behind once per run.
+
+  Closing the port delivers EOF, which stops a codex that is reading stdin and
+  nothing else. These drive the two cases it does not cover, against real
+  processes standing in for the app-server and the tools it spawns.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Symphony.Runners.Codex.Session
+
+  defp open_session_port(script) do
+    port =
+      Port.open(
+        {:spawn_executable, System.find_executable("bash")},
+        [
+          :binary,
+          :exit_status,
+          :stderr_to_stdout,
+          :hide,
+          {:line, 1_048_576},
+          {:cd, System.tmp_dir!()},
+          {:args, ["-lc", script]}
+        ]
+      )
+
+    Process.sleep(300)
+    {:os_pid, os_pid} = Port.info(port, :os_pid)
+    {port, os_pid}
+  end
+
+  defp alive?(target) do
+    {_out, status} = System.cmd("/bin/kill", ["-0", target], stderr_to_stdout: true)
+    status == 0
+  end
+
+  test "stops a session that is not reading stdin" do
+    # Wedged, or busy inside a turn: the EOF lands on a codex that never looks.
+    {port, os_pid} = open_session_port("sleep 30")
+
+    assert :ok = Session.stop(port)
+
+    refute alive?("-#{os_pid}")
+  end
+
+  test "reaps the tool subprocesses a cleanly exited codex left behind" do
+    {port, os_pid} = open_session_port("( sleep 30 ) & cat > /dev/null")
+
+    assert :ok = Session.stop(port)
+
+    refute alive?("-#{os_pid}"),
+           "the app-server exits on EOF, but its tool subprocess does not"
+  end
+
+  test "accepts a session map and a already-dead port" do
+    {port, os_pid} = open_session_port("sleep 30")
+
+    assert :ok = Session.stop(%{port: port})
+    refute alive?("-#{os_pid}")
+
+    # Stopping twice must not raise on the already-closed port.
+    assert :ok = Session.stop(port)
+    assert :ok = Session.stop(nil)
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
@@ -120,6 +120,31 @@ defmodule Raxol.Symphony.WorkspaceTest do
       refute File.exists?(hook_witness)
       refute File.exists?(child_witness)
     end
+
+    # The same leak, one step meaner: the hook's own bash exits IMMEDIATELY and
+    # only the background child is left. That child still holds the inherited
+    # stdout, so no exit status is delivered, the port stays open, and the
+    # timeout fires as before -- but now against a pid that has already been
+    # reaped. Resolving the kill target off that pid signals a corpse and leaves
+    # the child running; resolving it off the process group reaps it.
+    @tag :tmp_dir
+    test "kills the children of a hook that exited before its own timeout", %{tmp_dir: tmp_dir} do
+      child_witness = Path.join(tmp_dir, "orphan_finished")
+
+      script = """
+      ( sleep 1; touch #{child_witness} ) &
+      exit 0
+      """
+
+      config = build_config(tmp_dir, %{before_run: script, timeout_ms: 200})
+
+      assert {:error, :timeout} = Workspace.run_hook(config, :before_run, tmp_dir)
+
+      # Past the point the orphan would have finished its own work.
+      Process.sleep(1_200)
+
+      refute File.exists?(child_witness)
+    end
   end
 
   describe "run_before_run_hook/2" do

--- a/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
@@ -104,8 +104,8 @@ defmodule Raxol.Symphony.WorkspaceTest do
       child_witness = Path.join(tmp_dir, "child_finished")
 
       script = """
-      ( sleep 2; touch #{child_witness} ) &
-      sleep 2
+      ( sleep 1; touch #{child_witness} ) &
+      sleep 1
       touch #{hook_witness}
       """
 
@@ -113,7 +113,9 @@ defmodule Raxol.Symphony.WorkspaceTest do
 
       assert {:error, :timeout} = Workspace.run_hook(config, :before_run, tmp_dir)
 
-      Process.sleep(2_400)
+      # Five times the timeout the hook was given, and past the point a survivor
+      # would have finished its own work.
+      Process.sleep(1_200)
 
       refute File.exists?(hook_witness)
       refute File.exists?(child_witness)

--- a/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workspace_test.exs
@@ -89,6 +89,37 @@ defmodule Raxol.Symphony.WorkspaceTest do
     end
   end
 
+  describe "run_hook/4 timeout" do
+    # A hook we have stopped waiting for has to actually be DEAD. `before_remove`
+    # is followed by an `rm_rf` of the very directory the hook is still writing
+    # to, and a hook that survives its timeout survives once per retry.
+    #
+    # The witnesses are what a survivor leaves behind, so the assertion is their
+    # ABSENCE once the hook's own natural runtime has elapsed. Only a survivor
+    # can create them, which is what keeps this from being a wall-clock race:
+    # slow machines cannot fail it, they can only stop proving anything.
+    @tag :tmp_dir
+    test "kills a timed-out hook and the children it spawned", %{tmp_dir: tmp_dir} do
+      hook_witness = Path.join(tmp_dir, "hook_finished")
+      child_witness = Path.join(tmp_dir, "child_finished")
+
+      script = """
+      ( sleep 2; touch #{child_witness} ) &
+      sleep 2
+      touch #{hook_witness}
+      """
+
+      config = build_config(tmp_dir, %{before_run: script, timeout_ms: 200})
+
+      assert {:error, :timeout} = Workspace.run_hook(config, :before_run, tmp_dir)
+
+      Process.sleep(2_400)
+
+      refute File.exists?(hook_witness)
+      refute File.exists?(child_witness)
+    end
+  end
+
   describe "run_before_run_hook/2" do
     @tag :tmp_dir
     test "noop when hook is not set", %{tmp_dir: tmp_dir} do

--- a/packages/raxol_symphony/test/support/fake_codex.sh
+++ b/packages/raxol_symphony/test/support/fake_codex.sh
@@ -17,6 +17,13 @@ set -u
 
 mode="${FAKE_CODEX_MODE:-happy}"
 
+# Optionally spawn a long-lived background child, standing in for a tool
+# subprocess. It inherits the port's stdout, as a real one would. Off unless
+# FAKE_CODEX_SPAWN_SECONDS is set, so no existing mode is affected.
+if [[ -n "${FAKE_CODEX_SPAWN_SECONDS:-}" ]]; then
+  ( sleep "$FAKE_CODEX_SPAWN_SECONDS" ) &
+fi
+
 # Read one line from stdin; exit on EOF.
 # Do NOT echo to stderr -- the runner opens the port with :stderr_to_stdout,
 # which would mix the echo into the JSON-RPC stream.


### PR DESCRIPTION
Closes #890, and fixes the same class of defect in `Runners.Codex.Session`.

Supersedes #894, which carried the first two commits against master. That PR's
own Linux CI was red for the reason the fourth commit here explains, so the two
are landing as one change rather than putting a known-broken commit on master.

`Port.close/1` releases the BEAM-side port and signals NOTHING. What becomes of
the child is the child's own business, and both call sites had assumed
otherwise.

## 1. Workspace hooks (#890)

`Workspace.collect_output/3` claimed in a comment that `Port.close` SIGKILLs the
child. It does not: a local hook exceeding `hooks.timeout_ms` kept running after
the orchestrator gave up on it. `before_remove` then `rm_rf`s the workspace out
from under a live hook, and a hook that leaks a process per timeout leaks one
per retry. Reproduced before fixing: the hook completed its work a full 3s after
it was declared timed out.

Killed outright, where the remote deadline sends SIGTERM -- nothing reads the
status here, and the workspace may be deleted next.

## 2. Codex sessions

`Session.stop/1` closed the port and stopped there. Closing delivers the EOF a
stdio server treats as "shut down", so a codex that is reading stdin *does*
exit. That is why this looked fine, and it is only the ordinary case. Measured,
two cases fall straight through it:

| child | after `Port.close` |
|---|---|
| reads stdin, exits on EOF | dead -- the clean path, works today |
| **not reading stdin** (wedged / mid-turn) | **alive** |
| **tool subprocess of a cleanly exited parent** | **alive**, reparented to init |

The second is the one that bites in practice: codex spawns tool subprocesses,
and they outlive a parent that exited perfectly cleanly. `stop/1` runs in the
`after` block of every codex run, so whatever it misses is left behind per run.

The EOF is still delivered first, and a group kill backs it up after a grace
window -- a well-behaved codex stays on the clean path and gets to flush and
exit on its own terms; the kill only reaches a session that would otherwise have
been abandoned. Polling stops as soon as the group drains, so the ordinary case
does not spend the grace.

## The shared guard

Both sites need the same safety-critical decision, so it is extracted into
`Raxol.Symphony.PortReaper` rather than copied.

Signal the process **group**: killing only the child leaves its descendants
running, still working and still holding the inherited stdout pipe. Measured on
this machine, `erl_child_setup` gives a spawned port child its own process group
(child pid 79195, pgid 79195) while the BEAM sits in a different group (pgid
79135), and the child's `sleep` shares the child's group -- so `kill -KILL -PID`
reaches the descendants and nothing else.

That is **checked, not assumed**. A child that is not a group leader shares the
BEAM's group, and the group kill would take the VM down with it. The
`{:pid, _}` fallback loses the descendants and keeps the VM; a `ps` that is
missing, fails, or answers something unparseable resolves the same way.

The target is captured **before** the close: a process group outlives its
leader, which is exactly what makes the orphan case reachable, and once the
child exits there is nothing left to read the group off.

## The reap never ran where it mattered

`try/after` does not run on an untrappable exit, and the orchestrator tears
workers down with exactly that on all three of its teardown paths (`stop_run`,
`terminate_stalled_run`, `terminate_running`). So `after Session.stop(session)`
in `Codex.do_run/3` never fired. The stall path is the sharp one: it fires
precisely when codex is wedged, which is the case EOF cannot reach, and
`terminate_running` then `rm_rf`s the workspace.

Cleanup that has to survive its owner cannot live in the owner, so
`PortReaper.watch/1` spawns an unlinked process that monitors the caller and
reaps on `:DOWN`. A failed handshake reaps too: only a session that was built
ever reached `stop/1`.

## kill(1) lies on Linux

The reap was measured on macOS and never worked on Linux at all. #894's own CI
said so: the hook timed out at 11.357, the kill ran, and the hook completed
anyway at 13.05 -- with no `kill_failed` warning, because the kill had reported
success.

procps-ng's `kill`, which is `/usr/bin/kill` on Debian and Ubuntu, takes a
negative pid in its own argv slot, does nothing with it, and exits 0. Reproduced
in a Linux container: with the group live,
`System.cmd(kill, ["-KILL", "-204"])` returns `{"", 0}` and the group is still
running afterwards, while the bash builtin on the same target returns `{"", 0}`
and reaps it. `kill -s KILL -- -204` is no way out either: procps has no `--`
and answers with a usage error. macOS's `/bin/kill` handles the same argv
correctly, which is exactly why this was green on a developer machine and red on
CI.

`kill -0` is worse than useless there: procps answers 0 for a group that does
not exist, so `alive?/1` was permanently true. That is the 25 minutes. Every
`await_exit/2` burned its whole grace forking a `kill` twenty times a second,
and under `max_cases: 16` the suite ground past the job budget. The hook-only
commit, which has no polling loop, just failed in 34s -- which is what CI showed
for each.

Bash's builtin is POSIX about negative pids on both platforms, and bash is
already a hard dependency of every call site, so it is the whole mechanism
rather than a fallback: a path known to silently no-op is not worth keeping as
one. The test oracle had the same bug and would have hidden the fix; it stays
independent of `PortReaper`, spelled out rather than routed through it, but goes
through the builtin too.

## Smaller findings

- The hook kill moves ahead of the close. While the port is open the child's pid
  is still ours and the OS cannot recycle it; afterwards a group kill is aimed
  at a pgid nothing pins. Nothing there waits on output, so there was never a
  reason to close first.
- Remote sessions get their own grace. `ssh` does not exit on stdin EOF, so the
  2s local budget SIGKILLed a well-behaved client partway through a network
  round trip.
- `kill`/`await_exit` guard against pgid 0 and 1 ("my own group" and "everything
  I may signal"). `capture/1` cannot produce them; the public API could.
- `Port.info(port, :os_pid)` is `:undefined` for a non-spawned port and would
  have reached an argv.
- `close_port/1` extracted rather than living in two modules with divergent
  bodies, and the comment claiming the kill lands before the close is gone.
- `grace_expired` logged at warning, not debug; a group kill degrading to a lone
  pid now says so.
- Tests poll to a deadline instead of sleeping a fixed span, and scripts
  announce readiness on stdout so the orphan tests cannot proceed before the
  fork.

## Verification

Every behavioural test here was proven RED against the unfixed code first.

Hook timeout:

```
1) test run_hook/4 timeout kills a timed-out hook and the children it spawned
   Expected false or nil, got true
   code: refute File.exists?(hook_witness)
```

Codex stop, against the old close-only `stop/1`:

```
1) test reaps the tool subprocesses a cleanly exited codex left behind
2) test accepts a session map and a already-dead port
3) test stops a session that is not reading stdin
3 tests, 3 failures
```

Plus the two review tests (owner-killed reap, handshake-failure reap), also
proven RED against the unfixed `session.ex`.

All GREEN with the fix. The hook test asserts the ABSENCE of witness files only
a survivor could create, so a slow machine cannot fail it -- it can only stop
proving anything. The reaper and session tests ask the OS for liveness
(`kill -0`) rather than inferring it from a side effect.

- `mix test` (raxol_symphony): 23 doctests, **946 tests, 0 failures**
- Linux CI green on `Package Tests (raxol_symphony)`, 1m15s
- `mix format --check-formatted`: clean
- `mix compile --warnings-as-errors`: clean
- `mix credo --strict`: no new findings. The three hits in changed files are
  pre-existing and in untouched code (`workspace.ex:213` in `bracket/2`, two
  `opts ++ [...]` appends in `Session.launch_spec`)

## Acceptance (from #890)

- [x] a local hook exceeding `hooks.timeout_ms` is dead afterwards, asserted by
      a witness file that must NOT appear
- [x] the hook's children die with it
- [x] `collect_output/3` still returns `{:error, :timeout}` promptly
- [x] the incorrect `Port.close` comment is gone

## Manual testing

- [ ] Configure a `before_remove` hook that outlives `hooks.timeout_ms`, run an
      issue to removal, confirm no orphan remains (`ps -o pid,ppid,pgid,command`)
- [ ] Confirm an in-budget hook still reports its real exit status
- [ ] Run a codex issue that shells out to a long-running tool, stop it, confirm
      the tool is gone and a clean session still shuts down without the grace
- [ ] Stop a running codex issue mid-turn, confirm its tool subprocesses are gone
- [ ] Confirm a remote (`worker.ssh_hosts`) codex session still tears down --
      killing the local `ssh` client is what triggers `reap_on_disconnect` on
      the host, so this should be unchanged
