### PR TITLE
Format every package, and gate them all

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -16,22 +16,13 @@
   # editor save does in a monorepo workspace -- rewraps those files at 80 and
   # reverts exactly what the per-package CI gate blessed.
   #
-  # This list tracks the `package-tests` matrix in .github/workflows/ci-unified.yml,
-  # which is the only place a package is format-gated. Widening it to `packages/*`
-  # pulls the ungated packages (169 files of pre-existing drift) into the root
-  # check, so a package joins here when it joins that matrix.
-  subdirectories: [
-    "packages/raxol_agent",
-    "packages/raxol_agent_client_protocol",
-    "packages/raxol_cli",
-    "packages/raxol_console",
-    "packages/raxol_core",
-    "packages/raxol_earn",
-    "packages/raxol_gateway",
-    "packages/raxol_payments",
-    "packages/raxol_symphony",
-    "packages/raxol_telegram"
-  ],
+  # Every package, by glob. This used to be an explicit list tracking the
+  # `package-tests` matrix, because the packages outside that matrix carried
+  # ~145 files of drift and pulling them in would have made the root check
+  # unsatisfiable. That drift is now gone and the `format` job in
+  # .github/workflows/ci-unified.yml gates all of them, so the two agree by
+  # construction rather than by keeping two lists in step.
+  subdirectories: ["packages/*"],
   locals_without_parens: [
     # Phoenix
     action_fallback: 1,

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -178,24 +178,14 @@ jobs:
       - name: Check formatting
         run: mix format --check-formatted
 
-      # The root check reads the root .formatter.exs, which delegates every
-      # `packages/*` path to that package's own config -- so it covers package
-      # files only for paths its own `inputs` reach, and those inputs stop at
-      # the repo root. This walks each package and runs its gate directly.
-      #
-      # Deliberately here and not in the `package-tests` matrix: that job
-      # compiles and runs a full suite per package, so gating all 17 there would
-      # add a lot of CI for a check that needs neither. `mix format` reads
-      # .formatter.exs and the source; nothing is compiled.
+      # The root check above reads the root .formatter.exs, whose `inputs` stop
+      # at the repo root -- so it reaches a package file only when a caller
+      # names one. This walks every package and runs its own gate. It compiles
+      # nothing, which is why it lives here and not in `package-tests`; the
+      # script says why at length, and asserts the two conditions that would
+      # make that untrue.
       - name: Check package formatting
-        run: |
-          failed=0
-          for dir in packages/*/; do
-            if [ -f "$dir/.formatter.exs" ]; then
-              (cd "$dir" && mix format --check-formatted) || failed=1
-            fi
-          done
-          exit $failed
+        run: bash scripts/check_package_formatting.sh
 
       - name: Check singleton allowlist
         run: bash scripts/check_singletons.sh

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -178,6 +178,25 @@ jobs:
       - name: Check formatting
         run: mix format --check-formatted
 
+      # The root check reads the root .formatter.exs, which delegates every
+      # `packages/*` path to that package's own config -- so it covers package
+      # files only for paths its own `inputs` reach, and those inputs stop at
+      # the repo root. This walks each package and runs its gate directly.
+      #
+      # Deliberately here and not in the `package-tests` matrix: that job
+      # compiles and runs a full suite per package, so gating all 17 there would
+      # add a lot of CI for a check that needs neither. `mix format` reads
+      # .formatter.exs and the source; nothing is compiled.
+      - name: Check package formatting
+        run: |
+          failed=0
+          for dir in packages/*/; do
+            if [ -f "$dir/.formatter.exs" ]; then
+              (cd "$dir" && mix format --check-formatted) || failed=1
+            fi
+          done
+          exit $failed
+
       - name: Check singleton allowlist
         run: bash scripts/check_singletons.sh
 
@@ -306,11 +325,10 @@ jobs:
         # with a compiler warning nobody could fail on, because nothing here ran
         # them. Adding them required unbreaking both suites first -- see the PR.
         #
-        # raxol_agent_client_protocol joins for the format half: ungated, five of
-        # its files had been rewrapped at the root's 80 columns and no check
-        # anywhere disagreed. A package earns its entry in the root
-        # .formatter.exs `subdirectories` list by being gated here, so the two
-        # lists move together.
+        # Formatting is NOT what this matrix is for any more. Every package is
+        # format-checked by the `format` job, which needs no compile, and the
+        # root .formatter.exs delegates `packages/*` by glob -- so a package
+        # joins here to get its TESTS run, not to earn a formatter entry.
         #
         # raxol_console boots agent packages onto the gateway and was ungated for
         # the same reason the others were: nothing in per-PR CI ran it. It joins
@@ -408,12 +426,11 @@ jobs:
             --exclude cli_signer \
             --exclude skip_on_ci
 
-      # Last, not first. The root Format Check reads the root .formatter.exs,
-      # whose inputs cover only root lib/config/examples/test, so before this
-      # step no file under packages/ was format-checked anywhere in CI (25 files
-      # over three packages had drifted). But this job is named "Package Tests"
-      # and two of its cells move real money: a red X here has to mean the tests
-      # ran, not that a line was two columns too wide before compile started.
+      # Kept as a per-package backstop, and kept LAST. The `format` job checks
+      # every package now, so this is redundant on the happy path -- but this
+      # job is named "Package Tests" and two of its cells move real money, so a
+      # red X here has to mean the tests ran, not that a line was two columns
+      # too wide before compile started.
       - name: Check formatting
         working-directory: packages/${{ matrix.package }}
         run: mix format --check-formatted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,14 @@ mix dialyzer                  # Type checking
 ```
 
 Packages format at their own line length (98), not the root's 80. The root
-`.formatter.exs` delegates to the packages CI format-gates (`:subdirectories`),
-so a root `mix format` handles those correctly. For any other package, format
-from inside it: `cd packages/<pkg> && mix format`.
+`.formatter.exs` delegates every `packages/*` path to that package's own config
+(`:subdirectories`), so `mix format` from the repo root is correct for any file
+in the repo and matches what CI checks.
+
+CI gates the same thing in two places, both in the `format` job: the root
+`mix format --check-formatted`, then a loop running each package's own gate.
+Every package is covered, so `cd packages/<pkg> && mix format` is a no-op on a
+clean tree. If it rewrites files, that is a real diff and not drift.
 
 ### Running examples
 

--- a/packages/raxol_liveview/test/raxol/live_view/terminal_bridge_property_test.exs
+++ b/packages/raxol_liveview/test/raxol/live_view/terminal_bridge_property_test.exs
@@ -25,9 +25,7 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
   defp box_drawing_gen do
     StreamData.map(
       StreamData.list_of(
-        StreamData.member_of(
-          Enum.to_list(0x2500..0x257F) ++ Enum.to_list(0x250C..0x2573)
-        ),
+        StreamData.member_of(Enum.to_list(0x2500..0x257F) ++ Enum.to_list(0x250C..0x2573)),
         min_length: 1,
         max_length: 20
       ),
@@ -93,11 +91,18 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
   end
 
   defp escape_html_binary(<<>>, acc), do: acc |> Enum.reverse() |> IO.iodata_to_binary()
-  defp escape_html_binary(<<?&, rest::binary>>, acc), do: escape_html_binary(rest, ["&amp;" | acc])
+
+  defp escape_html_binary(<<?&, rest::binary>>, acc),
+    do: escape_html_binary(rest, ["&amp;" | acc])
+
   defp escape_html_binary(<<?<, rest::binary>>, acc), do: escape_html_binary(rest, ["&lt;" | acc])
   defp escape_html_binary(<<?>, rest::binary>>, acc), do: escape_html_binary(rest, ["&gt;" | acc])
-  defp escape_html_binary(<<?", rest::binary>>, acc), do: escape_html_binary(rest, ["&quot;" | acc])
-  defp escape_html_binary(<<?', rest::binary>>, acc), do: escape_html_binary(rest, ["&#39;" | acc])
+
+  defp escape_html_binary(<<?", rest::binary>>, acc),
+    do: escape_html_binary(rest, ["&quot;" | acc])
+
+  defp escape_html_binary(<<?', rest::binary>>, acc),
+    do: escape_html_binary(rest, ["&#39;" | acc])
 
   defp escape_html_binary(<<c::utf8, rest::binary>>, acc),
     do: escape_html_binary(rest, [<<c::utf8>> | acc])
@@ -105,7 +110,7 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
   # --- Properties ---
 
   property "escape_html_text never crashes on any valid UTF-8 string" do
-    check all text <- unicode_gen(), max_runs: 500 do
+    check all(text <- unicode_gen(), max_runs: 500) do
       result = escape_html_text(text)
       assert is_binary(result)
     end
@@ -113,14 +118,16 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
 
   property "escape_html_text preserves string length for non-special chars" do
     # For strings without HTML-special chars, content length is preserved
-    check all text <- StreamData.one_of([ascii_printable_gen(), cjk_gen(), box_drawing_gen()]),
-              not String.contains?(text, ["&", "<", ">", "\"", "'"]) do
+    check all(
+            text <- StreamData.one_of([ascii_printable_gen(), cjk_gen(), box_drawing_gen()]),
+            not String.contains?(text, ["&", "<", ">", "\"", "'"])
+          ) do
       assert escape_html_text(text) == text
     end
   end
 
   property "escape_html_text roundtrips: unescape(escape(x)) == x" do
-    check all text <- unicode_gen(), max_runs: 300 do
+    check all(text <- unicode_gen(), max_runs: 300) do
       escaped = escape_html_text(text)
 
       unescaped =
@@ -136,14 +143,14 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
   end
 
   property "escape_html_text produces valid UTF-8" do
-    check all text <- unicode_gen(), max_runs: 300 do
+    check all(text <- unicode_gen(), max_runs: 300) do
       result = escape_html_text(text)
       assert String.valid?(result)
     end
   end
 
   property "escape_html_text handles box-drawing characters" do
-    check all text <- box_drawing_gen(), max_runs: 200 do
+    check all(text <- box_drawing_gen(), max_runs: 200) do
       result = escape_html_text(text)
       assert is_binary(result)
       assert String.valid?(result)
@@ -153,7 +160,7 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
   end
 
   property "escape_html_text handles CJK characters" do
-    check all text <- cjk_gen(), max_runs: 200 do
+    check all(text <- cjk_gen(), max_runs: 200) do
       result = escape_html_text(text)
       assert is_binary(result)
       assert String.valid?(result)
@@ -162,7 +169,7 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
   end
 
   property "escape_html_text handles extended Latin" do
-    check all text <- latin_extended_gen(), max_runs: 200 do
+    check all(text <- latin_extended_gen(), max_runs: 200) do
       result = escape_html_text(text)
       assert is_binary(result)
       assert String.valid?(result)
@@ -171,7 +178,7 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
   end
 
   property "escape_html_text escapes all five HTML-special characters" do
-    check all text <- html_special_gen(), max_runs: 200 do
+    check all(text <- html_special_gen(), max_runs: 200) do
       result = escape_html_text(text)
       # No raw < or > should survive
       refute String.contains?(result, ["<", ">"])
@@ -191,18 +198,21 @@ defmodule Raxol.LiveView.TerminalBridgePropertyTest do
   end
 
   property "escape_html_text handles mixed ASCII + CJK + box-drawing + specials" do
-    check all parts <- StreamData.list_of(
-                         StreamData.one_of([
-                           ascii_printable_gen(),
-                           cjk_gen(),
-                           box_drawing_gen(),
-                           latin_extended_gen(),
-                           html_special_gen()
-                         ]),
-                         min_length: 1,
-                         max_length: 5
-                       ),
-                       max_runs: 200 do
+    check all(
+            parts <-
+              StreamData.list_of(
+                StreamData.one_of([
+                  ascii_printable_gen(),
+                  cjk_gen(),
+                  box_drawing_gen(),
+                  latin_extended_gen(),
+                  html_special_gen()
+                ]),
+                min_length: 1,
+                max_length: 5
+              ),
+            max_runs: 200
+          ) do
       text = Enum.join(parts)
       result = escape_html_text(text)
       assert is_binary(result)

--- a/packages/raxol_mcp/lib/raxol/mcp/adaptive_tools.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/adaptive_tools.ex
@@ -109,8 +109,7 @@ defmodule Raxol.MCP.AdaptiveTools do
         properties: %{
           window_count: %{
             type: "integer",
-            description:
-              "Number of recent aggregate windows to return (default: 3)"
+            description: "Number of recent aggregate windows to return (default: 3)"
           }
         }
       },
@@ -206,11 +205,9 @@ defmodule Raxol.MCP.AdaptiveTools do
         most_used_panes: Enum.map(agg.most_used_panes, &to_string/1),
         least_used_panes: Enum.map(agg.least_used_panes, &to_string/1),
         scroll_frequency: stringify_keys(Map.get(agg, :scroll_frequency, %{})),
-        takeover_duration_ms:
-          stringify_keys(Map.get(agg, :takeover_duration_ms, %{})),
+        takeover_duration_ms: stringify_keys(Map.get(agg, :takeover_duration_ms, %{})),
         layout_override_count: Map.get(agg, :layout_override_count, 0),
-        command_concentration:
-          stringify_keys(Map.get(agg, :command_concentration, %{}))
+        command_concentration: stringify_keys(Map.get(agg, :command_concentration, %{}))
       }
     end)
   end

--- a/packages/raxol_mcp/lib/raxol/mcp/agent_bridge.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/agent_bridge.ex
@@ -62,8 +62,7 @@ defmodule Raxol.MCP.AgentBridge do
     [
       %{
         name: "agent.list",
-        description:
-          "List all active agent sessions with their IDs and status.",
+        description: "List all active agent sessions with their IDs and status.",
         inputSchema: %{type: "object", properties: %{}},
         callback: &list_agents/1
       },
@@ -148,8 +147,7 @@ defmodule Raxol.MCP.AgentBridge do
                [
                  %{
                    type: "text",
-                   text:
-                     "Enqueued #{String.length(message)} keystrokes for agent #{id}"
+                   text: "Enqueued #{String.length(message)} keystrokes for agent #{id}"
                  }
                ]}
 
@@ -176,8 +174,7 @@ defmodule Raxol.MCP.AgentBridge do
          function_exported?(Raxol.Headless, :get_model, 1) do
       with {:ok, session} <- existing_session_atom(id),
            {:ok, model} <- Raxol.Headless.get_model(session) do
-        {:ok,
-         [%{type: "text", text: inspect(model, pretty: true, limit: :infinity)}]}
+        {:ok, [%{type: "text", text: inspect(model, pretty: true, limit: :infinity)}]}
       else
         {:error, :unknown_session} -> {:error, "Unknown agent session: #{id}"}
         {:error, reason} -> {:error, reason}

--- a/packages/raxol_mcp/lib/raxol/mcp/tool_synchronizer.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/tool_synchronizer.ex
@@ -292,7 +292,10 @@ defmodule Raxol.MCP.ToolSynchronizer do
             Map.put(acc, key, proj_fn.(model))
           rescue
             e ->
-              Logger.warning("[MCP.ToolSynchronizer] Projection #{inspect(key)} failed: #{Exception.message(e)}")
+              Logger.warning(
+                "[MCP.ToolSynchronizer] Projection #{inspect(key)} failed: #{Exception.message(e)}"
+              )
+
               acc
           end
         end)

--- a/packages/raxol_mcp/lib/raxol/mcp/transport/stdio.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/transport/stdio.ex
@@ -105,7 +105,9 @@ defmodule Raxol.MCP.Transport.Stdio do
             id = Map.get(message, :id)
 
             if id do
-              error = Protocol.error_response(id, Protocol.internal_error(), "Internal server error")
+              error =
+                Protocol.error_response(id, Protocol.internal_error(), "Internal server error")
+
               write_response(state.output_device, error)
             end
         end

--- a/packages/raxol_mcp/mix.exs
+++ b/packages/raxol_mcp/mix.exs
@@ -45,7 +45,9 @@ defmodule RaxolMcp.MixProject do
   end
 
   defp raxol_dep(name, version, path) do
-    if System.get_env("HEX_BUILD") || !File.dir?(path), do: {name, version}, else: {name, version, path: path}
+    if System.get_env("HEX_BUILD") || !File.dir?(path),
+      do: {name, version},
+      else: {name, version, path: path}
   end
 
   defp description do

--- a/packages/raxol_mcp/test/raxol/mcp/phase12_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/phase12_test.exs
@@ -161,12 +161,42 @@ defmodule Raxol.MCP.Phase12Test do
   describe "FocusLens :hover mode" do
     setup do
       tools = [
-        %{name: "search.type_into", description: "Type", inputSchema: %{}, callback: fn _ -> {:ok, "ok"} end},
-        %{name: "search.clear", description: "Clear", inputSchema: %{}, callback: fn _ -> {:ok, "ok"} end},
-        %{name: "btn1.click", description: "Click btn1", inputSchema: %{}, callback: fn _ -> {:ok, "ok"} end},
-        %{name: "btn2.click", description: "Click btn2", inputSchema: %{}, callback: fn _ -> {:ok, "ok"} end},
-        %{name: "table.select_row", description: "Select", inputSchema: %{}, callback: fn _ -> {:ok, "ok"} end},
-        %{name: "global_action", description: "Global", inputSchema: %{}, callback: fn _ -> {:ok, "ok"} end}
+        %{
+          name: "search.type_into",
+          description: "Type",
+          inputSchema: %{},
+          callback: fn _ -> {:ok, "ok"} end
+        },
+        %{
+          name: "search.clear",
+          description: "Clear",
+          inputSchema: %{},
+          callback: fn _ -> {:ok, "ok"} end
+        },
+        %{
+          name: "btn1.click",
+          description: "Click btn1",
+          inputSchema: %{},
+          callback: fn _ -> {:ok, "ok"} end
+        },
+        %{
+          name: "btn2.click",
+          description: "Click btn2",
+          inputSchema: %{},
+          callback: fn _ -> {:ok, "ok"} end
+        },
+        %{
+          name: "table.select_row",
+          description: "Select",
+          inputSchema: %{},
+          callback: fn _ -> {:ok, "ok"} end
+        },
+        %{
+          name: "global_action",
+          description: "Global",
+          inputSchema: %{},
+          callback: fn _ -> {:ok, "ok"} end
+        }
       ]
 
       %{tools: tools}
@@ -214,7 +244,14 @@ defmodule Raxol.MCP.Phase12Test do
     end
 
     test "hover respects max_tools limit", %{tools: tools} do
-      result = FocusLens.filter(tools, mode: :hover, focused_id: "search", hover_id: "btn1", max_tools: 3)
+      result =
+        FocusLens.filter(tools,
+          mode: :hover,
+          focused_id: "search",
+          hover_id: "btn1",
+          max_tools: 3
+        )
+
       assert length(result) <= 3
     end
 

--- a/packages/raxol_mcp/test/raxol/mcp/read_surface_authz_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/read_surface_authz_test.exs
@@ -12,9 +12,7 @@ defmodule Raxol.MCP.ReadSurfaceAuthzTest do
     {:ok, _} = Registry.start_link(name: registry_name)
 
     {:ok, server} =
-      Server.start_link(
-        [name: server_name, registry: registry_name] ++ server_opts
-      )
+      Server.start_link([name: server_name, registry: registry_name] ++ server_opts)
 
     {server, registry_name}
   end
@@ -239,15 +237,13 @@ defmodule Raxol.MCP.ReadSurfaceAuthzTest do
         "uri" => "raxol://a"
       })
 
-      assert_receive {:mcp_notification,
-                      %{method: "notifications/resources/updated"}},
+      assert_receive {:mcp_notification, %{method: "notifications/resources/updated"}},
                      1_000
 
       # Other notification methods are unaffected by subscription state.
       Server.notify(server, "notifications/tools/list_changed", %{})
 
-      assert_receive {:mcp_notification,
-                      %{method: "notifications/tools/list_changed"}},
+      assert_receive {:mcp_notification, %{method: "notifications/tools/list_changed"}},
                      1_000
     end
   end

--- a/packages/raxol_mcp/test/raxol/mcp/registry_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/registry_test.exs
@@ -176,8 +176,8 @@ defmodule Raxol.MCP.RegistryTest do
 
       :ok = Registry.register_tools(r, [sample_tool()])
 
-      assert_receive {[:raxol, :mcp, :registry, :tools_changed], ^ref,
-                      %{count: 1}, %{action: :register, names: ["test_tool"]}}
+      assert_receive {[:raxol, :mcp, :registry, :tools_changed], ^ref, %{count: 1},
+                      %{action: :register, names: ["test_tool"]}}
     end
 
     test "emits tools_changed on unregister", %{registry: r} do
@@ -190,8 +190,8 @@ defmodule Raxol.MCP.RegistryTest do
 
       :ok = Registry.unregister_tools(r, ["test_tool"])
 
-      assert_receive {[:raxol, :mcp, :registry, :tools_changed], ^ref,
-                      %{count: 1}, %{action: :unregister, names: ["test_tool"]}}
+      assert_receive {[:raxol, :mcp, :registry, :tools_changed], ^ref, %{count: 1},
+                      %{action: :unregister, names: ["test_tool"]}}
     end
   end
 

--- a/packages/raxol_plugin/lib/raxol/plugin.ex
+++ b/packages/raxol_plugin/lib/raxol/plugin.ex
@@ -54,11 +54,11 @@ defmodule Raxol.Plugin do
       def get_commands, do: []
 
       defoverridable terminate: 2,
-                       enable: 1,
-                       disable: 1,
-                       filter_event: 2,
-                       handle_command: 3,
-                       get_commands: 0
+                     enable: 1,
+                     disable: 1,
+                     filter_event: 2,
+                     handle_command: 3,
+                     get_commands: 0
     end
   end
 end

--- a/packages/raxol_plugin/lib/raxol/plugin/api.ex
+++ b/packages/raxol_plugin/lib/raxol/plugin/api.ex
@@ -12,10 +12,11 @@ defmodule Raxol.Plugin.API do
       Raxol.Plugin.API.list()
   """
 
-  @compile {:no_warn_undefined, [
-    Raxol.Core.Runtime.Plugins.PluginManager,
-    Raxol.Core.Runtime.Plugins.PluginLifecycle
-  ]}
+  @compile {:no_warn_undefined,
+            [
+              Raxol.Core.Runtime.Plugins.PluginManager,
+              Raxol.Core.Runtime.Plugins.PluginLifecycle
+            ]}
 
   @type plugin_id :: atom() | String.t()
 
@@ -93,7 +94,7 @@ defmodule Raxol.Plugin.API do
 
   # Wraps calls in try/catch :exit for when the PluginManager/Lifecycle
   # GenServer is not running.
-  @spec call((() -> result)) :: result | {:error, :plugin_manager_not_running} when result: term()
+  @spec call((-> result)) :: result | {:error, :plugin_manager_not_running} when result: term()
   defp call(fun) do
     fun.()
   catch

--- a/packages/raxol_plugin/mix.exs
+++ b/packages/raxol_plugin/mix.exs
@@ -44,7 +44,9 @@ defmodule RaxolPlugin.MixProject do
   end
 
   defp raxol_dep(name, version, path) do
-    if System.get_env("HEX_BUILD") || !File.dir?(path), do: {name, version}, else: {name, version, path: path}
+    if System.get_env("HEX_BUILD") || !File.dir?(path),
+      do: {name, version},
+      else: {name, version, path: path}
   end
 
   defp description do

--- a/packages/raxol_plugin/test/raxol/plugin_test.exs
+++ b/packages/raxol_plugin/test/raxol/plugin_test.exs
@@ -68,12 +68,16 @@ defmodule Raxol.PluginTest do
 
     test "handle_command/3 can be overridden" do
       {:ok, state} = CustomPlugin.init(%{})
-      assert {:ok, _state, "Hello, World!"} = CustomPlugin.handle_command(:greet, ["World"], state)
+
+      assert {:ok, _state, "Hello, World!"} =
+               CustomPlugin.handle_command(:greet, ["World"], state)
     end
 
     test "handle_command/3 can return errors" do
       {:ok, state} = CustomPlugin.init(%{})
-      assert {:error, :intentional_failure, _state} = CustomPlugin.handle_command(:fail, [], state)
+
+      assert {:error, :intentional_failure, _state} =
+               CustomPlugin.handle_command(:fail, [], state)
     end
 
     test "get_commands/0 can be overridden" do

--- a/packages/raxol_sensor/lib/raxol/sensor/feed.ex
+++ b/packages/raxol_sensor/lib/raxol/sensor/feed.ex
@@ -103,9 +103,7 @@ defmodule Raxol.Sensor.Feed do
 
   @impl true
   def handle_continue(:connect, %__MODULE__{} = state) do
-    case state.module.connect(
-           [sensor_id: state.sensor_id] ++ state.connect_opts
-         ) do
+    case state.module.connect([sensor_id: state.sensor_id] ++ state.connect_opts) do
       {:ok, sensor_state} ->
         state = %__MODULE__{
           state
@@ -117,9 +115,7 @@ defmodule Raxol.Sensor.Feed do
         {:noreply, schedule_poll(state)}
 
       {:error, reason} ->
-        Logger.warning(
-          "Sensor #{state.sensor_id} connect failed: #{inspect(reason)}"
-        )
+        Logger.warning("Sensor #{state.sensor_id} connect failed: #{inspect(reason)}")
 
         state = %__MODULE__{state | status: :error}
         {:noreply, schedule_backoff(state)}

--- a/packages/raxol_sensor/lib/raxol/sensor/fusion.ex
+++ b/packages/raxol_sensor/lib/raxol/sensor/fusion.ex
@@ -86,16 +86,14 @@ defmodule Raxol.Sensor.Fusion do
   def handle_call({:subscribe, pid}, _from, %__MODULE__{} = state) do
     Process.monitor(pid)
 
-    {:reply, :ok,
-     %__MODULE__{state | subscribers: MapSet.put(state.subscribers, pid)}}
+    {:reply, :ok, %__MODULE__{state | subscribers: MapSet.put(state.subscribers, pid)}}
   end
 
   @impl true
   def handle_cast({:register_feed, sensor_id, feed_pid}, %__MODULE__{} = state) do
     Process.monitor(feed_pid)
 
-    {:noreply,
-     %__MODULE__{state | feeds: Map.put(state.feeds, sensor_id, feed_pid)}}
+    {:noreply, %__MODULE__{state | feeds: Map.put(state.feeds, sensor_id, feed_pid)}}
   end
 
   @impl true

--- a/packages/raxol_sensor/lib/raxol/sensor/hud.ex
+++ b/packages/raxol_sensor/lib/raxol/sensor/hud.ex
@@ -7,8 +7,7 @@ defmodule Raxol.Sensor.HUD do
   """
 
   @type cell ::
-          {non_neg_integer(), non_neg_integer(), String.t(), atom(), atom(),
-           map()}
+          {non_neg_integer(), non_neg_integer(), String.t(), atom(), atom(), map()}
   @type region ::
           {non_neg_integer(), non_neg_integer(), pos_integer(), pos_integer()}
 

--- a/packages/raxol_sensor/test/raxol/sensor/hud_overlay_test.exs
+++ b/packages/raxol_sensor/test/raxol/sensor/hud_overlay_test.exs
@@ -83,7 +83,13 @@ defmodule Raxol.Sensor.HUDOverlayTest do
 
       fused = %{
         sensors: %{
-          temp: %{values: %{value: 50.0}, quality: 1.0, latest_timestamp: 0, reading_count: 1, alerts: []}
+          temp: %{
+            values: %{value: 50.0},
+            quality: 1.0,
+            latest_timestamp: 0,
+            reading_count: 1,
+            alerts: []
+          }
         },
         fused_at: 0
       }
@@ -108,8 +114,20 @@ defmodule Raxol.Sensor.HUDOverlayTest do
 
       fused = %{
         sensors: %{
-          temp: %{values: %{value: 50.0}, quality: 1.0, latest_timestamp: 0, reading_count: 1, alerts: []},
-          prox: %{values: %{level: :high, bearing: 45}, quality: 1.0, latest_timestamp: 0, reading_count: 1, alerts: []}
+          temp: %{
+            values: %{value: 50.0},
+            quality: 1.0,
+            latest_timestamp: 0,
+            reading_count: 1,
+            alerts: []
+          },
+          prox: %{
+            values: %{level: :high, bearing: 45},
+            quality: 1.0,
+            latest_timestamp: 0,
+            reading_count: 1,
+            alerts: []
+          }
         },
         fused_at: 0
       }

--- a/packages/raxol_speech/lib/raxol/speech/recognizer.ex
+++ b/packages/raxol_speech/lib/raxol/speech/recognizer.ex
@@ -173,9 +173,7 @@ defmodule Raxol.Speech.Recognizer do
       e ->
         require Logger
 
-        Logger.warning(
-          "Failed to load Whisper model #{model_name}: #{Exception.message(e)}"
-        )
+        Logger.warning("Failed to load Whisper model #{model_name}: #{Exception.message(e)}")
 
         nil
     end

--- a/packages/raxol_speech/lib/raxol/speech/speaker.ex
+++ b/packages/raxol_speech/lib/raxol/speech/speaker.ex
@@ -66,7 +66,10 @@ defmodule Raxol.Speech.Speaker do
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
-  def handle_manager_info({:announcement_added, _ref, %{message: message, priority: :high}}, state) do
+  def handle_manager_info(
+        {:announcement_added, _ref, %{message: message, priority: :high}},
+        state
+      ) do
     if should_speak?() do
       state.tts_backend.stop()
 
@@ -82,7 +85,10 @@ defmodule Raxol.Speech.Speaker do
     {:noreply, state}
   end
 
-  def handle_manager_info({:announcement_added, _ref, %{message: message, priority: priority}}, state) do
+  def handle_manager_info(
+        {:announcement_added, _ref, %{message: message, priority: priority}},
+        state
+      ) do
     if should_speak?() do
       do_speak(state.tts_backend, message, %{source: :announcement, priority: priority})
     end

--- a/packages/raxol_speech/test/raxol/speech/input_adapter_property_test.exs
+++ b/packages/raxol_speech/test/raxol/speech/input_adapter_property_test.exs
@@ -8,14 +8,14 @@ defmodule Raxol.Speech.InputAdapterPropertyTest do
 
   describe "default command map" do
     property "every default phrase produces a :key event" do
-      check all phrase <- member_of(@default_keys) do
+      check all(phrase <- member_of(@default_keys)) do
         event = InputAdapter.translate(phrase)
         assert event.type == :key
       end
     end
 
     property "case-insensitive: upper-case forms match the lower-case command" do
-      check all phrase <- member_of(@default_keys) do
+      check all(phrase <- member_of(@default_keys)) do
         lower = InputAdapter.translate(phrase)
         upper = InputAdapter.translate(String.upcase(phrase))
         assert lower.type == upper.type
@@ -24,9 +24,11 @@ defmodule Raxol.Speech.InputAdapterPropertyTest do
     end
 
     property "leading/trailing whitespace is ignored" do
-      check all phrase <- member_of(@default_keys),
-                pad_left <- string([?\s, ?\t], max_length: 5),
-                pad_right <- string([?\s, ?\t], max_length: 5) do
+      check all(
+              phrase <- member_of(@default_keys),
+              pad_left <- string([?\s, ?\t], max_length: 5),
+              pad_right <- string([?\s, ?\t], max_length: 5)
+            ) do
         bare = InputAdapter.translate(phrase)
         padded = InputAdapter.translate(pad_left <> phrase <> pad_right)
         assert bare.type == padded.type
@@ -37,10 +39,12 @@ defmodule Raxol.Speech.InputAdapterPropertyTest do
 
   describe "fallback to paste" do
     property "phrases not in the command map become :paste events with the trimmed text" do
-      check all text <- string(:alphanumeric, min_length: 1, max_length: 30),
-                lower = text |> String.trim() |> String.downcase(),
-                lower not in @default_keys,
-                lower != "" do
+      check all(
+              text <- string(:alphanumeric, min_length: 1, max_length: 30),
+              lower = text |> String.trim() |> String.downcase(),
+              lower not in @default_keys,
+              lower != ""
+            ) do
         event = InputAdapter.translate(text)
         assert event.type == :paste
         assert event.data.text == String.trim(text)
@@ -48,7 +52,7 @@ defmodule Raxol.Speech.InputAdapterPropertyTest do
     end
 
     property "empty / whitespace-only inputs return nil" do
-      check all ws <- string([?\s, ?\t, ?\n], max_length: 10) do
+      check all(ws <- string([?\s, ?\t, ?\n], max_length: 10)) do
         assert InputAdapter.translate(ws) == nil
       end
     end
@@ -56,11 +60,13 @@ defmodule Raxol.Speech.InputAdapterPropertyTest do
 
   describe "merge semantics" do
     property "custom keys not in defaults produce events from the custom map" do
-      check all phrase <- string(:alphanumeric, min_length: 1, max_length: 12),
-                normalized = phrase |> String.trim() |> String.downcase(),
-                normalized not in @default_keys,
-                normalized != "",
-                char <- string(:alphanumeric, length: 1) do
+      check all(
+              phrase <- string(:alphanumeric, min_length: 1, max_length: 12),
+              normalized = phrase |> String.trim() |> String.downcase(),
+              normalized not in @default_keys,
+              normalized != "",
+              char <- string(:alphanumeric, length: 1)
+            ) do
         custom = %{normalized => {:key, %{key: :char, char: char}}}
         event = InputAdapter.translate(phrase, commands: custom)
         assert event.type == :key
@@ -69,9 +75,11 @@ defmodule Raxol.Speech.InputAdapterPropertyTest do
     end
 
     property "default phrases are preserved when not overridden" do
-      check all phrase <- member_of(@default_keys),
-                other_phrase <- string(:alphanumeric, min_length: 1, max_length: 12),
-                other_phrase != phrase do
+      check all(
+              phrase <- member_of(@default_keys),
+              other_phrase <- string(:alphanumeric, min_length: 1, max_length: 12),
+              other_phrase != phrase
+            ) do
         custom = %{other_phrase => {:key, %{key: :enter}}}
         bare = InputAdapter.translate(phrase)
         merged = InputAdapter.translate(phrase, commands: custom)
@@ -81,12 +89,15 @@ defmodule Raxol.Speech.InputAdapterPropertyTest do
     end
 
     property "malformed :commands option falls back to defaults" do
-      check all malformed <- one_of([
+      check all(
+              malformed <-
+                one_of([
                   constant(nil),
                   integer(),
                   string(:alphanumeric),
                   list_of(atom(:alphanumeric))
-                ]) do
+                ])
+            ) do
         event = InputAdapter.translate("quit", commands: malformed)
         assert event.type == :key
         assert event.data.char == "q"

--- a/packages/raxol_speech/test/raxol/speech/sanitize_property_test.exs
+++ b/packages/raxol_speech/test/raxol/speech/sanitize_property_test.exs
@@ -9,7 +9,7 @@ defmodule Raxol.Speech.TTS.SanitizePropertyTest do
 
   describe "strip_control_chars/1" do
     property "output contains no control characters for any input" do
-      check all input <- string(:utf8) do
+      check all(input <- string(:utf8)) do
         output = Sanitize.strip_control_chars(input)
 
         for cp <- @control_chars do
@@ -20,13 +20,13 @@ defmodule Raxol.Speech.TTS.SanitizePropertyTest do
     end
 
     property "output is never longer than input (in bytes)" do
-      check all input <- string(:utf8) do
+      check all(input <- string(:utf8)) do
         assert byte_size(Sanitize.strip_control_chars(input)) <= byte_size(input)
       end
     end
 
     property "ASCII printable text passes through verbatim" do
-      check all input <- string(:printable) do
+      check all(input <- string(:printable)) do
         # :printable includes \t, \n, \r, and printable ASCII; only \r is not
         # in the strip set, so filter input to characters the sanitizer keeps.
         kept = String.replace(input, ~r/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/, "")
@@ -35,8 +35,10 @@ defmodule Raxol.Speech.TTS.SanitizePropertyTest do
     end
 
     property "tabs and newlines are preserved" do
-      check all prefix <- string(:alphanumeric, max_length: 10),
-                suffix <- string(:alphanumeric, max_length: 10) do
+      check all(
+              prefix <- string(:alphanumeric, max_length: 10),
+              suffix <- string(:alphanumeric, max_length: 10)
+            ) do
         input = prefix <> "\t\n" <> suffix
         output = Sanitize.strip_control_chars(input)
         assert String.contains?(output, "\t")
@@ -45,7 +47,7 @@ defmodule Raxol.Speech.TTS.SanitizePropertyTest do
     end
 
     property "idempotent: strip(strip(x)) == strip(x)" do
-      check all input <- string(:utf8) do
+      check all(input <- string(:utf8)) do
         once = Sanitize.strip_control_chars(input)
         twice = Sanitize.strip_control_chars(once)
         assert once == twice
@@ -53,9 +55,11 @@ defmodule Raxol.Speech.TTS.SanitizePropertyTest do
     end
 
     property "control chars at any position are removed" do
-      check all left <- string(:alphanumeric, max_length: 5),
-                right <- string(:alphanumeric, max_length: 5),
-                cp <- member_of(@control_chars) do
+      check all(
+              left <- string(:alphanumeric, max_length: 5),
+              right <- string(:alphanumeric, max_length: 5),
+              cp <- member_of(@control_chars)
+            ) do
         input = left <> <<cp::utf8>> <> right
         output = Sanitize.strip_control_chars(input)
         refute String.contains?(output, <<cp::utf8>>)

--- a/packages/raxol_speech/test/raxol/speech/speaker_interrupt_test.exs
+++ b/packages/raxol_speech/test/raxol/speech/speaker_interrupt_test.exs
@@ -23,34 +23,29 @@ defmodule Raxol.Speech.SpeakerInterruptTest do
 
   describe "priority interrupt" do
     test "high-priority announcement calls stop/0 before speak/1" do
-      send(Speaker, {:announcement_added, make_ref(),
-                     %{message: "URGENT", priority: :high}})
+      send(Speaker, {:announcement_added, make_ref(), %{message: "URGENT", priority: :high}})
 
       assert :ok = wait_for_calls(2)
       assert [:stop, {:speak, "URGENT"}] = Tracking.calls()
     end
 
     test "normal-priority announcement does NOT call stop/0 first" do
-      send(Speaker, {:announcement_added, make_ref(),
-                     %{message: "info", priority: :normal}})
+      send(Speaker, {:announcement_added, make_ref(), %{message: "info", priority: :normal}})
 
       assert :ok = wait_for_calls(1)
       assert [{:speak, "info"}] = Tracking.calls()
     end
 
     test "back-to-back high-priority announcements each interrupt" do
-      send(Speaker, {:announcement_added, make_ref(),
-                     %{message: "first", priority: :high}})
-      send(Speaker, {:announcement_added, make_ref(),
-                     %{message: "second", priority: :high}})
+      send(Speaker, {:announcement_added, make_ref(), %{message: "first", priority: :high}})
+      send(Speaker, {:announcement_added, make_ref(), %{message: "second", priority: :high}})
 
       assert :ok = wait_for_calls(4)
       assert [:stop, {:speak, "first"}, :stop, {:speak, "second"}] = Tracking.calls()
     end
 
     test "low-priority announcement is treated as normal (no interrupt)" do
-      send(Speaker, {:announcement_added, make_ref(),
-                     %{message: "low", priority: :low}})
+      send(Speaker, {:announcement_added, make_ref(), %{message: "low", priority: :low}})
 
       assert :ok = wait_for_calls(1)
       assert [{:speak, "low"}] = Tracking.calls()

--- a/packages/raxol_speech/test/raxol/speech/telemetry_test.exs
+++ b/packages/raxol_speech/test/raxol/speech/telemetry_test.exs
@@ -29,8 +29,7 @@ defmodule Raxol.Speech.TelemetryTest do
       assert_receive {[:raxol_speech, :tts, :speak, :start], _ref, _,
                       %{source: :api, backend: Noop, byte_size: 5}}
 
-      assert_receive {[:raxol_speech, :tts, :speak, :stop], _ref,
-                      %{duration: duration},
+      assert_receive {[:raxol_speech, :tts, :speak, :stop], _ref, %{duration: duration},
                       %{source: :api, backend: Noop, result: :ok}}
 
       assert is_integer(duration) and duration >= 0
@@ -46,8 +45,10 @@ defmodule Raxol.Speech.TelemetryTest do
 
   describe "announcement-driven speech" do
     test "normal-priority announcement emits a :speak span with announcement source" do
-      send(Speaker, {:announcement_added, make_ref(),
-                     %{message: "build complete", priority: :normal}})
+      send(
+        Speaker,
+        {:announcement_added, make_ref(), %{message: "build complete", priority: :normal}}
+      )
 
       assert_receive {[:raxol_speech, :tts, :speak, :start], _, _,
                       %{source: :announcement, priority: :normal}}
@@ -56,8 +57,10 @@ defmodule Raxol.Speech.TelemetryTest do
     end
 
     test "high-priority announcement emits :interrupted before the :speak span" do
-      send(Speaker, {:announcement_added, make_ref(),
-                     %{message: "build failed", priority: :high}})
+      send(
+        Speaker,
+        {:announcement_added, make_ref(), %{message: "build failed", priority: :high}}
+      )
 
       assert_receive {[:raxol_speech, :tts, :interrupted], _, _,
                       %{priority: :high, backend: Noop}}

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/character_translations.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/character_translations.ex
@@ -4,7 +4,6 @@ defmodule Raxol.Terminal.ANSI.CharacterTranslations do
   Maps characters between different character sets according to ANSI standards.
   """
 
-
   # US ASCII character set (G0)
   @us_ascii_map %{
                   # Control characters (0x00-0x1F) are not translated

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/sequences/colors.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/sequences/colors.ex
@@ -7,8 +7,7 @@ defmodule Raxol.Terminal.ANSI.Sequences.Colors do
   """
 
   # Style.Colors lives in main raxol; guarded at runtime
-  @compile {:no_warn_undefined,
-            [Raxol.Style.Colors.Advanced, Raxol.Style.Colors.Color]}
+  @compile {:no_warn_undefined, [Raxol.Style.Colors.Advanced, Raxol.Style.Colors.Color]}
 
   alias Raxol.Terminal.ANSI.TextFormatting
 

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/state_machine.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/state_machine.ex
@@ -4,7 +4,6 @@ defmodule Raxol.Terminal.ANSI.StateMachine do
   This module provides a more efficient alternative to regex-based parsing.
   """
 
-
   # Guard macros for ANSI byte classification
   defmacro param_byte?(byte),
     do: quote(do: unquote(byte) >= ?0 and unquote(byte) <= ?9)

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/text_formatting.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/text_formatting.ex
@@ -360,6 +360,7 @@ defmodule Raxol.Terminal.ANSI.TextFormatting do
   @impl true
   def get_background(style), do: Core.get_background(style)
   def set_underline_color(style, color), do: Core.set_underline_color(style, color)
+
   def set_underline_style(style, underline_style),
     do: Core.set_underline_style(style, underline_style)
 

--- a/packages/raxol_terminal/lib/raxol/terminal/buffer/scroll_region.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/buffer/scroll_region.ex
@@ -19,7 +19,6 @@ defmodule Raxol.Terminal.Buffer.ScrollRegion do
   * Managing content within the region
   """
 
-
   alias Raxol.Terminal.Cell
   alias Raxol.Terminal.ScreenBuffer
   alias Raxol.Terminal.ScreenBuffer.Core, as: ScreenBufferCore

--- a/packages/raxol_terminal/lib/raxol/terminal/buffer/scroller.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/buffer/scroller.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Terminal.Buffer.Scroller do
   Handles scrolling operations for the terminal buffer.
   """
 
-
   alias Raxol.Terminal.ScreenBuffer
 
   @doc """

--- a/packages/raxol_terminal/lib/raxol/terminal/color/true_color.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/color/true_color.ex
@@ -32,7 +32,6 @@ defmodule Raxol.Terminal.Color.TrueColor do
       accessible? = TrueColor.wcag_compliant?(red, blue, :aa)
   """
 
-
   @compile {:no_warn_undefined, Raxol.Terminal.Color.TrueColor.Conversion}
   @compile {:no_warn_undefined, Raxol.Terminal.Color.TrueColor.Detection}
   @compile {:no_warn_undefined, Raxol.Terminal.Color.TrueColor.Palette}

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/command_server.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/command_server.ex
@@ -11,7 +11,6 @@ defmodule Raxol.Terminal.Commands.CommandServer do
   - `CommandServer.BufferLineOps` -- insert/delete lines with scroll regions
   """
 
-
   alias Raxol.Terminal.Commands.CommandServer.{
     BufferLineOps,
     CursorOps,

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/command_server/buffer_line_ops.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/command_server/buffer_line_ops.ex
@@ -2,7 +2,6 @@ defmodule Raxol.Terminal.Commands.CommandServer.BufferLineOps do
   @moduledoc false
   @compile {:no_warn_undefined, Raxol.Terminal.Commands.CommandServer.Helpers}
 
-
   alias Raxol.Terminal.Cell
   alias Raxol.Terminal.Commands.CommandServer.Helpers
   alias Raxol.Terminal.Emulator

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/command_server/device_ops.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/command_server/device_ops.ex
@@ -2,7 +2,6 @@ defmodule Raxol.Terminal.Commands.CommandServer.DeviceOps do
   @moduledoc false
   @compile {:no_warn_undefined, Raxol.Terminal.Commands.CommandServer.Helpers}
 
-
   alias Raxol.Terminal.Commands.CommandServer.Helpers
   alias Raxol.Terminal.OutputManager
 

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/command_server/erase_ops.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/command_server/erase_ops.ex
@@ -2,7 +2,6 @@ defmodule Raxol.Terminal.Commands.CommandServer.EraseOps do
   @moduledoc false
   @compile {:no_warn_undefined, Raxol.Terminal.Commands.CommandServer.Helpers}
 
-
   alias Raxol.Terminal.Buffer.Eraser
   alias Raxol.Terminal.Commands.CommandServer.Helpers
 

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/commands_parser.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/commands_parser.ex
@@ -49,7 +49,6 @@ defmodule Raxol.Terminal.Commands.CommandsParser do
     end
   end
 
-
   defp parse_subparam(""), do: nil
   defp parse_subparam(subparam), do: parse_int(subparam)
 

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/csi_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/csi_handler.ex
@@ -311,8 +311,7 @@ defmodule Raxol.Terminal.Commands.CSIHandler do
 
   def handle_bracketed_paste_start(emulator) do
     if emulator.mode_manager.bracketed_paste_mode do
-      {:ok,
-       %{emulator | bracketed_paste_active: true, bracketed_paste_buffer: ""}}
+      {:ok, %{emulator | bracketed_paste_active: true, bracketed_paste_buffer: ""}}
     else
       {:ok, emulator}
     end
@@ -320,8 +319,7 @@ defmodule Raxol.Terminal.Commands.CSIHandler do
 
   def handle_bracketed_paste_end(emulator) do
     if emulator.bracketed_paste_active do
-      {:ok,
-       %{emulator | bracketed_paste_active: false, bracketed_paste_buffer: ""}}
+      {:ok, %{emulator | bracketed_paste_active: false, bracketed_paste_buffer: ""}}
     else
       {:ok, emulator}
     end

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/manager.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/manager.ex
@@ -6,7 +6,6 @@ defmodule Raxol.Terminal.Commands.Manager do
   This module is responsible for handling command parsing, validation, and execution.
   """
 
-
   alias Raxol.Terminal.Commands.Command
   alias Raxol.Terminal.Emulator
 

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/osc_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/osc_handler.ex
@@ -432,9 +432,7 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
               if color_spec == "" do
                 {:reset, index}
               else
-                case Raxol.Terminal.Commands.OSCHandler.ColorParser.parse(
-                       color_spec
-                     ) do
+                case Raxol.Terminal.Commands.OSCHandler.ColorParser.parse(color_spec) do
                   {:ok, color} -> {:set, index, color}
                   error -> error
                 end
@@ -634,8 +632,7 @@ defmodule Raxol.Terminal.Commands.OSCHandler do
         [family, size, style] ->
           case Integer.parse(size) do
             {size_val, ""} ->
-              {:ok,
-               %{family: family, size: size_val, style: parse_style(style)}}
+              {:ok, %{family: family, size: size_val, style: parse_style(style)}}
 
             _ ->
               {:error, :invalid_size}

--- a/packages/raxol_terminal/lib/raxol/terminal/commands/parameter_validation.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/commands/parameter_validation.ex
@@ -1,7 +1,6 @@
 defmodule Raxol.Terminal.Commands.ParameterValidation do
   @moduledoc false
 
-
   @spec get_valid_param(
           list(integer() | nil),
           non_neg_integer(),

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/dispatch.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/dispatch.ex
@@ -55,9 +55,7 @@ defmodule Raxol.Terminal.Driver.Dispatch do
   Parses test input data into an Event struct.
   """
   def parse_test_input(input_data) when is_binary(input_data) do
-    Log.debug(
-      "[TerminalDriver.parse_test_input] Parsing: #{inspect(input_data)}"
-    )
+    Log.debug("[TerminalDriver.parse_test_input] Parsing: #{inspect(input_data)}")
 
     case InputParser.parse(input_data) do
       [event | _] -> event

--- a/packages/raxol_terminal/lib/raxol/terminal/driver/termbox_lifecycle.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/driver/termbox_lifecycle.ex
@@ -53,9 +53,7 @@ defmodule Raxol.Terminal.Driver.TermboxLifecycle do
             {:noreply, state}
 
           {:error, init_reason} ->
-            Log.error(
-              "Failed to recover from termbox error: #{inspect(init_reason)}"
-            )
+            Log.error("Failed to recover from termbox error: #{inspect(init_reason)}")
 
             {:stop, {:termbox_error, reason}, state}
         end

--- a/packages/raxol_terminal/lib/raxol/terminal/emulator/ansi_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/emulator/ansi_handler.ex
@@ -186,7 +186,6 @@ defmodule Raxol.Terminal.Emulator.ANSIHandler do
          {:cursor_horizontal_absolute, col, remaining},
          emulator
        ) do
-
     Raxol.Core.Runtime.Log.debug(
       "handle_sequence_type cursor_horizontal_absolute col=#{inspect(col)}"
     )

--- a/packages/raxol_terminal/lib/raxol/terminal/emulator/command_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/emulator/command_handler.ex
@@ -590,7 +590,6 @@ defmodule Raxol.Terminal.Emulator.CommandHandler do
   defp extract_emulator(emulator), do: emulator
 
   defp handle_csi_command(final_byte, params, emulator, intermediates) do
-
     Raxol.Core.Runtime.Log.debug(
       "handle_csi_command: final_byte=#{inspect(final_byte)}, params=#{inspect(params)}"
     )

--- a/packages/raxol_terminal/lib/raxol/terminal/emulator/style.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/emulator/style.ex
@@ -4,7 +4,6 @@ defmodule Raxol.Terminal.Emulator.Style do
   Provides functions for managing character attributes, colors, and text formatting.
   """
 
-
   alias Raxol.Terminal.ANSI.TextFormatting
   alias Raxol.Terminal.Emulator.Struct, as: EmulatorStruct
   @behaviour Raxol.Terminal.Emulator.Style.Behaviour

--- a/packages/raxol_terminal/lib/raxol/terminal/escape/parsers/base_parser.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/escape/parsers/base_parser.ex
@@ -5,7 +5,6 @@ defmodule Raxol.Terminal.Escape.Parsers.BaseParser do
   Provides common functionality for logging and handling unknown sequences.
   """
 
-
   @doc """
   Logs an unknown escape sequence for debugging purposes.
 

--- a/packages/raxol_terminal/lib/raxol/terminal/event_processor.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/event_processor.ex
@@ -10,7 +10,6 @@ defmodule Raxol.Terminal.EventProcessor do
   - Performance monitoring integration
   """
 
-
   alias Raxol.Core.Events.Event
   alias Raxol.Terminal.Emulator
   alias Raxol.Terminal.Events.Handler

--- a/packages/raxol_terminal/lib/raxol/terminal/input/character_processor.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/input/character_processor.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Terminal.Input.CharacterProcessor do
   Handles character processing, translation, and writing to the terminal buffer.
   """
 
-
   alias Raxol.Terminal.ANSI.CharacterSets
   alias Raxol.Terminal.{CharacterHandling, Emulator, ScreenBuffer}
   alias Raxol.Terminal.ModeManager

--- a/packages/raxol_terminal/lib/raxol/terminal/input/control_sequence_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/input/control_sequence_handler.ex
@@ -13,7 +13,6 @@ defmodule Raxol.Terminal.Input.ControlSequenceHandler do
   Where `G` indicates Kitty graphics and control-data contains key=value pairs.
   """
 
-
   alias Raxol.Terminal.ANSI.KittyGraphics
   alias Raxol.Terminal.Commands.{CSIHandler, OSCHandler}
 

--- a/packages/raxol_terminal/lib/raxol/terminal/integration/integration_config.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/integration/integration_config.ex
@@ -5,7 +5,6 @@ defmodule Raxol.Terminal.Integration.Config do
 
   @default_scrollback Raxol.Core.Defaults.scrollback_limit()
 
-
   alias Raxol.Terminal.{
     Config,
     Rendering.RenderServer,

--- a/packages/raxol_terminal/lib/raxol/terminal/io/io_server.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/io/io_server.ex
@@ -578,7 +578,6 @@ defmodule Raxol.Terminal.IO.IOServer do
     handle_buffer_manager_resize(buffer_manager, state, width, height)
   end
 
-
   defp handle_buffer_manager_resize(buffer_manager, state, width, height) do
     # Update buffer manager
     new_buffer_manager = Manager.resize(buffer_manager, width, height)

--- a/packages/raxol_terminal/lib/raxol/terminal/mode_state.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/mode_state.ex
@@ -9,7 +9,6 @@ defmodule Raxol.Terminal.ModeState do
   - Providing mode state queries
   """
 
-
   # DEC Private Mode codes and their corresponding mode atoms
   @dec_private_modes %{
     # Cursor Keys Mode

--- a/packages/raxol_terminal/lib/raxol/terminal/modes/handlers/mouse_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/modes/handlers/mouse_handler.ex
@@ -4,7 +4,6 @@ defmodule Raxol.Terminal.Modes.Handlers.MouseHandler do
   Manages different mouse reporting modes and their effects on the terminal.
   """
 
-
   alias Raxol.Terminal.Emulator
   alias Raxol.Terminal.Modes.Types.ModeTypes
 

--- a/packages/raxol_terminal/lib/raxol/terminal/modes/handlers/screen_buffer_handler.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/modes/handlers/screen_buffer_handler.ex
@@ -4,7 +4,6 @@ defmodule Raxol.Terminal.Modes.Handlers.ScreenBufferHandler do
   Manages alternate screen buffer switching and related functionality.
   """
 
-
   alias Raxol.Terminal.ANSI.TextFormatting
   alias Raxol.Terminal.Emulator
   alias Raxol.Terminal.ModeManager

--- a/packages/raxol_terminal/lib/raxol/terminal/parser/states/csi_entry_state.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/parser/states/csi_entry_state.ex
@@ -27,7 +27,6 @@ defmodule Raxol.Terminal.Parser.States.CSIEntryState do
   end
 
   defp dispatch_byte(byte, data) do
-
     Raxol.Core.Runtime.Log.warning("Invalid byte in CSI Entry state: #{inspect(byte)}")
 
     {:ground, data}

--- a/packages/raxol_terminal/lib/raxol/terminal/parser/states/dcs_passthrough_maybe_st_state.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/parser/states/dcs_passthrough_maybe_st_state.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Terminal.Parser.States.DCSPassthroughMaybeSTState do
   Handles the :dcs_passthrough_maybe_st state of the terminal parser.
   """
 
-
   alias Raxol.Terminal.Commands.Executor
   alias Raxol.Terminal.Emulator
   alias Raxol.Terminal.Parser.ParserState, as: State

--- a/packages/raxol_terminal/lib/raxol/terminal/parser/states/designate_charset_state.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/parser/states/designate_charset_state.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Terminal.Parser.States.DesignateCharsetState do
   Handles the :designate_charset state of the terminal parser.
   """
 
-
   alias Raxol.Terminal.ANSI.CharacterSets
   alias Raxol.Terminal.Emulator
   alias Raxol.Terminal.Parser.ParserState, as: State

--- a/packages/raxol_terminal/lib/raxol/terminal/parser/states/ground_state.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/parser/states/ground_state.ex
@@ -6,7 +6,6 @@ defmodule Raxol.Terminal.Parser.States.GroundState do
   alias Raxol.Terminal.Input.InputHandler
   alias Raxol.Terminal.TerminalParser, as: Parser
 
-
   @behaviour Raxol.Terminal.Parser.StateBehaviour
 
   @impl Raxol.Terminal.Parser.StateBehaviour

--- a/packages/raxol_terminal/lib/raxol/terminal/parser/states/osc_string_maybe_st_state.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/parser/states/osc_string_maybe_st_state.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Terminal.Parser.States.OSCStringMaybeSTState do
   Handles the :osc_string_maybe_st state of the terminal parser.
   """
 
-
   alias Raxol.Terminal.Commands.Executor
   alias Raxol.Terminal.Emulator
   alias Raxol.Terminal.Parser.ParserState, as: State

--- a/packages/raxol_terminal/lib/raxol/terminal/parser/states/osc_string_state.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/parser/states/osc_string_state.ex
@@ -4,7 +4,6 @@ defmodule Raxol.Terminal.Parser.States.OSCStringState do
   This state is entered when an OSC sequence is initiated.
   """
 
-
   alias Raxol.Terminal.Commands.Executor
   alias Raxol.Terminal.Emulator
   alias Raxol.Terminal.Parser.ParserState, as: State

--- a/packages/raxol_terminal/lib/raxol/terminal/parser_state_manager.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/parser_state_manager.ex
@@ -19,7 +19,6 @@ defmodule Raxol.Terminal.ParserStateManager do
   Use `create_parser_manager/0` instead of `Parser.State.Manager.new/0`
   """
 
-
   alias Raxol.Terminal.Parser.State.Manager, as: DetailedManager
   alias Raxol.Terminal.ParserState
 

--- a/packages/raxol_terminal/lib/raxol/terminal/registry.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/registry.ex
@@ -49,6 +49,7 @@ defmodule Raxol.Terminal.Registry do
         :set,
         read_concurrency: true
       ])
+
     {:ok, %{table: table, name: Keyword.get(opts, :name, __MODULE__)}}
   end
 

--- a/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/renderer.ex
@@ -464,18 +464,14 @@ defmodule Raxol.Terminal.Renderer do
   defp parse_hex_color("#" <> hex), do: parse_hex_digits(hex)
   defp parse_hex_color(hex) when is_binary(hex), do: parse_hex_digits(hex)
 
-  defp parse_hex_digits(
-         <<_::binary-size(2), _::binary-size(2), _::binary-size(2)>> = hex
-       ) do
+  defp parse_hex_digits(<<_::binary-size(2), _::binary-size(2), _::binary-size(2)>> = hex) do
     case Raxol.Terminal.Color.TrueColor.AnsiCodes.parse_hex_6(hex) do
       {:ok, r, g, b, _a} -> {:ok, r, g, b}
       {:error, _} -> :error
     end
   end
 
-  defp parse_hex_digits(
-         <<_::binary-size(1), _::binary-size(1), _::binary-size(1)>> = hex
-       ) do
+  defp parse_hex_digits(<<_::binary-size(1), _::binary-size(1), _::binary-size(1)>> = hex) do
     case Raxol.Terminal.Color.TrueColor.AnsiCodes.parse_hex_3(hex) do
       {:ok, r, g, b, _a} -> {:ok, r, g, b}
       {:error, _} -> :error

--- a/packages/raxol_terminal/lib/raxol/terminal/rendering/ligature_renderer.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/rendering/ligature_renderer.ex
@@ -45,7 +45,6 @@ defmodule Raxol.Terminal.Rendering.LigatureRenderer do
       has_ligatures? = LigatureRenderer.contains_ligatures?(text, config)
   """
 
-
   defstruct [
     :font,
     :enabled_sets,

--- a/packages/raxol_terminal/lib/raxol/terminal/screen_buffer/erase_operations.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/screen_buffer/erase_operations.ex
@@ -8,7 +8,6 @@ defmodule Raxol.Terminal.ScreenBuffer.EraseOperations do
 
   @default_height Raxol.Core.Defaults.terminal_height()
 
-
   alias Raxol.Terminal.Cell
   alias Raxol.Terminal.Buffer.CharEditor
   alias Raxol.Terminal.ScreenBuffer

--- a/packages/raxol_terminal/lib/raxol/terminal/session.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/session.ex
@@ -16,7 +16,6 @@ defmodule Raxol.Terminal.Session do
 
   use Raxol.Core.Behaviours.BaseManager
 
-
   alias Raxol.Terminal.Env
 
   alias Raxol.Terminal.Emulator.Struct, as: EmulatorStruct
@@ -325,9 +324,7 @@ defmodule Raxol.Terminal.Session do
       :ok
   catch
     :exit, reason ->
-      Raxol.Core.Runtime.Log.error(
-        "Failed to register session #{id}: #{inspect(reason)}"
-      )
+      Raxol.Core.Runtime.Log.error("Failed to register session #{id}: #{inspect(reason)}")
 
       :ok
   end

--- a/packages/raxol_terminal/lib/raxol/terminal/terminal_parser.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/terminal_parser.ex
@@ -4,7 +4,6 @@ defmodule Raxol.Terminal.TerminalParser do
   Handles escape sequences (CSI, OSC, DCS, etc.) and plain text.
   """
 
-
   alias Raxol.Terminal.Parser.States.CSIEntryState
   alias Raxol.Terminal.Parser.States.CSIIntermediateState
   alias Raxol.Terminal.Parser.States.CSIParamState

--- a/packages/raxol_terminal/lib/raxol/terminal/terminal_utils.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/terminal_utils.ex
@@ -138,9 +138,7 @@ defmodule Raxol.Terminal.TerminalUtils do
              {:ok, width, height}
            else
              {:error, reason} ->
-               Raxol.Core.Runtime.Log.debug(
-                 "io.columns/rows error: #{inspect(reason)}"
-               )
+               Raxol.Core.Runtime.Log.debug("io.columns/rows error: #{inspect(reason)}")
 
                {:error, reason}
 
@@ -156,9 +154,7 @@ defmodule Raxol.Terminal.TerminalUtils do
         result
 
       {:error, reason} ->
-        Raxol.Core.Runtime.Log.debug(
-          "Error in detect_with_io: #{inspect(reason)}"
-        )
+        Raxol.Core.Runtime.Log.debug("Error in detect_with_io: #{inspect(reason)}")
 
         {:error, reason}
     end
@@ -212,9 +208,7 @@ defmodule Raxol.Terminal.TerminalUtils do
                end
 
              {output, code} ->
-               Raxol.Core.Runtime.Log.debug(
-                 "stty exited with code #{code}: #{inspect(output)}"
-               )
+               Raxol.Core.Runtime.Log.debug("stty exited with code #{code}: #{inspect(output)}")
 
                {:error, {:exit_code, code}}
            end
@@ -223,9 +217,7 @@ defmodule Raxol.Terminal.TerminalUtils do
         result
 
       {:error, reason} ->
-        Raxol.Core.Runtime.Log.debug(
-          "Error in detect_with_stty: #{inspect(reason)}"
-        )
+        Raxol.Core.Runtime.Log.debug("Error in detect_with_stty: #{inspect(reason)}")
 
         {:error, reason}
     end

--- a/packages/raxol_terminal/lib/raxol/terminal/window/manager/window_manager_server.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/window/manager/window_manager_server.ex
@@ -34,7 +34,6 @@ defmodule Raxol.Terminal.Window.Manager.WindowManagerServer do
 
   use Raxol.Core.Behaviours.BaseManager
 
-
   alias Raxol.Terminal.{Config, Window}
   alias Raxol.Terminal.Window.Manager.{NavigationOps, StateOps}
 

--- a/packages/raxol_terminal/test/raxol/terminal/commands/csi_handlers_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/commands/csi_handlers_test.exs
@@ -277,8 +277,7 @@ defmodule Raxol.Terminal.Commands.CSIHandlerTest do
     setup %{emulator: emulator} do
       {:ok,
        emulator: emulator,
-       buffer_height:
-         ScreenBuffer.get_height(Emulator.get_screen_buffer(emulator))}
+       buffer_height: ScreenBuffer.get_height(Emulator.get_screen_buffer(emulator))}
     end
 
     test "sets a valid scrolling region and moves cursor to home", %{

--- a/packages/raxol_terminal/test/raxol/terminal/driver/capabilities_probe_integration_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver/capabilities_probe_integration_test.exs
@@ -79,27 +79,27 @@ defmodule Raxol.Terminal.Driver.CapabilitiesProbeIntegrationTest do
       # Keystrokes survive, in order, none dropped, none duplicated, none
       # reordered relative to the replies they rode alongside.
       assert_receive {:"$gen_cast",
-                       {:dispatch, %Event{type: :key, data: %{key: :char, char: "a"}}}}
+                      {:dispatch, %Event{type: :key, data: %{key: :char, char: "a"}}}}
 
       assert_receive {:"$gen_cast",
-                       {:dispatch, %Event{type: :key, data: %{key: :char, char: "b"}}}}
+                      {:dispatch, %Event{type: :key, data: %{key: :char, char: "b"}}}}
 
       assert_receive {:"$gen_cast",
-                       {:dispatch, %Event{type: :key, data: %{key: :char, char: "c"}}}}
+                      {:dispatch, %Event{type: :key, data: %{key: :char, char: "c"}}}}
 
       # Compat side effect #1: the old OSC 11 background event, preserved
       # verbatim for existing consumers.
       assert_receive {:"$gen_cast",
-                       {:dispatch,
-                        %Event{type: :terminal_background, data: %{color: {16, 16, 16}}}}}
+                      {:dispatch,
+                       %Event{type: :terminal_background, data: %{color: {16, 16, 16}}}}}
 
       # New side effect: the full classified capabilities record.
       assert_receive {:"$gen_cast",
-                       {:dispatch,
-                        %Event{
-                          type: :terminal_capabilities,
-                          data: %{capabilities: %Capabilities{} = caps}
-                        }}}
+                      {:dispatch,
+                       %Event{
+                         type: :terminal_capabilities,
+                         data: %{capabilities: %Capabilities{} = caps}
+                       }}}
 
       assert caps.background == {16, 16, 16}
       assert caps.foreground == {232, 232, 232}
@@ -131,7 +131,7 @@ defmodule Raxol.Terminal.Driver.CapabilitiesProbeIntegrationTest do
       send(driver_pid, {:raw_input, "x"})
 
       assert_receive {:"$gen_cast",
-                       {:dispatch, %Event{type: :key, data: %{key: :char, char: "x"}}}}
+                      {:dispatch, %Event{type: :key, data: %{key: :char, char: "x"}}}}
 
       GenServer.stop(driver_pid)
     end
@@ -145,11 +145,11 @@ defmodule Raxol.Terminal.Driver.CapabilitiesProbeIntegrationTest do
       send(driver_pid, :capabilities_probe_clock)
 
       assert_receive {:"$gen_cast",
-                       {:dispatch,
-                        %Event{
-                          type: :terminal_capabilities,
-                          data: %{capabilities: %Capabilities{} = caps}
-                        }}}
+                      {:dispatch,
+                       %Event{
+                         type: :terminal_capabilities,
+                         data: %{capabilities: %Capabilities{} = caps}
+                       }}}
 
       assert caps.background == nil
       assert caps.foreground == nil
@@ -176,11 +176,11 @@ defmodule Raxol.Terminal.Driver.CapabilitiesProbeIntegrationTest do
       send(driver_pid, :capabilities_probe_clock)
 
       assert_receive {:"$gen_cast",
-                       {:dispatch,
-                        %Event{
-                          type: :terminal_capabilities,
-                          data: %{capabilities: %Capabilities{} = caps}
-                        }}}
+                      {:dispatch,
+                       %Event{
+                         type: :terminal_capabilities,
+                         data: %{capabilities: %Capabilities{} = caps}
+                       }}}
 
       assert caps.tier == :core_minus
       assert caps.background == nil
@@ -204,11 +204,11 @@ defmodule Raxol.Terminal.Driver.CapabilitiesProbeIntegrationTest do
       send(driver_pid, :capabilities_probe_clock)
 
       assert_receive {:"$gen_cast",
-                       {:dispatch,
-                        %Event{
-                          type: :terminal_capabilities,
-                          data: %{capabilities: %Capabilities{}}
-                        }}}
+                      {:dispatch,
+                       %Event{
+                         type: :terminal_capabilities,
+                         data: %{capabilities: %Capabilities{}}
+                       }}}
 
       # The probe is done; its job is over. A later, wholly unrelated lone
       # ESC keystroke (its own chunk, no more bytes behind it -- exactly
@@ -217,8 +217,7 @@ defmodule Raxol.Terminal.Driver.CapabilitiesProbeIntegrationTest do
       # "partial" and discarded on the next chunk.
       send(driver_pid, {:raw_input, "\e"})
 
-      assert_receive {:"$gen_cast",
-                       {:dispatch, %Event{type: :key, data: %{key: :escape}}}}
+      assert_receive {:"$gen_cast", {:dispatch, %Event{type: :key, data: %{key: :escape}}}}
 
       assert Process.alive?(driver_pid)
       GenServer.stop(driver_pid)

--- a/packages/raxol_terminal/test/raxol/terminal/driver/terminal_report_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver/terminal_report_test.exs
@@ -57,8 +57,7 @@ defmodule Raxol.Terminal.Driver.TerminalReportTest do
 
       send(driver_pid, {:raw_input, "\e[>0;282;0c\e[B"})
 
-      assert_receive {:"$gen_cast",
-                      {:dispatch, %Event{type: :key, data: %{key: :down}}}},
+      assert_receive {:"$gen_cast", {:dispatch, %Event{type: :key, data: %{key: :down}}}},
                      500
 
       refute_receive {:"$gen_cast", {:dispatch, %Event{type: :key}}}, 200

--- a/packages/raxol_terminal/test/raxol/terminal/driver_io_terminal_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/driver_io_terminal_test.exs
@@ -15,8 +15,7 @@ defmodule Raxol.Terminal.DriverIOTerminalTest do
 
   describe "Driver with IOTerminal backend" do
     if @termbox_available do
-      @tag skip:
-             "termbox2 NIF loaded; Driver only falls back to IOTerminal without it"
+      @tag skip: "termbox2 NIF loaded; Driver only falls back to IOTerminal without it"
     end
 
     test "initializes with IOTerminal when termbox2_nif not available" do
@@ -44,8 +43,7 @@ defmodule Raxol.Terminal.DriverIOTerminalTest do
     end
 
     if @termbox_available do
-      @tag skip:
-             "termbox2 NIF loaded; IOTerminal size fallback not reachable here"
+      @tag skip: "termbox2 NIF loaded; IOTerminal size fallback not reachable here"
     end
 
     test "Driver uses IOTerminal for size detection when termbox unavailable" do
@@ -60,8 +58,7 @@ defmodule Raxol.Terminal.DriverIOTerminalTest do
 
   describe "IOTerminal fallback behavior" do
     if @termbox_available do
-      @describetag skip:
-                     "termbox2 NIF loaded; IOTerminal-only fallback not reachable here"
+      @describetag skip: "termbox2 NIF loaded; IOTerminal-only fallback not reachable here"
     end
 
     test "get_termbox_width uses IOTerminal when NIF unavailable" do
@@ -106,8 +103,7 @@ defmodule Raxol.Terminal.DriverIOTerminalTest do
 
   describe "terminal operations without termbox2_nif" do
     if @termbox_available do
-      @describetag skip:
-                     "termbox2 NIF loaded; IOTerminal-only path not reachable here"
+      @describetag skip: "termbox2 NIF loaded; IOTerminal-only path not reachable here"
     end
 
     setup do

--- a/packages/raxol_terminal/test/raxol/terminal/renderer_integration_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/renderer_integration_test.exs
@@ -55,8 +55,7 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
   defp parse_hex("#" <> hex), do: parse_hex(hex)
 
   defp parse_hex(<<r::binary-size(2), g::binary-size(2), b::binary-size(2)>>) do
-    {String.to_integer(r, 16), String.to_integer(g, 16),
-     String.to_integer(b, 16)}
+    {String.to_integer(r, 16), String.to_integer(g, 16), String.to_integer(b, 16)}
   end
 
   describe "integration with Manipulation module" do
@@ -248,9 +247,7 @@ defmodule Raxol.Terminal.RendererIntegrationTest do
       text = "Red text"
 
       buffer =
-        Enum.reduce(Enum.with_index(String.graphemes(text)), buffer, fn {char,
-                                                                         col},
-                                                                        acc ->
+        Enum.reduce(Enum.with_index(String.graphemes(text)), buffer, fn {char, col}, acc ->
           ScreenBuffer.write_char(acc, col, 0, char, style)
         end)
 

--- a/packages/raxol_terminal/test/raxol/terminal/scroll_region_manager_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/scroll_region_manager_test.exs
@@ -252,8 +252,7 @@ defmodule Raxol.Terminal.ScrollRegionManagerTest do
       {:ok, sio} = StringIO.open("")
 
       final =
-        Enum.reduce([24, 80, 30, 6, 120], SRM.start(sio, 24, 3), fn rows,
-                                                                    state ->
+        Enum.reduce([24, 80, 30, 6, 120], SRM.start(sio, 24, 3), fn rows, state ->
           state =
             if SRM.rows(state) == rows, do: state, else: SRM.resize(state, rows)
 

--- a/packages/raxol_watch/test/raxol/watch/push_fcm_test.exs
+++ b/packages/raxol_watch/test/raxol/watch/push_fcm_test.exs
@@ -118,6 +118,7 @@ defmodule Raxol.Watch.Push.FCMTest do
       data = FCM.build_data_payload(%{title: "t", body: "b", actions: [], location: loc})
 
       assert is_binary(data["raxol_location"])
+
       assert Jason.decode!(data["raxol_location"]) == %{
                "lat" => 37.7749,
                "lng" => -122.4194,

--- a/scripts/check_package_formatting.sh
+++ b/scripts/check_package_formatting.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Format-check every package under packages/ using that package's OWN
+# .formatter.exs.
+#
+# The root `mix format --check-formatted` cannot do this. Its `inputs` stop at
+# the repo root, so it only ever reaches package files a caller names
+# explicitly -- which is how nine packages accumulated ~145 files of drift while
+# every gated package stayed clean.
+#
+# Deliberately not part of the `package-tests` matrix: that job compiles a
+# package and runs its suite. `mix format` reads .formatter.exs and the source
+# and compiles nothing, so gating all 17 there would buy a whitespace check at
+# the price of 17 full suites.
+#
+# Exit codes: 0 all clean, 1 at least one package failed.
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+failed=0
+
+# GitHub Actions renders `::error::` as an annotation; elsewhere it is just a
+# prefix on stderr, which is why the message stands on its own without it.
+err() {
+  printf '::error::%s\n' "$1" >&2
+}
+
+# The deps a package's formatter config would make `mix format` LOAD.
+#
+# Evaluated rather than grepped. `import_deps: []` and `import_deps: [:phoenix]`
+# differ by one character and a multi-line list defeats a line-based match
+# entirely, so a regex here is a gate that reports clean for the shape it exists
+# to catch. A .formatter.exs is a literal term; evaluating it is what `mix
+# format` itself does.
+import_deps_of() {
+  elixir -e '
+    [path] = System.argv()
+    {opts, _bindings} = Code.eval_file(path)
+    opts |> Keyword.get(:import_deps, []) |> Enum.join(", ") |> IO.write()
+  ' "$1"
+}
+
+for dir in packages/*/; do
+  pkg="$(basename "$dir")"
+
+  # A package is defined by its mix.exs. A MISSING .formatter.exs is a failure
+  # rather than a skip: the root config delegates `packages/*` by glob, so a
+  # package without one silently falls back to the root's 80 columns -- and
+  # skipping it would report that as a green check that checked nothing.
+  if [[ ! -f "$dir/mix.exs" ]]; then
+    continue
+  fi
+
+  if [[ ! -f "$dir/.formatter.exs" ]]; then
+    err "$pkg has no .formatter.exs, so the root glob formats it at 80 columns while its own gate expects 98. Add one (copy any sibling package's)."
+    failed=1
+    continue
+  fi
+
+  # This script's cheapness is the reason it is not in `package-tests`, and
+  # `import_deps:` is the one option that would cost it: the formatter loads the
+  # named deps, and nothing here runs `mix deps.get` inside a package. Caught by
+  # name so the failure does not arrive as an unrelated "could not find dep".
+  deps="$(import_deps_of "$dir/.formatter.exs")"
+  if [[ -n "$deps" ]]; then
+    err "$pkg sets import_deps: [$deps], which makes mix format load those deps. This check does not fetch them. Either drop it, or move this package into the package-tests matrix where deps are available."
+    failed=1
+    continue
+  fi
+
+  if ! (cd "$dir" && mix format --check-formatted); then
+    err "$pkg is not formatted. Run: (cd $dir && mix format)"
+    failed=1
+  fi
+done
+
+if [[ "$failed" -eq 0 ]]; then
+  echo "All packages formatted."
+fi
+
+exit "$failed"

--- a/test/raxol/formatter_delegation_test.exs
+++ b/test/raxol/formatter_delegation_test.exs
@@ -20,14 +20,26 @@ defmodule Raxol.FormatterDelegationTest do
     refute format.(@wide_line) == @wide_line
   end
 
+  # A package is defined by its mix.exs, NOT by having a .formatter.exs -- which
+  # is the point. Enumerating by `.formatter.exs` would make a package that is
+  # missing one invisible to the very test that exists to catch it, and the root
+  # glob would quietly format it at 80 columns. CI's `Check package formatting`
+  # step makes the same assertion; this is the cheaper of the two signals.
+  test "every package carries its own .formatter.exs" do
+    for package <- packages() do
+      assert File.exists?("packages/#{package}/.formatter.exs"),
+             "#{package} has no .formatter.exs, so the root glob formats it at " <>
+               "80 columns while its own CI gate expects 98"
+    end
+  end
+
   # Asked of the formatter rather than of the config's shape. The delegation list
   # is a glob now, so string-matching a package name against it would pass while
   # proving nothing about what `mix format` actually does to that package's
   # files -- which is the whole property.
   test "every package resolves through its own formatter, not the root's" do
     for package <- packages() do
-      file = sample_file(package)
-      {format, _opts} = Mix.Tasks.Format.formatter_for_file(file)
+      {format, _opts} = Mix.Tasks.Format.formatter_for_file(probe_path(package))
 
       assert format.(@wide_line) == @wide_line,
              "#{package} resolves through the root formatter (80 columns), so a " <>
@@ -36,20 +48,18 @@ defmodule Raxol.FormatterDelegationTest do
   end
 
   defp packages do
-    "packages/*/.formatter.exs"
+    "packages/*/mix.exs"
     |> Path.wildcard()
     |> Enum.map(&(&1 |> Path.dirname() |> Path.basename()))
+    |> tap(&assert &1 != [], "no packages found; is this running from the repo root?")
   end
 
-  # Any real source file under the package will do: the question is which
-  # formatter config `mix format` picks for that path, not what the file holds.
-  defp sample_file(package) do
-    "packages/#{package}/lib/**/*.ex"
-    |> Path.wildcard()
-    |> List.first()
-    |> case do
-      nil -> flunk("#{package} has no lib/**/*.ex to probe delegation with")
-      file -> file
-    end
-  end
+  # A path that need not EXIST. `formatter_for_file/1` picks a config by walking
+  # up from the path, so it answers for a hypothetical file just as well as a
+  # real one -- and asking about a hypothetical removes two ways for this test
+  # to fail for reasons that are not the property: a package whose `lib/` is
+  # empty or absent (docs-only, or code not landed yet) used to `flunk`, and
+  # picking `List.first()` out of a wildcard made the subject depend on
+  # directory order.
+  defp probe_path(package), do: "packages/#{package}/lib/formatter_probe.ex"
 end

--- a/test/raxol/formatter_delegation_test.exs
+++ b/test/raxol/formatter_delegation_test.exs
@@ -1,11 +1,11 @@
 defmodule Raxol.FormatterDelegationTest do
   @moduledoc """
-  The root formatter must resolve format-gated package files through the
-  package's own `.formatter.exs`.
+  The root formatter must resolve every package's files through that package's
+  own `.formatter.exs`.
 
   Without that, a root-cwd `mix format packages/...` -- an editor save in a
   monorepo workspace -- rewraps those files at the root's 80 columns, reverting
-  the 98-column shape the per-package CI cell enforces, and the two gates become
+  the 98-column shape the package's own gate enforces, and the two gates become
   mutually unsatisfiable.
   """
 
@@ -14,49 +14,42 @@ defmodule Raxol.FormatterDelegationTest do
   # 94 columns: legal at the package default of 98, split by the root's 80.
   @wide_line "{:ok, ExKeccak.hash_256(<<0x19, 0x01, domain_separator::binary, message_hash::binary>>)}\n"
 
-  @gated_file "packages/raxol_payments/lib/raxol/payments/eip712.ex"
-  @workflow ".github/workflows/ci-unified.yml"
-
-  test "a gated package file keeps its own line length under the root formatter" do
-    {format, _opts} = Mix.Tasks.Format.formatter_for_file(@gated_file)
-
-    assert format.(@wide_line) == @wide_line
-  end
-
   test "the root formatter still holds root files to 80 columns" do
     {format, _opts} = Mix.Tasks.Format.formatter_for_file("lib/raxol.ex")
 
     refute format.(@wide_line) == @wide_line
   end
 
-  test "every format-gated package is delegated by the root formatter" do
-    delegated = Keyword.fetch!(root_formatter_opts(), :subdirectories)
+  # Asked of the formatter rather than of the config's shape. The delegation list
+  # is a glob now, so string-matching a package name against it would pass while
+  # proving nothing about what `mix format` actually does to that package's
+  # files -- which is the whole property.
+  test "every package resolves through its own formatter, not the root's" do
+    for package <- packages() do
+      file = sample_file(package)
+      {format, _opts} = Mix.Tasks.Format.formatter_for_file(file)
 
-    for package <- gated_packages() do
-      assert "packages/#{package}" in delegated,
-             "#{package} is format-gated in #{@workflow} but the root " <>
-               ".formatter.exs does not delegate to it"
+      assert format.(@wide_line) == @wide_line,
+             "#{package} resolves through the root formatter (80 columns), so a " <>
+               "root-cwd `mix format` would rewrap what its own gate blessed"
     end
   end
 
-  defp root_formatter_opts do
-    {opts, _bindings} = Code.eval_file(".formatter.exs")
-    opts
+  defp packages do
+    "packages/*/.formatter.exs"
+    |> Path.wildcard()
+    |> Enum.map(&(&1 |> Path.dirname() |> Path.basename()))
   end
 
-  defp gated_packages do
-    matrix =
-      @workflow
-      |> File.read!()
-      |> String.split("\n")
-      |> Enum.find(&Regex.match?(~r/^\s*package: \[/, &1))
-
-    assert is_binary(matrix), "no package matrix found in #{@workflow}"
-
-    ~r/^\s*package: \[(?<packages>[^\]]+)\]/
-    |> Regex.named_captures(matrix)
-    |> Map.fetch!("packages")
-    |> String.split(",")
-    |> Enum.map(&String.trim/1)
+  # Any real source file under the package will do: the question is which
+  # formatter config `mix format` picks for that path, not what the file holds.
+  defp sample_file(package) do
+    "packages/#{package}/lib/**/*.ex"
+    |> Path.wildcard()
+    |> List.first()
+    |> case do
+      nil -> flunk("#{package} has no lib/**/*.ex to probe delegation with")
+      file -> file
+    end
   end
 end


### PR DESCRIPTION
`mix format` and CI disagreed about nine packages, so running the formatter
locally produced a large unrelated diff that no gate anywhere wanted.

## What was wrong

Every package format-gated in CI was clean. Every package NOT gated had drifted.
The correlation was exact, and it was the mechanism: the root `.formatter.exs`
delegated to an explicit list of the gated packages, and its own `inputs` stop at
the repo root, so nothing checked the others anywhere. `cd packages/raxol_agent
&& mix format` then rewrote files that were "wrong" only in the sense that no one
had ever run the formatter on them.

That is a trap rather than an inconvenience: the obvious way to format your own
change in one of those packages silently reformats files you did not touch.

## What this does

1. Formats the remaining ungated packages. Mechanical.
2. Root `.formatter.exs` delegates by glob: `subdirectories: ["packages/*"]`.
   The explicit list existed only because the drift made a glob unsatisfiable.
3. Adds `scripts/check_package_formatting.sh` to the existing `format` job. It
   runs each package's own gate, needs no compile and no tests.

After this, `mix format` from anywhere in the repo produces what CI checks, and
`cd packages/<pkg> && mix format` is a no-op on a clean tree.

## Rebased onto #915

#915 landed first and formatted `raxol_agent` and `raxol_core`, so this dropped
from 145 files to 79 and its `.formatter.exs` hunk became "replace the list #915
just extended with the glob". Both bundled `mix.lock` commits are gone -- #916
landed the `phoenix`/`req` half upstream, so `git rebase` dropped them as
already-applied. This PR no longer touches `mix.lock` at all.

## Changes from review

The gate as first written had three holes, all fixed in `93a7775`:

- **A package with no `.formatter.exs` was skipped.** That is the one case the
  gate exists for -- the root glob then formats it at 80 columns while its own
  CI cell expects 98 -- and skipping reported it as a green check that had
  checked nothing. Now a failure.
- **"Nothing is compiled" was an assumption.** It holds only while no package
  sets a non-empty `import_deps:`, which makes the formatter load those deps in
  a job that never runs `mix deps.get` inside a package. Now asserted by name,
  so it fails as "raxol_x sets import_deps" instead of as "could not find dep"
  inside a whitespace check.
- **The detection evaluates the config instead of grepping it.** My first
  attempt was a regex, and it missed every shape I tested it against:

  | `.formatter.exs` shape | `import_deps_of` | the regex |
  | --- | --- | --- |
  | `[import_deps: [:phoenix], ...]` | `phoenix` | miss |
  | multi-line `import_deps: [\n :phoenix,\n :ecto\n]` | `phoenix, ecto` | miss |
  | `[import_deps: [], ...]` | (none) | miss |
  | absent | (none) | miss |

  The single-line case fails an `^\s*import_deps:` anchor because the line
  starts `[import_deps:`; the multi-line case is invisible to any line-based
  match. A `.formatter.exs` is a literal term, so it is evaluated -- which is
  what `mix format` itself does.

Moved into a script alongside `check_singletons.sh` so it is runnable and
shellcheck-able locally rather than only in CI.

## The delegation test

`formatter_delegation_test.exs` asserted `"packages/#{package}" in delegated`,
which cannot survive a glob. It now asks the FORMATTER instead of the config's
shape: for every package, `Mix.Tasks.Format.formatter_for_file/1` must resolve a
94-column line without splitting it, which is only true if that package's own
98-column config won. String-matching a glob would have passed while proving
nothing about what `mix format` actually does.

Two review fixes here too. It enumerated packages by `.formatter.exs`, which made
a package missing one invisible to the test that should catch it, so it
enumerates by `mix.exs` and asserts the config exists. And its probe path no
longer has to be a real file -- `formatter_for_file/1` resolves config by walking
up from a path, so a hypothetical one answers the same question. That drops the
`flunk` on a package with an empty or absent `lib/` and the dependence on
wildcard ordering.

## Toolchain note

PATH `mix` on a dev machine here is commonly Homebrew's 1.19.5, while
`.tool-versions` and CI both pin 1.20.2. Formatter output can differ across
Elixir versions, so this was checked under the pin.

## Advisories

`mix hex.audit` reports three, all in `cowlib 2.19.0`, none touched here and
none fixable by a bump (2.19.0 is the newest published). Now tracked in #921
rather than left in this description.

## Testing

- all 17 packages pass `scripts/check_package_formatting.sh` under Elixir
  1.20.2 / OTP 29 (60s, no compile)
- both new failure branches exercised against a real package: removing
  `packages/raxol_sensor/.formatter.exs` fails it by name; adding
  `import_deps: [:phoenix]` in both single- and multi-line form fails it by name
- root `mix format --check-formatted` clean
- `test/raxol/formatter_delegation_test.exs`: 3 passed
- `shellcheck scripts/check_package_formatting.sh` clean

## Manual testing

- [ ] `cd packages/raxol_terminal && mix format` is a no-op on a clean tree
- [ ] a root-cwd `mix format packages/raxol_payments/lib/raxol/payments/eip712.ex` leaves it at 98 columns
