### PR TITLE
Probe the process group instead of asking ps for it

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/interrupt.ex
+++ b/packages/raxol_agent/lib/raxol/agent/interrupt.ex
@@ -75,6 +75,8 @@ defmodule Raxol.Agent.Interrupt do
   `interrupt/3` implements this behaviour; the red suite runs green against it.
   """
 
+  alias Raxol.Core.ProcessGroup
+
   @signal :interrupt_signaled
   @wait :interrupt_waited
   @kill :interrupt_killed
@@ -85,8 +87,9 @@ defmodule Raxol.Agent.Interrupt do
   # Executable for the mutating `kill` shell-outs. Overridable via
   # `config :raxol_agent, :interrupt_kill_sh` so a test can force an OS-level
   # signal failure (a permission-denied kill) without an unkillable live
-  # process. Only the `kill` calls honor this seam — every `ps`/pgid read uses
-  # the real binary, so liveness and pgid derivation stay truthful.
+  # process. Only the `kill` calls honor this seam — every `ps` read and every
+  # target RESOLUTION uses the real binary, so liveness and group derivation
+  # stay truthful while the signal itself is made to fail.
   @kill_sh "/bin/sh"
 
   @typedoc "The three staged-kill event types, in escalation order."
@@ -474,21 +477,20 @@ defmodule Raxol.Agent.Interrupt do
   # signalable (a non-positive/invalid pid).
   defp group_signal(os_pid, signal)
        when is_integer(os_pid) and os_pid > 1 and is_binary(signal) do
-    if group_leader_safe?(os_pid) do
-      {_out, status} =
-        System.cmd(kill_sh(), ["-c", "kill #{signal} -#{os_pid} 2>/dev/null"])
+    case ProcessGroup.resolve(os_pid) do
+      {:group, _} = target ->
+        {ProcessGroup.signal(target, signal, shell: kill_sh()) == :ok, :group}
 
-      {status == 0, :group}
-    else
-      # Enumerate the whole subtree BEFORE signaling the parent: killing the
-      # parent first reparents its children and loses the ppid linkage.
-      descendants = descendants_of(os_pid)
+      _ ->
+        # Enumerate the whole subtree BEFORE signaling the parent: killing the
+        # parent first reparents its children and loses the ppid linkage.
+        descendants = descendants_of(os_pid)
 
-      {_out, status} =
-        System.cmd(kill_sh(), ["-c", "kill #{signal} #{os_pid} 2>/dev/null"])
+        parent_ok? =
+          ProcessGroup.signal({:pid, os_pid}, signal, shell: kill_sh()) == :ok
 
-      swept_ok? = descendants |> Enum.map(&individual_signal(&1, signal)) |> Enum.all?()
-      {status == 0 and swept_ok?, {:fallback, descendants}}
+        swept_ok? = descendants |> Enum.map(&individual_signal(&1, signal)) |> Enum.all?()
+        {parent_ok? and swept_ok?, {:fallback, descendants}}
     end
   end
 
@@ -496,8 +498,7 @@ defmodule Raxol.Agent.Interrupt do
 
   # Signal one pid; returns whether the `kill` exited 0 (status not discarded).
   defp individual_signal(pid, signal) when is_integer(pid) and pid > 1 do
-    {_out, status} = System.cmd(kill_sh(), ["-c", "kill #{signal} #{pid} 2>/dev/null"])
-    status == 0
+    ProcessGroup.signal({:pid, pid}, signal, shell: kill_sh()) == :ok
   end
 
   defp individual_signal(_pid, _signal), do: false
@@ -592,14 +593,29 @@ defmodule Raxol.Agent.Interrupt do
   # derivation works on this host — a nil pgid silently degrades group-kill to
   # the per-pid fallback (the macOS/BSD pgid-derivation regression).
   @doc false
-  def group_leader_safe?(os_pid) do
-    with pgid when is_integer(pgid) <- pgid_of(os_pid),
-         own when is_integer(own) <- own_pgid() do
-      pgid == os_pid and pgid != own
-    else
-      _ -> false
-    end
+  def group_leader_safe?(os_pid) when is_integer(os_pid) and os_pid > 1 do
+    # This used to read the pgid out of `ps` and require `pgid == os_pid and
+    # pgid != own_pgid()`. Both halves are subsumed by probing the group
+    # directly, and the probe answers a case the read could not.
+    #
+    # `pgid == os_pid`: a group's id is its leader's pid, and that pid stays
+    # allocated while the group has any member. So a group answering under
+    # `os_pid` can only be one this pid led.
+    #
+    # `pgid != own_pgid()`: a child that is NOT a group leader sits in the
+    # BEAM's group, whose id is the BEAM's leader's pid -- never `os_pid`, which
+    # is a live child. The probe therefore finds no group under `os_pid` and
+    # falls back. The VM's own group is unreachable here by construction rather
+    # than by inspection.
+    #
+    # What the read could not do: see a corpse. A tool that backgrounds a child
+    # and exits leaves `ps -o pgid= -p <corpse>` empty, so the group kill was
+    # skipped for the one topology it is most needed in -- and the fallback's
+    # ppid sweep cannot reach a reparented orphan either.
+    ProcessGroup.group_leader?(os_pid)
   end
+
+  def group_leader_safe?(_os_pid), do: false
 
   # Derive a pid's process-group id. The primary form (`-o pgid=`, empty-header
   # suppression) works on GNU ps and modern macOS/BSD ps; the fallback requests
@@ -637,10 +653,6 @@ defmodule Raxol.Agent.Interrupt do
         nil
     end
   end
-
-  defp own_pgid, do: pgid_of(os_getpid())
-
-  defp os_getpid, do: :os.getpid() |> to_string() |> String.to_integer()
 
   # All transitive descendants of `root` from ONE `ps -Ao pid=,ppid=` table
   # scan (portable across GNU and BSD ps; `--ppid` is not) walked breadth-first

--- a/packages/raxol_agent/lib/raxol/agent/interrupt.ex
+++ b/packages/raxol_agent/lib/raxol/agent/interrupt.ex
@@ -92,6 +92,13 @@ defmodule Raxol.Agent.Interrupt do
   # stay truthful while the signal itself is made to fail.
   @kill_sh "/bin/sh"
 
+  # The override is read in a TEST build only. What it names is an executable
+  # this VM then runs with its own privileges on every kill, and a config file
+  # is not where that choice belongs: the whole purpose of the seam is to make a
+  # kill FAIL, which is never something a deployment wants. Compile-time, so a
+  # release carries no path from config to an exec at all.
+  @kill_sh_overridable? if Code.ensure_loaded?(Mix), do: Mix.env() == :test, else: false
+
   @typedoc "The three staged-kill event types, in escalation order."
   @type stage :: :interrupt_signaled | :interrupt_waited | :interrupt_killed
 
@@ -503,7 +510,11 @@ defmodule Raxol.Agent.Interrupt do
 
   defp individual_signal(_pid, _signal), do: false
 
-  defp kill_sh, do: Application.get_env(:raxol_agent, :interrupt_kill_sh, @kill_sh)
+  if @kill_sh_overridable? do
+    defp kill_sh, do: Application.get_env(:raxol_agent, :interrupt_kill_sh, @kill_sh)
+  else
+    defp kill_sh, do: @kill_sh
+  end
 
   # Poll the single-pid oracle until `os_pid` is gone or the budget elapses.
   # Used only where the group is not observable — it can short-circuit the

--- a/packages/raxol_agent/test/raxol/agent/red/u5_interrupt_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u5_interrupt_red_test.exs
@@ -303,6 +303,40 @@ defmodule Raxol.Agent.Red.U5InterruptRedTest do
     end
   end
 
+  describe "P11 — an orphan whose parent already exited is still reaped" do
+    @tag :unix_only
+    test "the group is resolved off the surviving group, not off the corpse's pgid" do
+      # The commonest leak shape: the tool backgrounds something and exits. Its
+      # own pid is a corpse, so a `ps -o pgid= -p <corpse>` read comes back
+      # empty, the group-kill path is never taken, and the per-pid fallback's
+      # ppid sweep cannot see the orphan either -- it was reparented to init the
+      # moment its parent died. Both halves of the old derivation miss it.
+      #
+      # The surviving process GROUP still names it, which is what resolving via
+      # `kill -0 -<pgid>` finds.
+      lab = KillLab.spawn_orphaning(sleep: 30)
+      on_exit(fn -> KillLab.reap(lab) end)
+
+      assert KillLab.await_dead(lab.os_pid, 3_000),
+             "test premise broken: the tool's top process should have exited on its own"
+
+      assert KillLab.alive?(lab.child_pid),
+             "test premise broken: the orphan should still be running"
+
+      assert Interrupt.group_leader_safe?(lab.os_pid),
+             "a corpse still leads a live group -- resolving the target off `ps` " <>
+               "cannot see that, and drops to a sweep that cannot reach the orphan"
+
+      {disposition, confirmed?, _os_pid} = Interrupt.kill_os_pid(lab.os_pid)
+
+      assert KillLab.await_dead(lab.child_pid, 3_000),
+             "the orphan survived the kill: this is the leak the group path exists to close"
+
+      assert disposition == :killed
+      assert confirmed?, "the group was signalled, so group death is observable"
+    end
+  end
+
   describe "P9 — the liveness oracle is state-aware (a zombie is dead, not alive)" do
     @tag :unix_only
     test "a killed-but-unreaped (zombie) child is reported dead, though ps -p exits 0" do

--- a/packages/raxol_agent/test/support/kill_lab.ex
+++ b/packages/raxol_agent/test/support/kill_lab.ex
@@ -82,6 +82,31 @@ defmodule Raxol.Agent.KillLab do
   end
 
   @doc """
