### PR TITLE
Ask 1Password once, not once per provider

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/backend/credentials.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/credentials.ex
@@ -397,13 +397,27 @@ defmodule Raxol.Agent.Backend.Credentials do
   Returns `{:ok, secret}` (trimmed), or `{:error, reason}` when `op` is
   missing, not signed in, or the reference does not resolve. The secret is
   returned to the caller and never logged or persisted here.
+
+  ## Options
+
+    * `:timeout_ms` - override the default `op` budget for THIS read.
+
+  The default budget is sized so an interactive 1Password approval fits, which
+  is right when a user is starting a turn and wrong when nobody is waiting on
+  the answer. A caller that will not spend that long says so here rather than
+  changing it globally: `RAXOL_OP_TIMEOUT_MS` is process-wide and would also
+  shorten the reads a user IS waiting for. `{:error, :op_timeout}` on expiry.
   """
-  @spec read_ref(String.t()) :: {:ok, String.t()} | {:error, term()}
-  def read_ref("op://" <> _ = ref) do
-    ["read", ref] |> run_op() |> interpret_op_output()
+  @spec read_ref(String.t(), keyword()) :: {:ok, String.t()} | {:error, term()}
+  def read_ref(ref, opts \\ [])
+
+  def read_ref("op://" <> _ = ref, opts) do
+    ["read", ref]
+    |> run_op(Keyword.get(opts, :timeout_ms))
+    |> interpret_op_output()
   end
 
-  def read_ref(_other), do: {:error, :not_an_op_ref}
+  def read_ref(_other, _opts), do: {:error, :not_an_op_ref}
 
   defp interpret_op_output({out, 0}) do
     case String.trim(out) do

--- a/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
@@ -50,6 +50,16 @@ defmodule Raxol.Agent.Backend.Resolver do
   # `:local` server, or a `:free` tier. Ordering still matters within the
   # allowed set, and the subscription harness comes first because it is the
   # one that costs nothing extra AND is a frontier model.
+  # What one `op read` may cost inside `diagnostics/0`.
+  #
+  # Deliberately far below the 15s interactive default, which is sized so a
+  # human can approve a 1Password prompt. Nobody is on the other side of
+  # `/inspect`, so the only thing that budget buys there is a wait for an
+  # approval that is not coming. And because a timeout demotes `op` to
+  # `:unresponsive` for the rest of the sweep, this is the ceiling for the whole
+  # diagnostic rather than the price of each provider.
+  @diagnostic_op_timeout_ms 1_500
+
   @providers [
     %{
       harness: :claude_native,
@@ -169,11 +179,30 @@ defmodule Raxol.Agent.Backend.Resolver do
   """
   @spec resolve(keyword()) :: resolution()
   def resolve(opts \\ []) do
+    opts = seal_internal_opts(opts)
+
     case explicit_harness(opts) do
       nil -> auto_detect(opts)
       harness -> resolve_explicit(harness, opts)
     end
   end