+  Spawn a tool that **exits immediately** after backgrounding its child, so the
+  child is orphaned and reparented to init while the tool's own pid becomes a
+  corpse. Returns `%{port:, os_pid:, child_pid:}`.
+
+  The port stays OPEN throughout: ERTS withholds the exit status until the
+  inherited stdout reaches EOF, and the orphan is still holding it, so
+  `Port.info/2` goes on reporting a pid that has already been reaped.
+
+  This is the topology a pgid-via-`ps` derivation cannot resolve -- `ps` cannot
+  see a corpse, so the group is never found -- and that a ppid sweep cannot
+  reach either, since the orphan's ppid is already `1`. Only the surviving
+  process GROUP still names it.
+  """
+  @spec spawn_orphaning(keyword()) :: %{
+          port: port(),
+          os_pid: non_neg_integer(),
+          child_pid: non_neg_integer()
+        }
+  def spawn_orphaning(opts \\ []) do
+    secs = Keyword.get(opts, :sleep, 30)
+    cmd = "sleep #{secs} & echo RAXOL_CHILD $!; exit 0"
+    spawn_tool(cmd)
+  end
+
+  @doc """
   Spawn a tool that manufactures a **zombie**: a short-lived child exits under
   a parent (`exec sleep`) that never reaps it, so the child sits in STAT `Z`
   until the parent dies. Returns `%{port:, os_pid:, child_pid:}` where
@@ -102,9 +127,7 @@ defmodule Raxol.Agent.KillLab do
   @doc "True iff `ps` reports `pid` in a zombie (`Z*`) state."
   @spec zombie?(non_neg_integer()) :: boolean()
   def zombie?(pid) when is_integer(pid) do
-    case System.cmd("ps", ["-o", "stat=", "-p", Integer.to_string(pid)],
-           stderr_to_stdout: true
-         ) do
+    case System.cmd("ps", ["-o", "stat=", "-p", Integer.to_string(pid)], stderr_to_stdout: true) do
       {out, 0} -> out |> String.trim() |> String.starts_with?("Z")
       _ -> false
     end
@@ -258,9 +281,7 @@ defmodule Raxol.Agent.KillLab do
   end
 
   defp pgid_of(pid) do
-    case System.cmd("ps", ["-o", "pgid=", "-p", Integer.to_string(pid)],
-           stderr_to_stdout: true
-         ) do
+    case System.cmd("ps", ["-o", "pgid=", "-p", Integer.to_string(pid)], stderr_to_stdout: true) do
       {out, 0} -> out |> String.trim() |> parse_int()
       _ -> nil
     end

--- a/packages/raxol_core/lib/raxol/core/process_group.ex
+++ b/packages/raxol_core/lib/raxol/core/process_group.ex
@@ -38,7 +38,11 @@ defmodule Raxol.Core.ProcessGroup do
   correctly, which is why this class of bug is green on a developer machine and
   red on Linux CI.
 
-  Shell builtins are POSIX about negative pids on both.
+  Shell builtins are POSIX about negative pids on both, and any POSIX shell will
+  do: bash, dash and busybox ash were each measured signalling a real group
+  through `-<pgid>` and reporting the same errno text back. `shell/0` prefers
+  bash and settles for `sh`, so a host with only the latter keeps the group kill
+  rather than degrading to a bare-pid reap that leaves the descendants running.
 
   ## Callers
 
@@ -71,8 +75,8 @@ defmodule Raxol.Core.ProcessGroup do
   NONE of these may be reported as success: a caller about to delete the
   target's working directory is relying on the difference.
 
-  `:unavailable` -- no shell to signal with, so nothing was verified and nothing
-  was killed.
+  `:unavailable` -- no shell on PATH to signal with, so nothing was verified and
+  nothing was killed.
 
   `:refused` -- the kernel rejected the signal (EPERM). The target is
   demonstrably still there, and still running.
@@ -89,10 +93,10 @@ defmodule Raxol.Core.ProcessGroup do
   @type reason :: :unavailable | :refused | :spawn_failed | :unknown
 
   @typedoc """
-  * `:shell` -- shell to deliver signals through. Defaults to `bash` on PATH.
-    Honoured by `signal/3` and `await_gone/3` only; `resolve/1` always uses the
-    real shell, so an injected failing shell simulates a failing KILL without
-    also corrupting the target it is aimed at.
+  * `:shell` -- shell to deliver signals through, `shell/0` when absent.
+    Honoured by `signal/3` and `await_gone/3` only; `resolve/1` takes no opts at
+    all, so an injected failing shell simulates a failing KILL without also
+    corrupting the target it is aimed at.
   """
   @type opts :: [shell: String.t() | nil]
 
@@ -109,18 +113,36 @@ defmodule Raxol.Core.ProcessGroup do
   @poll_ms 50
 
   @doc """
+  The shell signals are delivered through, or `nil` when this host has none.
+
+  Public because resolving it is a full PATH scan and a poll loop must not repeat
+  one: `await_gone/3` ticks every #{@poll_ms}ms for a whole grace window, so a
+  caller resolves once here and threads the answer down through `:shell`.
+
+  `bash` first, then any POSIX `sh`. The preference is habit, not requirement:
+  both things this module asks of the builtin -- that `-<pgid>` names a process
+  group, and that a failure carries `strerror` (see `classify/1`) -- were
+  measured identical on Debian's dash and on busybox ash. Settling for `sh`
+  matters because those are the hosts with no bash to find, and answering
+  `:unavailable` there would give up the group kill on exactly the systems the
+  moduledoc cites as the reason not to depend on `ps`.
+  """
+  @spec shell() :: String.t() | nil
+  def shell, do: System.find_executable("bash") || System.find_executable("sh")
+
+  @doc """
   Resolve the safe signal target for a spawned child's OS pid.
 
   `{:group, os_pid}` when a process group under that id answers a signal, which
   can only be true if this child led it. `{:pid, os_pid}` otherwise -- safe, but
   it silently drops the descendants, so it is logged.
 
-  Always uses the real shell, never an injected one: this decides WHAT gets
+  Takes no opts, so an injected shell cannot reach it: this decides WHAT gets
   signalled, and a wrong answer here is the unrecoverable failure.
   """
   @spec resolve(pos_integer()) :: target()
   def resolve(os_pid) when is_integer(os_pid) and os_pid > 1 do
-    case signal({:group, os_pid}, "-0", shell: nil) do
+    case signal({:group, os_pid}, "-0", shell: shell()) do
       :ok ->
         {:group, os_pid}
 
@@ -168,7 +190,7 @@ defmodule Raxol.Core.ProcessGroup do
   def signal(:none, _flag, _opts), do: :gone
 
   def signal(target, flag, opts) when is_signallable(target) and is_binary(flag) do
-    case shell(opts) do
+    case shell_for(opts) do
       nil -> {:error, :unavailable}
       path -> run(path, flag, arg(target))
     end
@@ -232,7 +254,8 @@ defmodule Raxol.Core.ProcessGroup do
   #
   # The locale is pinned to C because the errno text is the only thing that can
   # tell ESRCH from EPERM -- the builtin exits 1 for both. macOS libc does not