+
+  # `:skip_op` is INTERNAL to the diagnostic path and is dropped here rather
+  # than trusted.
+  #
+  # It reads as harmless -- "do not shell out to `op`" -- but what it actually
+  # does is silence the vault and let resolution fall through to environment
+  # variables. A caller that set it, deliberately or by forwarding an opts list
+  # it did not audit, would get a credential from `$ANTHROPIC_API_KEY` where the
+  # operator had stored an `op://` reference, and nothing would say so. The
+  # comment on `resolve_key/2` asserted only this path sets it; a comment is not
+  # a boundary, and this function is public.
+  @internal_opts [:skip_op]
+
+  defp seal_internal_opts(opts) when is_list(opts),
+    do: Keyword.drop(opts, @internal_opts)
+
+  defp seal_internal_opts(opts), do: opts
 
   @doc """
   Per-provider availability, for the setup panel and `/login` status.
@@ -223,7 +252,24 @@ defmodule Raxol.Agent.Backend.Resolver do
   @spec diagnostics() :: %{op: atom(), providers: [map()]}
   def diagnostics do
     op = Credentials.op_status()
-    %{op: op, providers: Enum.map(@providers, &provider_diag(&1, op))}
+
+    # Threaded, not mapped, so one unresponsive vault stops the sweep.
+    #
+    # Skipping when `op_status/0` says the CLI is unusable covers signed-out and
+    # absent. It does NOT cover the state that is slowest: signed in, so
+    # `op whoami` exits 0 and the status reads `:ok`, while every `op read`
+    # still waits on a desktop authorization the user has not given. There the
+    # skip never fires and each provider pays a full budget in series.
+    #
+    # A timed-out read is evidence about the VAULT rather than about the
+    # provider whose reference happened to be first, so the first one demotes
+    # `op` to `:unresponsive` for the rest of the sweep and the others are
+    # answered from the same knowledge without paying for it again. Worst case
+    # is one diagnostic budget, not one per provider.
+    {providers, final_op} =
+      Enum.map_reduce(@providers, op, &provider_diag/2)
+
+    %{op: final_op, providers: providers}
   end
 
   # A stored `op://` reference cannot resolve while the CLI is absent or signed
@@ -237,13 +283,10 @@ defmodule Raxol.Agent.Backend.Resolver do
   # reference under a signed-out CLI with "run `op signin`" -- the same
   # conclusion the probe spends 15 seconds arriving at.
   defp provider_diag(spec, op) do
-    {available?, source} =
-      case detect_available(spec, skip_op: op != :ok) do
-        {:ok, _config, src} -> {true, src}
-        _ -> {false, nil}
-      end
+    {op_result, op} = probe_op_ref(spec, op)
+    {available?, source} = diag_availability(spec, op_result)
 
-    %{
+    diag = %{
       harness: spec.harness,
       label: spec.label,
       keyless?: spec.keyless,
@@ -251,6 +294,48 @@ defmodule Raxol.Agent.Backend.Resolver do
       source: source,
       note: diag_note(spec, available?, op)
     }
+
+    {diag, op}
+  end
+
+  # The diagnostic owns the `op` probe outright, rather than letting
+  # `resolve_key/2` do it: only from here can a timeout be seen for what it is
+  # and charged to the vault instead of to this provider.
+  #
+  # A diagnostic budget rather than the interactive one. The 15s default is
+  # sized so a human can approve a 1Password prompt; nobody is waiting on the
+  # other side of `/inspect`, and the wait it buys is a wait for an approval
+  # that is not coming.
+  defp probe_op_ref(spec, op) do
+    ref = op_ref(spec.harness)
+
+    cond do
+      op != :ok -> {:skipped, op}
+      is_nil(ref) -> {:skipped, op}
+      true -> read_diag_ref(ref, op)
+    end
+  end
+
+  defp read_diag_ref(ref, op) do
+    case Credentials.read_ref(ref, timeout_ms: @diagnostic_op_timeout_ms) do
+      {:ok, secret} -> {{:ok, secret}, op}
+      # Evidence about the vault, not about this provider: demote once so the
+      # remaining providers are answered without each paying the budget again.
+      {:error, :op_timeout} -> {:unresponsive, :unresponsive}
+      {:error, _other} -> {:failed, op}
+    end
+  end
+
+  # `skip_op: true` unconditionally, because `probe_op_ref/2` has already had
+  # its turn. Letting `resolve_key/2` try again would spend a second budget to
+  # reach the answer we are already holding.
+  defp diag_availability(_spec, {:ok, _secret}), do: {true, :op}
+
+  defp diag_availability(spec, _op_result) do
+    case detect_available(spec, skip_op: true) do
+      {:ok, _config, src} -> {true, src}
+      _ -> {false, nil}
+    end
   end
 
   defp diag_note(_spec, true, _op), do: nil
@@ -265,6 +350,10 @@ defmodule Raxol.Agent.Backend.Resolver do
 
   defp op_hint(:not_signed_in), do: "op reference stored, run `op signin`"
   defp op_hint(:absent), do: "op reference stored, but the `op` CLI is not installed"
+
+  defp op_hint(:unresponsive),
+    do: "op reference stored, but the vault did not answer -- unlock 1Password"
+
   defp op_hint(_status), do: nil
 
   defp empty_env_key(%{env_keys: keys}) do

--- a/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
@@ -216,6 +216,9 @@ defmodule Raxol.Agent.Backend.Resolver do
   Returns `%{op: op_status, providers: [%{harness, label, keyless?,
   available?, source, note}]}`. Probing may shell out to `op` for stored
   references, so treat it as a point-in-time snapshot.
+
+  The `op` state is read ONCE and, when it is unusable, the per-provider `op`
+  probes are skipped entirely. See `provider_diag/2`.
   """
   @spec diagnostics() :: %{op: atom(), providers: [map()]}
   def diagnostics do