-  # translate `strerror`, but glibc does, and CI is glibc.
+  # translate `strerror`, but glibc does, and CI is glibc. Pinning it is also
+  # what makes `classify/1` a claim about libc rather than about a shell.
   defp run(path, flag, arg) do
     args = ["-c", ~s(kill "$1" "$2"), "raxol-process-group", flag, arg]
     env = [{"BASH_ENV", nil}, {"ENV", nil}, {"LC_ALL", "C"}, {"LANG", "C"}]
@@ -256,6 +279,23 @@ defmodule Raxol.Core.ProcessGroup do
   # that reach this and are not EPERM: a seccomp or LSM filter answers EACCES,
   # whose text is "Permission denied" and not "Operation not permitted"; and a
   # shell whose builtin rejects the flag answers with a usage error.
+  #
+  # These patterns are NOT bash's wording, and that distinction is the whole
+  # reason to write them down: `/bin/sh` is dash on Debian and Ubuntu and CI is
+  # Linux, so the shell whose text reaches here is routinely not the one this
+  # was authored against. What makes the match portable is that each builtin
+  # prints `strerror(errno)` verbatim and varies only in what it puts in FRONT
+  # of it, which a substring match ignores. Measured under `LC_ALL=C`, ESRCH
+  # then EPERM (the prefix each one adds is elided; dash's carries `$0`):
+  #
+  #   bash 5   ... kill: (-57) - No such process       ... kill: (1) - Operation not permitted
+  #   dash     ... kill: No such process               ... kill: Operation not permitted
+  #   busybox  ... can't kill pid -57: No such process ... can't kill pid 1: Operation not permitted
+  #
+  # So the locale pin above is what makes this a claim about libc rather than
+  # about a shell, and the pattern is only how the claim is read. A builtin that
+  # hid `strerror` entirely would land on `:unknown`, which is the safe half of
+  # the inversion.
   defp classify(output) do
     cond do
       output =~ ~r/no such process/i -> :gone
@@ -264,10 +304,10 @@ defmodule Raxol.Core.ProcessGroup do
     end
   end
 
-  defp shell(opts) do
+  defp shell_for(opts) do
     case Keyword.get(opts, :shell) do
       path when is_binary(path) -> path
-      _ -> System.find_executable("bash")
+      _ -> shell()
     end
   end
 

--- a/packages/raxol_core/lib/raxol/core/process_group.ex
+++ b/packages/raxol_core/lib/raxol/core/process_group.ex
@@ -1,0 +1,283 @@
+defmodule Raxol.Core.ProcessGroup do
+  @moduledoc """
+  Safely signal the OS process group behind a spawned child.
+
+  Killing only a child leaves its descendants running: still doing work, still
+  holding whatever fds they inherited. Killing its process GROUP reaches them.
+  The catch is that a group kill aimed at the wrong id is unrecoverable -- a
+  child that is not a group leader shares the BEAM's own group, and
+  `kill -KILL -<pgid>` against that takes the VM down with it.
+
+  So a target is RESOLVED before it is signalled. `resolve/1` answers
+  `{:group, pgid}` only when it can show a group under that id exists, and
+  `{:pid, os_pid}` (which loses the descendants, and says so) when it cannot.
+
+  ## Why the group is probed rather than read
+
+  A process group's id is the pid of its leader, and that pid stays allocated
+  for as long as the group has ANY member. So "group `os_pid` answers a signal"
+  can only be true if the process holding pid `os_pid` led it.
+
+  The obvious alternative -- ask `ps` for the child's pgid and require
+  `pgid == os_pid` -- cannot answer the case that matters most. When a child
+  backgrounds something and exits, the parent is a corpse and `ps` cannot see
+  it, so the pgid read fails and the group is never found. That is exactly the
+  case where a group is still running and needs reaping, and the ppid-walk
+  fallback misses it too: a reparented orphan's ppid is already `1`. `ps` is
+  also absent on busybox.
+
+  ## Why signals go through a shell builtin
+
+  Never `kill(1)`. procps-ng's `kill` -- `/usr/bin/kill` on Debian and Ubuntu --
+  takes a negative pid in its own argv slot, does NOTHING with it, and exits 0.
+  Measured on linux/aarch64 with the group live: `System.cmd(kill,
+  ["-KILL", "-57"])` returned `{"", 0}` and both members were still running.
+  That is the worst failure available here, a reap that reports success and
+  reaps nothing. `kill -s KILL -- -57` is no way out either: procps has no `--`
+  and answers with a usage error. macOS's `/bin/kill` handles the same argv
+  correctly, which is why this class of bug is green on a developer machine and
+  red on Linux CI.
+
+  Shell builtins are POSIX about negative pids on both.
+
+  ## Callers
+
+  `Raxol.Symphony.PortReaper` (port children, with an owner-death watcher) and
+  `Raxol.Agent.Interrupt` (the shell tool's staged TERM/KILL escalation). Both
+  used to carry their own copy of this; they disagreed, and the `ps`-based one
+  had the corpse-parent hole described above.
+
+  This module deliberately does NOT cover zombie-aware liveness. `kill -0`
+  answers "is this pid still allocated", and a zombie still holds its pid, so a
+  caller that needs to distinguish "exited but unreaped" from "running" needs a
+  `ps`-based oracle instead -- which is why `Interrupt` keeps one.
+  """
+
+  require Logger
+
+  @typedoc """
+  What may safely be signalled.
+
+  `{:group, pgid}` when the child leads its own process group, so its
+  descendants come with it. `{:pid, os_pid}` when it does not, in which case
+  only the child itself can be signalled. `:none` when there is nothing to
+  signal.
+  """
+  @type target :: {:group, pos_integer()} | {:pid, pos_integer()} | :none
+
+  @typedoc """
+  Why a signal could not be delivered.
+
+  NONE of these may be reported as success: a caller about to delete the
+  target's working directory is relying on the difference.
+
+  `:unavailable` -- no shell to signal with, so nothing was verified and nothing
+  was killed.
+
+  `:refused` -- the kernel rejected the signal (EPERM). The target is
+  demonstrably still there, and still running.
+
+  `:spawn_failed` -- the shell resolved but could not be run this time.
+  Transient by nature (a fork that hit `EAGAIN` under process-table pressure is
+  the case that matters, and that pressure is exactly when a reaper is most
+  needed), so callers retry it rather than answering it.
+
+  `:unknown` -- the signal failed with something unrecognised. NOT reported as
+  `:gone`: "the message was not one I know" is not evidence that the target
+  exited.
+  """
+  @type reason :: :unavailable | :refused | :spawn_failed | :unknown
+
+  @typedoc """
+  * `:shell` -- shell to deliver signals through. Defaults to `bash` on PATH.
+    Honoured by `signal/3` and `await_gone/3` only; `resolve/1` always uses the
+    real shell, so an injected failing shell simulates a failing KILL without
+    also corrupting the target it is aimed at.
+  """
+  @type opts :: [shell: String.t() | nil]
+
+  # A pid of 0 means "my own process group" and 1 means "everything I am allowed
+  # to signal". Neither is ever a spawned child, and either one turned into a
+  # group kill takes the VM (or the host) with it. `resolve/1` cannot produce
+  # them, but the signalling functions are public and this module exists
+  # precisely to not assume that.
+  defguard is_signallable(target)
+           when is_tuple(target) and tuple_size(target) == 2 and
+                  elem(target, 0) in [:group, :pid] and
+                  is_integer(elem(target, 1)) and elem(target, 1) > 1
+
+  @poll_ms 50
+
+  @doc """
+  Resolve the safe signal target for a spawned child's OS pid.
+
+  `{:group, os_pid}` when a process group under that id answers a signal, which
+  can only be true if this child led it. `{:pid, os_pid}` otherwise -- safe, but
+  it silently drops the descendants, so it is logged.
+
+  Always uses the real shell, never an injected one: this decides WHAT gets
+  signalled, and a wrong answer here is the unrecoverable failure.
+  """
+  @spec resolve(pos_integer()) :: target()
+  def resolve(os_pid) when is_integer(os_pid) and os_pid > 1 do
+    case signal({:group, os_pid}, "-0", shell: nil) do
+      :ok ->
+        {:group, os_pid}
+
+      # EPERM is an existence proof: the kernel can only refuse a signal to
+      # something that is there.
+      {:error, :refused} ->
+        {:group, os_pid}
+
+      :gone ->
+        warn_no_group(os_pid, "no_process_group_under_that_id")
+        {:pid, os_pid}
+
+      {:error, reason} ->
+        warn_no_group(os_pid, "group_probe_failed_#{reason}")
+        {:pid, os_pid}
+    end
+  end
+
+  def resolve(_os_pid), do: :none
+
+  @doc """
+  True when a process group exists under `os_pid` -- i.e. the child is its own
+  group leader and a group kill is safe.
+  """
+  @spec group_leader?(pos_integer()) :: boolean()
+  def group_leader?(os_pid) when is_integer(os_pid) and os_pid > 1 do
+    match?({:group, _}, resolve(os_pid))
+  end
+
+  def group_leader?(_os_pid), do: false
+
+  @doc """
+  Deliver `flag` (`"-0"`, `"-TERM"`, `"-KILL"`, ...) to `target`.
+
+  `:gone` means nothing signallable is left, which against a GROUP is the
+  question worth asking: the leader can be gone while an orphaned subprocess
+  keeps the group alive.
+
+  Raises `FunctionClauseError` for a target outside `is_signallable/1`, which is
+  the point -- signalling pid 0 or 1 is not a recoverable mistake.
+  """
+  @spec signal(target(), String.t(), opts()) :: :ok | :gone | {:error, reason()}
+  def signal(target, flag, opts \\ [])
+
+  def signal(:none, _flag, _opts), do: :gone
+
+  def signal(target, flag, opts) when is_signallable(target) and is_binary(flag) do
+    case shell(opts) do
+      nil -> {:error, :unavailable}
+      path -> run(path, flag, arg(target))
+    end
+  end
+
+  @doc """
+  Poll until `target` is gone, giving up after `timeout_ms`.
+
+  `:timeout` is a distinct answer from `{:error, _}`: it means the target is
+  still there and the caller's grace is spent, which is normally the cue to stop
+  asking and SIGKILL. An error means the question could not be answered at all.
+
+  Returns `{:error, reason}` immediately rather than waiting out the deadline
+  for any failure waiting cannot fix. A `:spawn_failed` IS waited on: giving up
+  there would abandon the check under process-table pressure, which both causes
+  it and is when it matters.
+  """
+  @spec await_gone(target(), non_neg_integer(), opts()) :: :ok | :timeout | {:error, reason()}
+  def await_gone(target, timeout_ms, opts \\ [])
+
+  def await_gone(:none, timeout_ms, _opts) when is_integer(timeout_ms), do: :ok
+
+  def await_gone(target, timeout_ms, opts)
+      when is_signallable(target) and is_integer(timeout_ms) and timeout_ms >= 0 do
+    poll(target, System.monotonic_time(:millisecond) + timeout_ms, opts)
+  end
+
+  defp poll(target, deadline, opts) do
+    case signal(target, "-0", opts) do
+      :gone ->
+        :ok
+
+      {:error, :spawn_failed} ->
+        keep_waiting(target, deadline, opts)
+
+      {:error, _reason} = err ->
+        err
+
+      :ok ->
+        keep_waiting(target, deadline, opts)
+    end
+  end
+
+  defp keep_waiting(target, deadline, opts) do
+    if System.monotonic_time(:millisecond) >= deadline do
+      :timeout
+    else
+      Process.sleep(@poll_ms)
+      poll(target, deadline, opts)
+    end
+  end
+
+  # Arguments are passed positionally rather than interpolated into the script,
+  # so nothing about the target can be read as shell.
+  #
+  # `BASH_ENV` and `ENV` are unset for the same reason. Bash sources `$BASH_ENV`
+  # for NON-INTERACTIVE shells, `bash -c` included, so inheriting it hands
+  # whatever set it arbitrary execution on every signal. Passing the target
+  # safely is not worth much if the interpreter reading it was configured by
+  # someone else.
+  #
+  # The locale is pinned to C because the errno text is the only thing that can
+  # tell ESRCH from EPERM -- the builtin exits 1 for both. macOS libc does not
+  # translate `strerror`, but glibc does, and CI is glibc.
+  defp run(path, flag, arg) do
+    args = ["-c", ~s(kill "$1" "$2"), "raxol-process-group", flag, arg]
+    env = [{"BASH_ENV", nil}, {"ENV", nil}, {"LC_ALL", "C"}, {"LANG", "C"}]
+
+    case System.cmd(path, args, stderr_to_stdout: true, env: env) do
+      {_output, 0} -> :ok
+      {output, _status} -> classify(output)
+    end
+  rescue
+    e in [ErlangError, ArgumentError] ->
+      Logger.debug("raxol.process_group.signal_raised error=#{inspect(e)}")
+      {:error, :spawn_failed}
+  end
+
+  # ESRCH is matched POSITIVELY and anything unrecognised is an error, rather
+  # than the other way round.
+  #
+  # The two mistakes do not cost the same. A false `:refused` logs a warning. A
+  # false `:gone` reports a successful reap to a caller that may be about to
+  # delete the directory the process is still writing into. Two real failures
+  # that reach this and are not EPERM: a seccomp or LSM filter answers EACCES,
+  # whose text is "Permission denied" and not "Operation not permitted"; and a
+  # shell whose builtin rejects the flag answers with a usage error.
+  defp classify(output) do
+    cond do
+      output =~ ~r/no such process/i -> :gone
+      output =~ ~r/operation not permitted/i -> {:error, :refused}
+      true -> {:error, :unknown}
+    end
+  end
+
+  defp shell(opts) do
+    case Keyword.get(opts, :shell) do
+      path when is_binary(path) -> path
+      _ -> System.find_executable("bash")
+    end
+  end
+
+  defp arg({:group, pgid}), do: "-#{pgid}"
+  defp arg({:pid, os_pid}), do: "#{os_pid}"
+
+  defp warn_no_group(os_pid, reason) do
+    Logger.warning(
+      "raxol.process_group.no_group_kill os_pid=#{os_pid} reason=#{reason} " <>
+        "detail=descendants_will_survive"
+    )
+  end
+end