@@ -223,9 +226,19 @@ defmodule Raxol.Agent.Backend.Resolver do
     %{op: op, providers: Enum.map(@providers, &provider_diag(&1, op))}
   end
 
+  # A stored `op://` reference cannot resolve while the CLI is absent or signed
+  # out, so probing one here is a shell-out per provider that is guaranteed to
+  # fail. Against a LOCKED vault each probe additionally raises a desktop
+  # authorization prompt and then waits out the full `op` timeout, and there is
+  # one per provider: measured, that turned `/inspect` into a 12-to-22 second
+  # stall where `op_status/0` alone accounted for under 7s of it.
+  #
+  # Skipping costs no information. `diag_note/3` already answers a stored
+  # reference under a signed-out CLI with "run `op signin`" -- the same
+  # conclusion the probe spends 15 seconds arriving at.
   defp provider_diag(spec, op) do
     {available?, source} =
-      case detect_available(spec, []) do
+      case detect_available(spec, skip_op: op != :ok) do
         {:ok, _config, src} -> {true, src}
         _ -> {false, nil}
       end
@@ -409,10 +422,13 @@ defmodule Raxol.Agent.Backend.Resolver do
 
   # -- key resolution ---------------------------------------------------------
 
+  # `:skip_op` is set only by `provider_diag/2`. The resolution path proper never
+  # skips: a user actually starting a turn wants their stored key read, and is
+  # willing to wait for an unlock prompt to do it. A diagnostic is not.
   defp resolve_key(spec, opts) do
     first_ok([
       fn -> explicit_key(opts) end,
-      fn -> op_key(spec) end,
+      fn -> if Keyword.get(opts, :skip_op, false), do: :none, else: op_key(spec) end,
       fn -> env_key(spec) end
     ])
   end

--- a/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
@@ -335,4 +335,70 @@ defmodule Raxol.Agent.Backend.ResolverTest do
       assert anthropic.note == nil
     end
   end
+
+  describe "diagnostics/0 against an unusable op CLI" do
+    # A fake `op` that records every invocation and always fails, standing in
+    # for a signed-out CLI. A locked vault behaves worse still: each call blocks
+    # on a desktop authorization prompt until the timeout.
+    setup do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol-op-count-#{System.os_time(:millisecond)}-" <>
+            "#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      log = Path.join(dir, "calls")
+      fake_op = Path.join(dir, "op")
+
+      File.write!(fake_op, "#!/bin/sh\necho \"$@\" >> #{log}\nexit 1\n")
+      File.chmod!(fake_op, 0o755)
+
+      prev_path = System.get_env("PATH")
+      System.put_env("PATH", dir <> ":" <> (prev_path || ""))
+
+      on_exit(fn ->
+        System.put_env("PATH", prev_path || "")
+        File.rm_rf!(dir)
+      end)
+
+      %{log: log}
+    end
+
+    test "probes op once for status, not once per provider", %{log: log} do
+      # Every provider carries a stored reference, so before the fix each one
+      # shelled out to `op read` on top of the single `op whoami` -- a serial
+      # storm that made `/inspect` take 12 to 22 seconds against a locked vault
+      # and raised one authorization prompt per provider.
+      for var <- ~w(RAXOL_ANTHROPIC_OP RAXOL_OPENAI_OP RAXOL_KIMI_OP RAXOL_OPENROUTER_OP) do
+        System.put_env(var, "op://vault/#{var}/credential")
+      end
+
+      diag = Resolver.diagnostics()
+
+      assert diag.op == :not_signed_in
+
+      calls =
+        if File.exists?(log), do: log |> File.read!() |> String.split("\n", trim: true), else: []
+
+      assert length(calls) == 1,
+             "expected one `op whoami`, got #{length(calls)}: #{inspect(calls)}"
+
+      assert hd(calls) =~ "whoami"
+    end
+
+    test "a stored reference still reports why it is unavailable" do
+      # Skipping the probe must not cost the diagnostic its answer: the note is
+      # the same conclusion the probe would have reached, minus the wait.
+      System.put_env("RAXOL_ANTHROPIC_OP", "op://vault/anthropic/credential")
+
+      anthropic =
+        Resolver.diagnostics().providers
+        |> Enum.find(&(&1.harness == :anthropic))
+
+      refute anthropic.available?
+      assert anthropic.note =~ "op signin"
+    end
+  end
 end

--- a/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
@@ -401,4 +401,163 @@ defmodule Raxol.Agent.Backend.ResolverTest do
       assert anthropic.note =~ "op signin"
     end
   end
+
+  # The state the skip above does NOT cover, and the slow one: signed in, so
+  # `op whoami` exits 0 and the status reads `:ok`, while every `op read` waits
+  # on a desktop authorization nobody is going to give. Each provider then paid
+  # a full budget in SERIES.
+  describe "diagnostics/0 against a signed-in but unresponsive vault" do
+    setup do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol-op-hang-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      log = Path.join(dir, "calls")
+      fake_op = Path.join(dir, "op")
+
+      # `whoami` answers instantly (signed in); every `read` hangs, the way a
+      # locked vault does while it waits for an approval.
+      File.write!(fake_op, """
+      #!/bin/sh
+      echo "$@" >> #{log}
+      case "$1" in
+        whoami) exit 0 ;;
+        read) sleep 30 ;;
+      esac
+      exit 1
+      """)
+
+      File.chmod!(fake_op, 0o755)
+
+      prev_path = System.get_env("PATH")
+      System.put_env("PATH", dir <> ":" <> (prev_path || ""))
+
+      # The suite-wide 2s pin would mask the per-read diagnostic budget under
+      # test, so the interactive default is restored for this block only.
+      prev_timeout = System.get_env("RAXOL_OP_TIMEOUT_MS")
+      System.put_env("RAXOL_OP_TIMEOUT_MS", "15000")
+
+      on_exit(fn ->
+        System.put_env("PATH", prev_path || "")
+
+        if prev_timeout,
+          do: System.put_env("RAXOL_OP_TIMEOUT_MS", prev_timeout),
+          else: System.delete_env("RAXOL_OP_TIMEOUT_MS")
+
+        File.rm_rf!(dir)
+      end)
+
+      %{log: log}
+    end
+
+    test "one hung read ends the sweep instead of costing one per provider", %{log: log} do
+      for var <- ~w(RAXOL_ANTHROPIC_OP RAXOL_OPENAI_OP RAXOL_KIMI_OP RAXOL_OPENROUTER_OP) do
+        System.put_env(var, "op://vault/#{var}/credential")
+      end
+
+      {elapsed_us, diag} = :timer.tc(&Resolver.diagnostics/0)
+
+      # A timeout is evidence about the VAULT, so the first one demotes `op`
+      # and the rest are answered from that without paying again.
+      assert diag.op == :unresponsive
+
+      reads =
+        log
+        |> File.read!()
+        |> String.split("\n", trim: true)
+        |> Enum.filter(&String.starts_with?(&1, "read"))
+
+      assert length(reads) == 1,
+             "expected the sweep to stop after one hung read, got #{length(reads)}: " <>
+               inspect(reads)
+
+      # Four references, one budget. Asserted generously -- the point is that
+      # this is not four budgets, not where it lands inside one.
+      assert elapsed_us < 10_000_000,
+             "diagnostics took #{div(elapsed_us, 1000)}ms; a per-provider budget is back"
+    end
+
+    test "the stored references say the vault did not answer" do
+      System.put_env("RAXOL_ANTHROPIC_OP", "op://vault/anthropic/credential")
+      System.put_env("RAXOL_OPENAI_OP", "op://vault/openai/credential")
+
+      providers = Resolver.diagnostics().providers
+
+      for harness <- [:anthropic, :openai] do
+        entry = Enum.find(providers, &(&1.harness == harness))
+
+        refute entry.available?
+
+        assert entry.note =~ "did not answer",
+               "#{harness} got #{inspect(entry.note)}"
+      end
+    end
+  end
+
+  describe "resolve/1 opts" do
+    # A fake `op` that RESOLVES, so the two outcomes are distinguishable: the
+    # vault answers "from-the-vault" and the environment answers something
+    # else. Without a working `op` this test would pass either way.
+    setup do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol-op-seal-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      fake_op = Path.join(dir, "op")
+
+      File.write!(fake_op, """
+      #!/bin/sh
+      case "$1" in
+        whoami) exit 0 ;;
+        read) echo "from-the-vault" ; exit 0 ;;
+      esac
+      exit 1
+      """)
+
+      File.chmod!(fake_op, 0o755)
+
+      prev_path = System.get_env("PATH")
+      System.put_env("PATH", dir <> ":" <> (prev_path || ""))
+
+      on_exit(fn ->
+        System.put_env("PATH", prev_path || "")
+        File.rm_rf!(dir)
+      end)
+
+      :ok
+    end
+
+    test ":skip_op from a caller is dropped, so the vault still wins" do
+      # `:skip_op` reads as harmless -- "do not shell out to `op`" -- but what
+      # it does is silence the vault and let resolution fall through to
+      # environment variables. A caller that set it, or forwarded an opts list
+      # it never audited, would get $ANTHROPIC_API_KEY where the operator had
+      # stored an `op://` reference, and nothing would say so.
+      #
+      # The old guarantee was a comment on `resolve_key/2` saying only the
+      # diagnostic sets it. A comment is not a boundary, and `resolve/1` is
+      # public.
+      System.put_env("RAXOL_ANTHROPIC_OP", "op://vault/anthropic/credential")
+      System.put_env("ANTHROPIC_API_KEY", "from-the-environment")
+
+      assert {:ok, sealed, source} =
+               Resolver.resolve(harness: :anthropic, skip_op: true)
+
+      assert sealed.auth[:api_key] == "from-the-vault",
+             "a caller-supplied :skip_op downgraded the vault to the environment"
+
+      assert source == :op
+
+      # Identical to the call that never passed the option, which is the
+      # property: the option changes nothing.
+      assert {:ok, plain, :op} = Resolver.resolve(harness: :anthropic)
+      assert plain.auth[:api_key] == sealed.auth[:api_key]
+    end
+  end
 end