--- a/packages/raxol_core/test/raxol/core/process_group_test.exs
+++ b/packages/raxol_core/test/raxol/core/process_group_test.exs
@@ -1,0 +1,226 @@
+defmodule Raxol.Core.ProcessGroupTest do
+  @moduledoc """
+  Driven against real spawned processes, because every claim this module makes
+  is a claim about the OS. Liveness is asked of the kernel (`kill -0`) rather
+  than inferred from a witness file: the question is whether a process is still
+  running, not whether it got as far as some side effect.
+
+  Every wait is a poll against a deadline, never a fixed sleep, so a loaded
+  machine makes these slower rather than red.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Core.ProcessGroup
+
+  @moduletag :unix_only
+
+  @wait_ms 5_000
+
+  # `script` must `echo ready` once it has spawned whatever it is going to spawn.
+  # Placed by the script because where it goes is the point: a test of orphaned
+  # subprocesses that proceeds before the fork proves nothing.
+  defp open_child(script) do
+    port =
+      Port.open(
+        {:spawn_executable, System.find_executable("bash")},
+        [
+          :binary,
+          :exit_status,
+          :stderr_to_stdout,
+          :hide,
+          {:line, 65_536},
+          {:cd, System.tmp_dir!()},
+          {:args, ["-lc", script]}
+        ]
+      )
+
+    receive do
+      {^port, {:data, {:eol, "ready"}}} -> port
+    after
+      @wait_ms -> flunk("child never signalled ready")
+    end
+  end
+
+  defp os_pid(port) do
+    {:os_pid, os_pid} = Port.info(port, :os_pid)
+    os_pid
+  end
+
+  # Spelled out rather than routed through `ProcessGroup`, so the oracle cannot
+  # agree with the implementation by sharing its bug -- but through bash's `kill`
+  # BUILTIN, because `kill(1)` is not an oracle at all on Linux. procps-ng
+  # answers `kill -0 -<pgid>` with exit 0 whether or not the group exists, so an
+  # oracle built on it reports every process alive forever.
+  defp alive?(target) do
+    {_out, status} =
+      System.cmd(
+        System.find_executable("bash"),
+        ["-c", ~s(kill "$1" "$2"), "oracle", "-0", target],
+        stderr_to_stdout: true
+      )
+
+    status == 0
+  end
+
+  defp wait_until(fun, timeout_ms \\ @wait_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    poll_until(fun, deadline)
+  end
+
+  defp poll_until(fun, deadline) do
+    cond do
+      fun.() ->
+        true
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        false
+
+      true ->
+        Process.sleep(20)
+        poll_until(fun, deadline)
+    end
+  end
+
+  describe "resolve/1" do
+    test "reports a spawned child as its own process group leader" do
+      port = open_child("echo ready; sleep 30")
+      pid = os_pid(port)
+
+      assert {:group, ^pid} = ProcessGroup.resolve(pid)
+
+      ProcessGroup.signal({:group, pid}, "-KILL")
+    end
+
+    test "resolves the group when the parent is a corpse but its orphan holds it" do
+      # The topology a `ps`-based pgid read cannot answer: the parent has exited
+      # and been reaped, so `ps -o pgid= -p <corpse>` is empty, while the group
+      # it led is still running. This is the case the whole probe exists for.
+      port = open_child("( sleep 30 ) & echo ready; exit 0")
+      pid = os_pid(port)
+
+      assert wait_until(fn -> not alive?("#{pid}") end), "the parent should have exited"
+      assert alive?("-#{pid}"), "the orphan should still hold the group"
+
+      assert {:group, ^pid} = ProcessGroup.resolve(pid)
+
+      ProcessGroup.signal({:group, pid}, "-KILL")
+    end
+
+    test "falls back to the bare pid when no group answers under that id" do
+      # The narrow target is the safe direction: it loses the descendants, where
+      # a group kill aimed at a group that is not ours is unrecoverable. It is
+      # also why the VM's own group is unreachable here -- a child that leads no
+      # group sits in the BEAM's group, whose id is never the child's pid, so
+      # the probe finds nothing and this branch is taken.
+      port = open_child("echo ready; sleep 30")
+      pid = os_pid(port)
+      {:group, _} = ProcessGroup.resolve(pid)
+
+      ProcessGroup.signal({:group, pid}, "-KILL")
+      assert wait_until(fn -> not alive?("-#{pid}") end)
+
+      assert {:pid, ^pid} = ProcessGroup.resolve(pid)
+    end
+
+    test "is :none for a pid that could never be a child" do
+      # 0 is "my own process group" and 1 is "everything I may signal". Turned
+      # into a group kill either takes the VM or the host down.
+      assert ProcessGroup.resolve(0) == :none
+      assert ProcessGroup.resolve(1) == :none
+    end
+  end
+
+  describe "group_leader?/1" do
+    test "true for a live leader, false once its group has drained" do
+      port = open_child("echo ready; sleep 30")
+      pid = os_pid(port)
+
+      assert ProcessGroup.group_leader?(pid)
+
+      ProcessGroup.signal({:group, pid}, "-KILL")
+      assert wait_until(fn -> not alive?("-#{pid}") end)
+
+      refute ProcessGroup.group_leader?(pid)
+    end
+  end
+
+  describe "signal/3" do
+    test "a group kill reaches the descendants, not just the child" do
+      port = open_child("( sleep 30 ) & echo ready; sleep 30")
+      pid = os_pid(port)
+
+      assert :ok = ProcessGroup.signal({:group, pid}, "-KILL")
+      assert wait_until(fn -> not alive?("-#{pid}") end)
+    end
+
+    test "reports :gone rather than :ok when nothing is left" do
+      port = open_child("echo ready; sleep 30")
+      pid = os_pid(port)
+      target = {:group, pid}
+
+      ProcessGroup.signal(target, "-KILL")
+      assert wait_until(fn -> not alive?("-#{pid}") end)
+
+      assert :gone = ProcessGroup.signal(target, "-0")
+    end
+
+    test "an unrecognised failure is an error, never :gone" do
+      # The failure this inversion exists to prevent: `true` exits 0 for
+      # everything and `false` exits 1 with no output at all. Neither says the
+      # target exited, and reporting `:gone` for the second would tell a caller
+      # a reap succeeded right before it deletes the target's workspace.
+      port = open_child("echo ready; sleep 30")
+      pid = os_pid(port)
+
+      false_bin = System.find_executable("false")
+
+      assert {:error, :unknown} =
+               ProcessGroup.signal({:group, pid}, "-0", shell: false_bin)
+
+      ProcessGroup.signal({:group, pid}, "-KILL")
+    end
+
+    test "is :gone for :none and refuses a target that would signal the world" do
+      assert ProcessGroup.signal(:none, "-KILL") == :gone
+
+      for pid <- [0, 1], kind <- [:group, :pid] do
+        assert_raise FunctionClauseError, fn -> ProcessGroup.signal({kind, pid}, "-KILL") end
+        assert_raise FunctionClauseError, fn -> ProcessGroup.await_gone({kind, pid}, 0) end
+      end
+    end
+  end
+
+  describe "await_gone/3" do
+    test "returns as soon as the group drains, without spending the budget" do
+      port = open_child("echo ready; cat > /dev/null")
+      pid = os_pid(port)
+      target = ProcessGroup.resolve(pid)
+
+      Port.close(port)
+
+      started = System.monotonic_time(:millisecond)
+      assert :ok = ProcessGroup.await_gone(target, 30_000)
+      elapsed = System.monotonic_time(:millisecond) - started
+
+      # Bounded well under the budget: the point is that a clean exit is
+      # detected rather than waited out. Generous enough not to be a race.
+      assert elapsed < 10_000
+    end
+
+    test ":timeout is a distinct answer from an error" do
+      # The caller's cue to stop asking and SIGKILL. Reporting it as an error
+      # would make "still running after the grace" look like "could not tell".
+      port = open_child("echo ready; sleep 30")
+      pid = os_pid(port)
+      target = ProcessGroup.resolve(pid)
+
+      assert :timeout = ProcessGroup.await_gone(target, 100)
+
+      ProcessGroup.signal(target, "-KILL")
+    end
+
+    test "is :ok for :none" do
+      assert :ok = ProcessGroup.await_gone(:none, 10_000)
+    end
+  end
+end

--- a/packages/raxol_core/test/raxol/core/process_group_test.exs
+++ b/packages/raxol_core/test/raxol/core/process_group_test.exs
@@ -81,6 +81,42 @@ defmodule Raxol.Core.ProcessGroupTest do
     end
   end
 
+  # A shell that records each invocation and then hands the argv to the real
+  # `/bin/sh`, so a caller's probes can be counted without changing what they do.
+  defp counting_shell do
+    dir = Path.join(System.tmp_dir!(), "raxol-pg-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf(dir) end)
+
+    log = Path.join(dir, "invocations")
+    script = Path.join(dir, "shell")
+
+    File.write!(script, """
+    #!/bin/sh
+    echo x >> #{log}
+    exec /bin/sh "$@"
+    """)
+
+    File.chmod!(script, 0o700)
+    {script, log}
+  end
+
+  defp invocations(log) do
+    case File.read(log) do
+      {:ok, contents} -> contents |> String.split("\n", trim: true) |> length()
+      {:error, :enoent} -> 0
+    end
+  end
+
+  describe "shell/0" do
+    test "resolves an executable POSIX shell on this host" do
+      path = ProcessGroup.shell()
+
+      assert is_binary(path)
+      assert {:ok, %File.Stat{type: :regular}} = File.stat(path)
+    end
+  end
+
   describe "resolve/1" do
     test "reports a spawned child as its own process group leader" do
       port = open_child("echo ready; sleep 30")
@@ -180,6 +216,25 @@ defmodule Raxol.Core.ProcessGroupTest do
       ProcessGroup.signal({:group, pid}, "-KILL")
     end
 
+    test "tells a live group from a drained one through the host's real /bin/sh" do
+      # `classify/1` reads ESRCH out of the errno TEXT, and `/bin/sh` is dash on
+      # Debian and Ubuntu where it is bash-in-sh-mode on macOS -- so the shell
+      # that reaches the classifier on CI is not the one it was authored
+      # against, and a wording mismatch would answer {:error, :unknown} where
+      # :gone is correct. Driving the host's own `/bin/sh` makes this a claim
+      # about the shell that is actually there.
+      port = open_child("( sleep 30 ) & echo ready; sleep 30")
+      pid = os_pid(port)
+      target = {:group, pid}
+
+      assert :ok = ProcessGroup.signal(target, "-0", shell: "/bin/sh")
+
+      assert :ok = ProcessGroup.signal(target, "-KILL", shell: "/bin/sh")
+      assert wait_until(fn -> not alive?("-#{pid}") end)
+
+      assert :gone = ProcessGroup.signal(target, "-0", shell: "/bin/sh")
+    end
+
     test "is :gone for :none and refuses a target that would signal the world" do
       assert ProcessGroup.signal(:none, "-KILL") == :gone
 
@@ -215,6 +270,26 @@ defmodule Raxol.Core.ProcessGroupTest do
       target = ProcessGroup.resolve(pid)
 
       assert :timeout = ProcessGroup.await_gone(target, 100)
+
+      ProcessGroup.signal(target, "-KILL")
+    end
+
+    test "every poll goes through the shell the caller resolved" do
+      # What lets a caller resolve the shell ONCE for a whole grace window --
+      # `PortReaper.await_exit/2` does, because each resolution is a full PATH
+      # scan and this loop ticks every 50ms. A loop that honoured `:shell` on
+      # the first probe and let the rest default would leave a single line in
+      # the log and quietly go back to a scan per tick.
+      port = open_child("echo ready; sleep 30")
+      pid = os_pid(port)
+      target = ProcessGroup.resolve(pid)
+      {script, log} = counting_shell()
+
+      assert :timeout = ProcessGroup.await_gone(target, 1_000, shell: script)
+
+      # A count, not a duration: the budget is long enough that reaching one
+      # probe would take a fork of over a second.
+      assert invocations(log) > 1
 
       ProcessGroup.signal(target, "-KILL")
     end

--- a/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
@@ -116,7 +116,7 @@ defmodule Raxol.Symphony.PortReaper do
   """
   @spec kill(target()) :: :ok | {:error, reason()}
   def kill(:none), do: :ok
-  def kill(target) when is_signallable(target), do: do_kill(target)
+  def kill(target) when is_signallable(target), do: do_kill(target, signal_opts())
 
   @doc """
   Wait up to `grace_ms` for the target to exit on its own, then SIGKILL it.
@@ -151,8 +151,14 @@ defmodule Raxol.Symphony.PortReaper do
 
   def await_exit(target, grace_ms)
       when is_signallable(target) and is_integer(grace_ms) and grace_ms >= 0 do
-    poll_then_kill(target, grace_ms)
+    poll_then_kill(target, grace_ms, signal_opts())
   end
+
+  # The shell is resolved ONCE here and threaded through everything that follows.
+  # `await_gone/3` polls every 50ms for the whole grace window and every
+  # resolution is a full PATH scan, so leaving it to default would put one scan
+  # on each tick of every reap.
+  defp signal_opts, do: [shell: ProcessGroup.shell()]
 
   @doc """
   Reap `target` if the calling process dies before calling `release/1`.
@@ -268,8 +274,8 @@ defmodule Raxol.Symphony.PortReaper do
 
   # The grace, then the kill. `await_gone/3` answers `:timeout` when the target
   # outlived the grace, which is the only case that still needs a signal.
-  defp poll_then_kill(target, deadline_ms) do
-    case ProcessGroup.await_gone(target, deadline_ms) do
+  defp poll_then_kill(target, grace_ms, opts) do
+    case ProcessGroup.await_gone(target, grace_ms, opts) do
       :ok ->
         :ok
 