--- a/packages/raxol_agent/test/test_helper.exs
+++ b/packages/raxol_agent/test/test_helper.exs
@@ -13,6 +13,20 @@ unless System.get_env("RAXOL_SESSIONS_DIR") do
   System.at_exit(fn _ -> File.rm_rf(sessions_dir) end)
 end
 
+# Bound every `op` shell-out for the whole run. The production default is 15s,
+# sized so an interactive 1Password approval still fits -- but under test that
+# is longer than the budget of any assertion waiting on the other side of it,
+# so a LOCKED vault (which blocks `op` on its desktop authorization prompt)
+# turns a passing test red on a machine state that has nothing to do with the
+# code. `/inspect` was failing exactly this way.
+#
+# Set rather than defaulted: an unlocked vault answers in well under a second,
+# so this only ever truncates a wait that was going to be answered by a human
+# who is not there. Tests that drive the timeout itself override it locally.
+unless System.get_env("RAXOL_OP_TIMEOUT_MS") do
+  System.put_env("RAXOL_OP_TIMEOUT_MS", "2000")
+end
+
 # The invariant suite's fault-injection harness lives under test/invariants/
 # (not test/support/, which elixirc_paths compiles) — load it explicitly.
 Code.require_file("invariants/support/fault_journal.ex", __DIR__)