@@ -281,17 +287,17 @@ defmodule Raxol.Symphony.PortReaper do
           "symphony.port_reaper.grace_expired target=#{inspect(target)} action=killed"
         )
 
-        do_kill(target)
+        do_kill(target, opts)
 
       {:error, _reason} = err ->
         err
     end
   end
 
-  defp do_kill(target), do: do_kill(target, @kill_attempts)
+  defp do_kill(target, opts), do: do_kill(target, opts, @kill_attempts)
 
-  defp do_kill(target, attempts_left) do
-    case ProcessGroup.signal(target, "-KILL") do
+  defp do_kill(target, opts, attempts_left) do
+    case ProcessGroup.signal(target, "-KILL", opts) do
       :ok ->
         :ok
 
@@ -305,7 +311,7 @@ defmodule Raxol.Symphony.PortReaper do
       # budget rather than reporting a fork failure as an unreaped target.
       {:error, :spawn_failed} when attempts_left > 1 ->
         Process.sleep(@retry_ms)
-        do_kill(target, attempts_left - 1)
+        do_kill(target, opts, attempts_left - 1)
 
       {:error, reason} = err ->
         Logger.warning(
@@ -317,8 +323,8 @@ defmodule Raxol.Symphony.PortReaper do
     end
   end
 
-  defp unreaped_detail(:unavailable), do: "no_bash_on_path"
+  defp unreaped_detail(:unavailable), do: "no_shell_on_path"
   defp unreaped_detail(:refused), do: "kernel_refused_the_signal_target_still_running"
-  defp unreaped_detail(:spawn_failed), do: "could_not_run_bash_target_not_verified"
+  defp unreaped_detail(:spawn_failed), do: "could_not_run_the_shell_target_not_verified"
   defp unreaped_detail(:unknown), do: "unrecognised_kill_failure_target_not_verified"
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/port_reaper.ex
@@ -20,75 +20,40 @@ defmodule Raxol.Symphony.PortReaper do
   does the same job on the far side of an ssh connection with `set -m` and a
   group kill inside bash.
 
-  ## Relationship to `Raxol.Agent.Interrupt`
+  ## What lives here, and what does not
 
-  That module solves the same OS problem for the agent's shell tool and answers
-  it differently: it proves group leadership by reading `pgid` out of `ps` and
-  requiring `pgid == os_pid`, where this probes with `kill -0` against the group.
+  Resolving a safe target and delivering a signal are `Raxol.Core.ProcessGroup`,
+  shared with `Raxol.Agent.Interrupt` (which does the same job for the agent's
+  shell tool). This module is the PORT-shaped layer on top: reading a target off
+  a live port, the close, the grace-then-kill sequence, and the owner-death
+  watcher.
 
-  The difference is not cosmetic. `ps` cannot see a corpse, so when a hook
-  backgrounds a child and exits -- the commonest leak shape, and the one that
-  keeps the port open while `Port.info/2` still names the dead parent -- the
-  `ps` read fails and the group is never found. `Interrupt` has a
-  `descendants_of/1` sweep that covers some of that through ppid linkage, which
-  a reparented orphan is also invisible to. It additionally interpolates the pid
-  into a shell string rather than passing it positionally, and depends on a `ps`
-  that busybox does not implement.
-
-  Consolidating onto this module is worth doing and is NOT done here: it is a
-  different package with its own tests, and `raxol_symphony` takes `raxol_agent`
-  only as an optional dependency.
+  The split is where it is because the two callers agree exactly on the OS
+  question -- which pid may be signalled, and did the signal land -- and agree on
+  nothing above it. `Interrupt` stages a cooperative TERM before its KILL and
+  needs a zombie-aware liveness oracle to confirm death; neither has anything to
+  do with ports.
   """
 
   require Logger
 
-  @typedoc """
-  What may safely be signalled.
+  import Raxol.Core.ProcessGroup, only: [is_signallable: 1]
 
-  `{:group, pgid}` when the child leads its own process group, so its
-  descendants come with it. `{:pid, os_pid}` when it does not, in which case
-  only the child itself can be signalled. `:none` when the child is already
-  gone.
-  """
-  @type target :: {:group, pos_integer()} | {:pid, pos_integer()} | :none
+  alias Raxol.Core.ProcessGroup
+
+  @typedoc "What may safely be signalled. See `Raxol.Core.ProcessGroup`."
+  @type target :: ProcessGroup.target()
 
   @typedoc "Handle returned by `watch/1`, to be handed back to `release/1`."
   @type watcher :: pid() | :none
 
   @typedoc """
-  Why a reap could not be carried out.
+  Why a reap could not be carried out. See `Raxol.Core.ProcessGroup`.
 
   NONE of these may be reported as success: a caller that is about to delete the
   target's working directory is relying on the difference.
-
-  `:unavailable` -- no signal could be run at all (no bash), so nothing was
-  verified and nothing was killed.
-
-  `:refused` -- the kernel rejected the signal (EPERM). The target is
-  demonstrably still there, and still running.
-
-  `:spawn_failed` -- bash resolved but could not be run this time. Transient by
-  nature (a fork that hit `EAGAIN` under process-table pressure is the case that
-  matters, and process-table pressure is exactly when a leaked-process reaper is
-  most needed), so it is RETRIED rather than answered.
-
-  `:unknown` -- the signal failed with something this does not recognise. Not
-  reported as `:gone`, because "the message was not one I know" is not evidence
-  that the target exited.
   """
-  @type reason :: :unavailable | :refused | :spawn_failed | :unknown
-
-  # A pid of 0 means "my own process group" and 1 means "everything I am
-  # allowed to signal". Neither is ever a port child, and either one turned
-  # into a group kill takes the VM (or the host) with it. `capture/1` cannot
-  # produce them, but `kill/1` and `await_exit/2` are public and this module
-  # exists precisely to not assume that.
-  defguardp is_signallable(target)
-            when is_tuple(target) and tuple_size(target) == 2 and
-                   elem(target, 0) in [:group, :pid] and
-                   is_integer(elem(target, 1)) and elem(target, 1) > 1
-
-  @poll_ms 50
+  @type reason :: ProcessGroup.reason()
 
   # `kill/1` answers immediately, so a transient fork failure has no deadline to
   # be retried against the way `await_exit/2`'s poll does. Small on purpose: this
@@ -113,7 +78,7 @@ defmodule Raxol.Symphony.PortReaper do
     case Port.info(port, :os_pid) do
       # `:os_pid` is `:undefined` for a port that did not spawn a process, and
       # the atom would otherwise flow all the way into an argv.
-      {:os_pid, os_pid} when is_integer(os_pid) and os_pid > 1 -> classify(os_pid)
+      {:os_pid, os_pid} when is_integer(os_pid) and os_pid > 1 -> ProcessGroup.resolve(os_pid)
       _ -> :none
     end
   end
@@ -151,7 +116,7 @@ defmodule Raxol.Symphony.PortReaper do
   """
   @spec kill(target()) :: :ok | {:error, reason()}
   def kill(:none), do: :ok
-  def kill(target) when is_signallable(target), do: do_kill(signaller(), target)
+  def kill(target) when is_signallable(target), do: do_kill(target)
 
   @doc """
   Wait up to `grace_ms` for the target to exit on its own, then SIGKILL it.
@@ -186,11 +151,7 @@ defmodule Raxol.Symphony.PortReaper do
 
   def await_exit(target, grace_ms)
       when is_signallable(target) and is_integer(grace_ms) and grace_ms >= 0 do
-    deadline = System.monotonic_time(:millisecond) + grace_ms
-
-    # Resolved once rather than per poll: this loop runs every 50ms and each
-    # resolution is a full PATH scan.
-    poll_until_gone(signaller(), target, deadline)
+    poll_then_kill(target, grace_ms)
   end
 
   @doc """
@@ -305,47 +266,32 @@ defmodule Raxol.Symphony.PortReaper do
     :ok
   end
 
-  defp poll_until_gone(signaller, target, deadline) do
-    case signal(signaller, target, "-0") do
-      # Nothing signallable is left, which is the whole question.
-      :gone ->
+  # The grace, then the kill. `await_gone/3` answers `:timeout` when the target
+  # outlived the grace, which is the only case that still needs a signal.
+  defp poll_then_kill(target, deadline_ms) do
+    case ProcessGroup.await_gone(target, deadline_ms) do
+      :ok ->
         :ok
 
-      # Could not fork bash this time. Giving up here would abandon the reap
-      # under process-table pressure -- the one condition that both causes this
-      # and makes a leaked process tree matter -- so it is retried on the same
-      # deadline as a target that is simply still running.
-      {:error, :spawn_failed} ->
-        keep_waiting(signaller, target, deadline)
+      :timeout ->
+        # Operationally interesting: reaching here means the child ignored the
+        # EOF or left subprocesses behind, which is a fact about the child worth
+        # seeing at the default log level.
+        Logger.warning(
+          "symphony.port_reaper.grace_expired target=#{inspect(target)} action=killed"
+        )
 
-      # Waiting cannot fix these, and each means the target may still be
-      # running, so they are answered now rather than at the deadline.
+        do_kill(target)
+
       {:error, _reason} = err ->
         err
-
-      :ok ->
-        keep_waiting(signaller, target, deadline)
     end
   end
 
-  defp keep_waiting(signaller, target, deadline) do
-    if System.monotonic_time(:millisecond) >= deadline do
-      # Operationally interesting: reaching here means the child ignored the
-      # EOF or left subprocesses behind, which is a fact about the child worth
-      # seeing at the default log level.
-      Logger.warning("symphony.port_reaper.grace_expired target=#{inspect(target)} action=killed")
+  defp do_kill(target), do: do_kill(target, @kill_attempts)
 
-      do_kill(signaller, target)
-    else
-      Process.sleep(@poll_ms)
-      poll_until_gone(signaller, target, deadline)
-    end
-  end
-
-  defp do_kill(signaller, target), do: do_kill(signaller, target, @kill_attempts)
-
-  defp do_kill(signaller, target, attempts_left) do
-    case signal(signaller, target, "-KILL") do
+  defp do_kill(target, attempts_left) do
+    case ProcessGroup.signal(target, "-KILL") do
       :ok ->
         :ok
 
@@ -359,7 +305,7 @@ defmodule Raxol.Symphony.PortReaper do
       # budget rather than reporting a fork failure as an unreaped target.
       {:error, :spawn_failed} when attempts_left > 1 ->
         Process.sleep(@retry_ms)
-        do_kill(signaller, target, attempts_left - 1)
+        do_kill(target, attempts_left - 1)
 
       {:error, reason} = err ->
         Logger.warning(
@@ -375,161 +321,4 @@ defmodule Raxol.Symphony.PortReaper do
   defp unreaped_detail(:refused), do: "kernel_refused_the_signal_target_still_running"
   defp unreaped_detail(:spawn_failed), do: "could_not_run_bash_target_not_verified"
   defp unreaped_detail(:unknown), do: "unrecognised_kill_failure_target_not_verified"
-
-  # `kill -0` reports whether anything signallable is left. Against a GROUP that
-  # is the question worth asking: the leader can be gone while an orphaned tool
-  # subprocess keeps the group alive.
-  #
-  # A zombie answers "alive" here, since it still holds its pid. `erl_child_setup`
-  # reaps its own children promptly, so that resolves on its own rather than
-  # costing the full grace.
-  defp signal(:unavailable, _target, _flag), do: {:error, :unavailable}
-
-  # Signals go through bash's `kill` BUILTIN, never `kill(1)`.
-  #
-  # procps-ng's `kill` -- `/usr/bin/kill` on Debian and Ubuntu, which is what CI
-  # runs -- takes a negative pid in its own argv slot, does NOTHING with it, and
-  # exits 0. Measured on linux/aarch64 with the group live:
-  # `System.cmd(kill, ["-KILL", "-57"])` returned `{"", 0}` and both members
-  # were still running afterwards. That is the worst failure available to this
-  # module, a reap that reports success and reaps nothing, and the exit status
-  # gives away none of it. `kill -s KILL -- -57` is no way out either: procps
-  # has no `--` and answers with a usage error.
-  #
-  # macOS's `/bin/kill` handles the same argv correctly, which is exactly why
-  # this was green on a developer machine and red on Linux CI.
-  #
-  # The builtin is POSIX about negative pids on both, and bash is already a hard
-  # dependency of every call site -- `Session.start/5` and
-  # `Workspace.execute_script/3` each spawn their child through it -- so where
-  # bash is missing there is no port child to reap in the first place.
-  #
-  # Arguments are passed positionally rather than interpolated into the script,
-  # so nothing about the target can be read as shell.
-  defp signal({:bash, path}, target, flag) do
-    run_signal(path, ["-c", ~s(kill "$1" "$2"), "raxol-port-reaper", flag, signal_arg(target)])
-  end
-
-  # The builtin exits 1 for EVERY failure, so the status alone cannot tell
-  # "already dead" (ESRCH) from "the kernel refused" (EPERM). Only the errno
-  # text can, and it is read with the locale pinned to C: macOS libc does not
-  # translate `strerror` at all, but glibc does, and CI is glibc.
-  #
-  # `BASH_ENV` and `ENV` are unset for the same reason the target is passed
-  # positionally. Bash sources `$BASH_ENV` for NON-INTERACTIVE shells, `bash -c`
-  # included, so inheriting it hands whatever set it arbitrary execution -- once
-  # per capture, once per stop, and once per poll of every grace window. Passing
-  # the target safely is not worth much if the interpreter reading it was
-  # configured by someone else.
-  defp run_signal(path, args) do
-    env = [{"BASH_ENV", nil}, {"ENV", nil}, {"LC_ALL", "C"}, {"LANG", "C"}]
-
-    case System.cmd(path, args, stderr_to_stdout: true, env: env) do
-      {_output, 0} -> :ok
-      {output, _status} -> classify_failure(output)
-    end
-  rescue
-    # bash resolved a moment ago and cannot be run now. A fork that hit EAGAIN
-    # under process-table pressure is the case worth surviving -- that pressure
-    # is exactly when a leaked-process reaper is most needed -- so this is
-    # retriable rather than terminal.
-    e in [ErlangError, ArgumentError] ->
-      Logger.debug("symphony.port_reaper.signal_raised error=#{inspect(e)}")
-      {:error, :spawn_failed}
-  end
-
-  # ESRCH is matched POSITIVELY and anything unrecognised is an error, rather
-  # than the other way round.
-  #
-  # The two mistakes do not cost the same. A false `:refused` logs a warning. A
-  # false `:gone` reports a SUCCESSFUL REAP to a caller that is about to `rm_rf`
-  # the directory the process is still writing into -- the exact failure the
-  # moduledoc calls the worst one available here, so defaulting to it was
-  # building it in.
-  #
-  # Two real failures that reach this and are not EPERM: a seccomp or LSM filter
-  # answers EACCES, whose text is "Permission denied" and not "Operation not
-  # permitted"; and a bash whose builtin rejects the flag answers with a usage
-  # error. Neither is evidence that the target exited.
-  defp classify_failure(output) do
-    cond do
-      output =~ ~r/no such process/i -> :gone
-      output =~ ~r/operation not permitted/i -> {:error, :refused}
-      true -> {:error, :unknown}
-    end
-  end
-
-  defp signaller do
-    case System.find_executable("bash") do
-      path when is_binary(path) -> {:bash, path}
-      nil -> :unavailable
-    end
-  end
-
-  defp signal_arg({:group, pgid}), do: "-#{pgid}"
-  defp signal_arg({:pid, os_pid}), do: "#{os_pid}"
-
-  # Signal the process GROUP wherever it is safe to, because killing only the
-  # child leaves its descendants running: still doing work, and still holding
-  # the inherited stdout pipe, so a reader waiting on EOF blocks for the
-  # command's full natural runtime after the supposed kill.
-  #
-  # `erl_child_setup` gives a spawned port child a process group of its own, so
-  # `kill -KILL -PID` reaches its descendants and nothing else. That is CHECKED
-  # rather than assumed, because the failure mode is not subtle: a child that is
-  # not a group leader shares the BEAM's own group, and the group kill would
-  # take the VM down with it. The `{:pid, _}` fallback loses the descendants and
-  # keeps the VM.
-  #
-  # The check is a `kill -0` against the GROUP rather than a `ps` read of the
-  # child's pgid, and that is load-bearing rather than a tidy-up.
-  #
-  # A process group's id is the pid of its leader, and that pid stays allocated
-  # for as long as the group has any member at all. So "group `os_pid` answers
-  # a signal" can only be true if the process holding pid `os_pid` -- our child,
-  # since the port is open -- is the one that led it. A child that is NOT a
-  # group leader has no group under its own id, the probe says so, and the
-  # fallback keeps the VM. The BEAM's own group is unreachable here by
-  # construction rather than by inspection.
-  #
-  # `ps` could not answer this at all in the case that matters most. A hook that
-  # backgrounds a child and exits leaves the port OPEN -- ERTS withholds the
-  # exit status until the inherited stdout reaches EOF and the orphan is still
-  # holding it -- while `Port.info/2` goes on reporting the dead parent's pid.
-  # `ps -o pgid= -p <dead pid>` fails there, which classified the live group as
-  # `{:pid, <corpse>}`, SIGKILLed a pid nobody owns, and reported success while
-  # the orphan the reap exists for kept running. It was also the module's only
-  # dependency on a `ps` that busybox does not implement.
-  #
-  # Falling back is safe but not free -- it silently drops the descendants --
-  # so it says so rather than degrading quietly.
-  defp classify(os_pid) do
-    case signal(signaller(), {:group, os_pid}, "-0") do
-      :ok ->
-        {:group, os_pid}
-
-      # EPERM is an existence proof: the kernel can only refuse a signal to
-      # something that is there.
-      {:error, :refused} ->
-        {:group, os_pid}
-
-      :gone ->
-        warn_no_group_kill(os_pid, "no_process_group_under_that_id")
-        {:pid, os_pid}
-
-      # Could not prove a group is there. The narrow target is the safe
-      # direction -- it loses the descendants, where a group kill against a
-      # group that is not ours would not be recoverable at all.
-      {:error, reason} ->
-        warn_no_group_kill(os_pid, "group_probe_failed_#{reason}")
-        {:pid, os_pid}
-    end
-  end
-
-  defp warn_no_group_kill(os_pid, reason) do
-    Logger.warning(
-      "symphony.port_reaper.no_group_kill os_pid=#{os_pid} reason=#{reason} " <>
-        "detail=descendants_will_survive"
-    )
-  end
 end


### PR DESCRIPTION
Stacked on #895 -- review that first, and merge it first.

`Raxol.Agent.Interrupt` and `Raxol.Symphony.PortReaper` both answer the same OS
question: given a spawned child's pid, is it safe to signal its process group,
and did the signal land. They answered it differently, and one of the answers
was wrong.

## The bug

`Interrupt` derived the group by reading `pgid` out of `ps` and requiring
`pgid == os_pid`. That cannot resolve the case it is most needed for.

When a tool backgrounds a child and exits, the parent is a corpse and the group
it led is still running. Measured directly:

```
os_pid=849
parent alive?          false
GROUP alive?           true
ps pgid read           ""
```

`ps` cannot see a corpse, so the pgid read comes back empty, `group_leader_safe?`
returns false, and the group kill is skipped. The per-pid fallback cannot reach
the orphan either -- it was reparented to init the moment its parent died, so a
ppid walk no longer links it to `os_pid`. The module's own comment already
conceded the sweep misses reparented orphans; what nobody had noticed is that
the group path is unreachable in exactly the same case, so both halves miss it
together.

The result is an orphan that survives the kill. `Interrupt` reports it honestly
(`:degraded`, `confirmed? false`) rather than claiming a false success, so this
is a failure to reap and not a false confirmation.

## The fix

Resolve the target by PROBING the group (`kill -0 -<pgid>`) instead of reading
it. A process group's id is its leader's pid, and that pid stays allocated while
the group has any member -- so a group answering under `os_pid` can only be one
this pid led, corpse or not.

`Raxol.Core.ProcessGroup` (new) owns exactly the layer the two callers agreed
on: target resolution, signal delivery, failure classification, poll-until-gone.
It lands in `raxol_core` because that is the only package both can depend on --
`raxol_symphony` takes `raxol_agent` optionally and never the reverse.

Everything above that layer stayed where it was. `PortReaper` keeps the
port-shaped parts (capture off a live port, close, grace-then-kill, the
owner-death watcher); `Interrupt` keeps its staged cooperative TERM before the
KILL and its zombie-aware liveness oracle, which `kill -0` cannot answer since a
zombie still holds its pid. `PortReaper` loses 293 lines.

## Removing the VM-safety guard

The old check also required `pgid != own_pgid()` -- never signal the BEAM's own
group. That is gone, and it is subsumed rather than dropped: a child that leads
no group sits in the BEAM's group, whose id is the BEAM leader's pid and never a
live child's, so the probe finds nothing under `os_pid` and falls back to the
narrow `{:pid, _}` target. The VM's own group is unreachable by construction
instead of by inspection. The reasoning is written into `group_leader_safe?/1`.

## Contracts preserved

- `interrupt_kill_sh` still forces kill failures for the P6 contour. Resolution
  uses the real shell and only signalling honours the seam -- which is what that
  seam's own comment already claimed it did.
- `pgid_of/1` stays, for the P7 host-derivation regression.
- P8's non-group-leader assertion holds: a mid shell leads no group, so the
  probe finds none and the fallback is taken.

## Testing

New contour **P11** in the U5 red suite reproduces the leak against real
processes. Authored first and confirmed RED at the predicted line:

```
1) test P11 ... the group is resolved off the surviving group, not off the corpse's pgid
   a corpse still leads a live group -- resolving the target off `ps` cannot see
   that, and drops to a sweep that cannot reach the orphan
   code: assert Interrupt.group_leader_safe?(lab.os_pid)
```

`KillLab.spawn_orphaning/1` is the new topology: parent exits immediately after
backgrounding, the port stays open because the orphan holds the inherited
stdout, and `Port.info/2` goes on naming a pid that has already been reaped.

- `raxol_core` -- 12 new `ProcessGroup` tests, green
- `raxol_agent` -- U5 interrupt suite 12/12 green including P11; full suite 2408
  tests, 1 failure
- `raxol_symphony` -- 951 tests green

The one agent failure is `/inspect` timing out at 10s. It is pre-existing: it
passes in isolation on both trees and fails on this branch AND on the base when
the whole file runs, so it is load-dependent and not from this change.

## Manual testing

- [ ] Run a shell tool that backgrounds a child and exits, interrupt it, confirm
      no orphan survives (`ps` for the grandchild pid)
- [ ] Interrupt a normal long-running shell tool, confirm the staged
      TERM -> grace -> KILL sequence still journals in order
- [ ] Confirm a Symphony codex run still reaps its tool subprocesses on stop