### PR DESCRIPTION
`/inspect` shelled out to the `op` CLI once per PROVIDER, not once.

`Resolver.diagnostics/0` read `Credentials.op_status()`, then for each provider
walked `detect_available -> resolve_key -> op_key -> Credentials.read_ref`, and
`read_ref` is another `op read` subprocess. Every provider with a stored
`op://` reference got its own. Measured here:

```
op_status                  6935ms
Resolver.diagnostics       21957ms
ProjectConfig.load             7ms
gather (whole)            12285ms
```

`ProjectConfig.load` is 7ms. It is all `op`.

## The two states, and the two fixes

**Signed out or absent.** A stored reference cannot resolve, so probing one is a
shell-out per provider guaranteed to fail. `diagnostics/0` already read the `op`
state once and used it only to choose the NOTE; now it also skips the probe.
Nothing is lost: `diag_note/3` already answers a stored reference under a
signed-out CLI with "run `op signin`", which is the same conclusion the probe
spends 15 seconds arriving at.

**Signed in but unresponsive** -- added in review, and this is the slow one.
`op whoami` exits 0, so the status reads `:ok` and the skip above never fires,
while every `op read` waits on a desktop authorization nobody is going to give.
Two changes:

- `read_ref/2` takes `:timeout_ms` and the diagnostic passes **1.5s**. The 15s
  default is sized so a human can approve a prompt; nobody is on the other side
  of `/inspect`. Per-call rather than via `RAXOL_OP_TIMEOUT_MS`, which is
  process-wide and would also shorten the reads a user IS waiting for.
- A timed-out read demotes `op` to `:unresponsive` for the rest of the sweep. A
  timeout is evidence about the VAULT, not about whichever provider's reference
  came first, so the others are answered from that instead of each paying again.
  **Worst case is one budget, not one per provider**, and those providers now
  read "op reference stored, but the vault did not answer -- unlock 1Password"
  instead of nothing.

`provider_diag/2` owns the op probe outright now and always passes
`skip_op: true` downstream: only from there can a timeout be seen for what it is,
and letting `resolve_key/2` try again would spend a second budget to reach an
answer already in hand.

## `:skip_op` is sealed at the public boundary

`resolve/1` drops it. It reads as harmless -- "do not shell out to `op`" -- but
what it does is silence the vault and fall through to environment variables, so
a caller that set it, or forwarded an opts list it never audited, would get
`$ANTHROPIC_API_KEY` where the operator had stored an `op://` reference, and
nothing would say so. The old guarantee was a comment on `resolve_key/2` saying
only the diagnostic sets it. A comment is not a boundary and `resolve/1` is
public.

## The test failure this was causing

`test/raxol/agent/code/app_test.exs` -- "the default /inspect fetcher delivers
the full snapshot" -- waits 10s for the rendered snapshot. `gather` was taking
12-22s, so it failed whenever the vault happened to be locked and passed when it
happened to be unlocked. It reads as a flake; it is a stopwatch on 1Password's
lock state.

`test_helper.exs` now bounds `RAXOL_OP_TIMEOUT_MS` to 2s for the whole run, so no
assertion waits on a prompt for a human who is not there. Tests that drive the
timeout itself override it locally. Production keeps the 15s interactive budget.

## Testing

Fake `op` binaries on PATH, no stubbing of the code under test. 35 passed.

Both review fixes are red-proven -- reverting each fails the test that names it:

| revert | fails with |
| --- | --- |
| unseal `:skip_op` | `a caller-supplied :skip_op downgraded the vault to the environment` |
| drop the `:unresponsive` demotion | `expected the sweep to stop after one hung read, got 4` |

The unresponsive-vault fixture answers `whoami` instantly and `sleep 30`s on
every `read`, which is the shape a locked vault actually has.

## Manual testing

- [ ] Lock 1Password, run `/inspect`: it returns promptly and the stored-reference rows say the vault did not answer
- [ ] Unlock, run `/inspect`: those rows resolve `via op`
