### PR TITLE
Confine the MCP headless path to a configured root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 - **Phoenix LiveDashboard 0.9.0** in the root development environment, including
   its resolved runtime companions Phoenix LiveView 1.2.11, telemetry_metrics
   1.2.0, and Ecto 3.14.2.
+- **Headless sessions now require the full TEA callback contract** (`init/1`,
+  `update/2`, and `view/1`). Modules that exported only `view/1` are refused as
+  `:not_a_raxol_application` instead of starting a session that cannot process
+  events.
 - **Spending budgets halt a running turn (#819)** instead of only the next prompt, and a model with no price fails closed once a ledger and policy are wired (an unpriced model bills real tokens while the ledger records $0.00).
 - **The web release carries the agent stack (#819)**: `raxol_agent`, `raxol_payments`, and `req` are release dependencies. Without them the hosted coding agent could not have started or made an LLM call, and `Raxol.Application` now declines to serve the surface rather than standing up a broken one.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,6 +459,7 @@ These namespaces are settled; don't create new top-level alternatives:
 - `HEX_BUILD=1` - Strip path deps for Hex publishing (`HEX_BUILD=1 mix hex.publish`)
 - `RAXOL_SSH_CODE` / `RAXOL_SSH_CODE_TENANTS` / `RAXOL_SSH_CODE_BUDGET_USD` - Hosted multi-tenant coding agent (all three required; `RAXOL_SSH_CODE_PORT` defaults to 2223)
 - `RAXOL_SESSIONS_DIR` - Coding-agent journal base (default `~/.raxol/sessions/`); `RAXOL_SHARE_SECRET` signs `/share` tokens
+- `RAXOL_HEADLESS_PATH_ROOT` (or `config :raxol, :headless_path_root`) - Directory the `raxol_start` MCP tool may start scripts from. Unset, the tool's `path` argument is refused outright: starting from a path compiles the file, and compiling a `defmodule` executes its body, so that argument is arbitrary code execution rather than a file read. Set, the requested path is confined under this root by `Raxol.Core.Boundary.Path.confine/3` (symlinks out of the root are refused, not followed) and must name an `.ex`/`.exs` file. The `module` argument is unaffected
 
 ## Dialyzer
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,7 +459,7 @@ These namespaces are settled; don't create new top-level alternatives:
 - `HEX_BUILD=1` - Strip path deps for Hex publishing (`HEX_BUILD=1 mix hex.publish`)
 - `RAXOL_SSH_CODE` / `RAXOL_SSH_CODE_TENANTS` / `RAXOL_SSH_CODE_BUDGET_USD` - Hosted multi-tenant coding agent (all three required; `RAXOL_SSH_CODE_PORT` defaults to 2223)
 - `RAXOL_SESSIONS_DIR` - Coding-agent journal base (default `~/.raxol/sessions/`); `RAXOL_SHARE_SECRET` signs `/share` tokens
-- `RAXOL_HEADLESS_PATH_ROOT` (or `config :raxol, :headless_path_root`) - Directory the `raxol_start` MCP tool may start scripts from. Unset, the tool's `path` argument is refused outright: starting from a path compiles the file, and compiling a `defmodule` executes its body, so that argument is arbitrary code execution rather than a file read. Set, the requested path is confined under this root by `Raxol.Core.Boundary.Path.confine/3` (symlinks out of the root are refused, not followed) and must name an `.ex`/`.exs` file. The `module` argument is unaffected
+- `RAXOL_HEADLESS_PATH_ROOT` (or `config :raxol, :headless_path_root`) - Directory the `raxol_start` MCP tool may start scripts from. Unset, the tool's `path` argument is refused outright: starting from a path compiles the file, and compiling a `defmodule` executes its body, so that argument is arbitrary code execution rather than a file read. Set, the requested path is confined under this root by `Raxol.Core.Boundary.Path.confine/3` (symlinks out of the root are refused, not followed), must be relative (an absolute, drive- or UNC-anchored path is refused rather than jailed under the root, so the file that runs is always the file named), and must name an `.ex`/`.exs` file. The `module` argument is unaffected
 
 ## Dialyzer
 

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -60,12 +60,27 @@ defmodule Raxol.Headless do
     )
   end
 
+  @typedoc """
+  Why a name could not become a runnable module.
+
+  `:not_a_raxol_application` is deliberately distinct from `:module_not_found`.
+  One says nothing on the code path answers to that name at all; the other says
+  the name resolved to real code that does not implement TEA. An operator fixes
+  those two by doing completely different things, so collapsing them into one
+  refusal costs them the diagnosis.
+  """
+  @type module_refusal ::
+          {:module_not_found, module()}
+          | {:not_a_raxol_application, module()}
+
   @doc """
   Starts a headless session.
 
-  First argument is either a module atom or a file path string.
-  When given a path, the file is compiled and the first module defined
-  with a `view/1` function is used.
+  First argument is either a module atom or a file path string. Either way the
+  module has to be a Raxol application: it declares
+  `Raxol.Core.Runtime.Application`, or exports `init/1`, `update/2` and
+  `view/1`. When given a path, the file is compiled and the first module
+  meeting that contract is used.
 
   ## Options
 
@@ -327,11 +342,36 @@ defmodule Raxol.Headless do
     end
   end
 
-  defp resolve_module(module) when is_atom(module) do
-    if Code.ensure_loaded?(module) do
-      {:ok, module}
-    else
-      {:error, {:module_not_found, module}}
+  # The gate lives HERE rather than in `Raxol.Headless.McpTools` because this is
+  # the one point every entry reaches: the `raxol_start` MCP tool,
+  # `Raxol.Recording.Video` and `Raxol.MCP.Test` all arrive through
+  # `start/2`. Gating at the MCP tool would leave the other two handing an
+  # arbitrary module to `Raxol.start_link/2`, whose `Lifecycle.Initializer`
+  # CALLS `init/1` -- the same defect one door down. It also puts both branches
+  # on one predicate: the compile branch has always picked a module out of a
+  # script by this test, and a name should not be admitted on weaker terms than
+  # a file is.
+  #
+  # `Code.ensure_loaded?/1` alone answers "is there a beam for this name", which
+  # is a far larger set than "is this a Raxol application": 527 modules on this
+  # tree export `init/1`, every `BaseManager` GenServer among them, against 53
+  # that implement TEA. `Raxol.Terminal.Buffer.BufferServer` is one of the 527,
+  # and starting it here ran its GenServer `init/1` outside any supervisor.
+  defp resolve_module(module) when is_atom(module),
+    do: resolve_named_module(module)
+
+  @spec resolve_named_module(module()) ::
+          {:ok, module()} | {:error, module_refusal()}
+  defp resolve_named_module(module) do
+    cond do
+      tea_module?(module) ->
+        {:ok, module}
+
+      Code.ensure_loaded?(module) ->
+        {:error, {:not_a_raxol_application, module}}
+
+      true ->
+        {:error, {:module_not_found, module}}
     end
   end
 
@@ -466,8 +506,52 @@ defmodule Raxol.Headless do
     )
   end
 
-  defp tea_module?(mod) do
-    Code.ensure_loaded?(mod) and function_exported?(mod, :view, 1)
+  # `Raxol.Core.Runtime.Application` is the formal TEA behaviour, so it is asked
+  # first: a module that declares it has said what it is, and that beats
+  # inferring it from exports.
+  #
+  # It cannot be the WHOLE test, though, because the runtime itself does not
+  # require it. `Lifecycle.Initializer` decides on
+  # `function_exported?(mod, :init, 1)` and never reads the attribute, so a
+  # module implementing the three callbacks without `use`-ing the behaviour runs
+  # correctly today -- `Raxol.Examples.Demos.IntegratedAccessibilityDemo` in
+  # this repo is exactly that, the only one of the 53 TEA modules on this tree
+  # that does not declare it. Refusing it would break a public API that has
+  # always started it.
+  #
+  # The fallback is the full triple rather than `view/1` alone because `view/1`
+  # is only the part this module happens to consume: a screenshot needs it, but
+  # the runtime drives `init/1` and `update/2` too, and a gate should name the
+  # contract it is gating.
+  @spec tea_module?(term()) :: boolean()
+  defp tea_module?(mod) when is_atom(mod) do
+    # Both halves answer for a LOADED module only, and under `mix mcp.server`
+    # code loads on demand -- so without this a module that is compiled and
+    # sitting on the code path gets refused for being unloaded rather than for
+    # failing the contract. Loading a beam runs nothing at module scope; the
+    # compile branch is what executes code, and it is confined separately.
+    Code.ensure_loaded?(mod) and
+      (tea_behaviour?(mod) or tea_callbacks_exported?(mod))
+  end
+
+  defp tea_module?(_other), do: false
+
+  # `module_info/1`, not `__info__/1`: the latter exists only on Elixir modules,
+  # so an Erlang module named by a caller would raise here instead of being
+  # refused. `@behaviour` compiles to the Erlang `behaviour` attribute, and
+  # repeating the attribute appends entries rather than replacing them.
+  @spec tea_behaviour?(module()) :: boolean()
+  defp tea_behaviour?(mod) do
+    mod.module_info(:attributes)
+    |> Keyword.get_values(:behaviour)
+    |> List.flatten()
+    |> Enum.member?(Raxol.Core.Runtime.Application)
+  end
+
+  @spec tea_callbacks_exported?(module()) :: boolean()
+  defp tea_callbacks_exported?(mod) do
+    function_exported?(mod, :init, 1) and function_exported?(mod, :update, 2) and
+      function_exported?(mod, :view, 1)
   end
 
   # Extract top-level defmodule blocks from AST, ignoring other expressions.

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -348,14 +348,15 @@ defmodule Raxol.Headless do
     end
   end
 
-  # Read and parse are answered, not raised. `File.read!` and a strict
-  # `{:ok, ast} =` match both blow up INSIDE the `Raxol.Headless` GenServer,
-  # which is a singleton holding every other caller's session -- so one
-  # unreadable or non-Elixir file took down sessions that had nothing to do with
-  # it. The caller asked whether this file could start; "no" is an answer.
+  # Read and parse are answered, not raised. `File.read!`, a strict
+  # `{:ok, ast} =` match, and `Code.string_to_quoted/2` itself all blow up INSIDE
+  # the `Raxol.Headless` GenServer, which is a singleton holding every other
+  # caller's session -- so one unreadable or non-Elixir file took down sessions
+  # that had nothing to do with it. The caller asked whether this file could
+  # start; "no" is an answer.
   defp compile_and_find_module(path) do
     with {:ok, source} <- read_source(path),
-         {:ok, ast} <- Code.string_to_quoted(source, file: path) do
+         {:ok, ast} <- parse_source(source, path) do
       compile_modules(extract_module_defs(ast), path)
     end
   end
@@ -365,6 +366,17 @@ defmodule Raxol.Headless do
       {:ok, source} -> {:ok, source}
       {:error, reason} -> {:error, {:unreadable_file, path, reason}}
     end
+  end
+
+  # `Code.string_to_quoted/2` answers a SYNTAX error and raises an ENCODING one:
+  # it charlist-converts the whole binary before the parser ever sees it, so
+  # `<<0xFF, ...>>` is a `UnicodeConversionError` out of `String.to_charlist/1`.
+  # Nothing upstream excludes that file -- the confined path checks the
+  # extension, and any binary can be named `*.exs`.
+  defp parse_source(source, path) do
+    Code.string_to_quoted(source, file: path)
+  rescue
+    e -> {:error, {:unparseable_file, path, Exception.message(e)}}
   end
 
   defp compile_modules([], _path), do: {:error, :no_modules_found}
@@ -382,8 +394,8 @@ defmodule Raxol.Headless do
   # does not kill this process, it WEDGES it, and no `try` can interrupt that.
   #
   # So the compile runs in a monitored child on a budget, which answers all four
-  # the same way: a crash arrives as `:DOWN`, a timeout is brutal-killed, and the
-  # caller gets an error instead of an unrelated session losing its manager.
+  # the same way: a crash arrives as `:DOWN`, a timeout is killed, and the caller
+  # gets an error instead of an unrelated session losing its manager.
   defp compile_modules(module_asts, path) do
     with {:ok, modules} <- compile_off_thread(module_asts, path) do
       case Enum.find(modules, &tea_module?/1) do
@@ -412,9 +424,13 @@ defmodule Raxol.Headless do
       {:DOWN, ^ref, :process, ^pid, reason} ->
         {:error, {:compile_failed, path, Exception.format_exit(reason)}}
     after
+      # `:kill`, not `:brutal_kill`. The latter is a Supervisor shutdown SPEC,
+      # and `Process.exit/2` reads it as an ordinary reason a body can trap --
+      # so a body that traps would outlive its own budget, still holding the
+      # code server's claim on the module name it was compiling.
       budget ->
         Process.demonitor(ref, [:flush])
-        Process.exit(pid, :brutal_kill)
+        Process.exit(pid, :kill)
         {:error, {:compile_timed_out, path, budget}}
     end
   end

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -341,36 +341,52 @@ defmodule Raxol.Headless do
     end
   end
 
+  # Read and parse are answered, not raised. `File.read!` and a strict
+  # `{:ok, ast} =` match both blow up INSIDE the `Raxol.Headless` GenServer,
+  # which is a singleton holding every other caller's session -- so one
+  # unreadable or non-Elixir file took down sessions that had nothing to do with
+  # it. The caller asked whether this file could start; "no" is an answer.
   defp compile_and_find_module(path) do
-    # Parse the file AST, extract only defmodule blocks (skip top-level
-    # side effects like Raxol.start_link and receive), then compile them.
-    source = File.read!(path)
-
-    {:ok, ast} = Code.string_to_quoted(source, file: path)
-
-    module_asts = extract_module_defs(ast)
-
-    if module_asts == [] do
-      {:error, :no_modules_found}
-    else
-      modules =
-        module_asts
-        |> Enum.flat_map(fn mod_ast ->
-          Code.compile_quoted(mod_ast, path)
-        end)
-        |> Enum.map(fn {module, _bytecode} -> module end)
-
-      tea_module =
-        Enum.find(modules, fn mod ->
-          Code.ensure_loaded?(mod) and function_exported?(mod, :view, 1)
-        end)
-
-      if tea_module do
-        {:ok, tea_module}
-      else
-        {:error, :no_tea_module_found}
-      end
+    with {:ok, source} <- read_source(path),
+         {:ok, ast} <- Code.string_to_quoted(source, file: path) do
+      compile_modules(extract_module_defs(ast), path)
     end
+  end
+
+  defp read_source(path) do
+    case File.read(path) do
+      {:ok, source} -> {:ok, source}
+      {:error, reason} -> {:error, {:unreadable_file, path, reason}}
+    end
+  end
+
+  defp compile_modules([], _path), do: {:error, :no_modules_found}
+
+  # Only defmodule blocks are compiled, skipping top-level side effects like
+  # `Raxol.start_link` and `receive`. That is a CONVENIENCE, not a sandbox:
+  # compiling a `defmodule` executes its body, so anything at module scope runs.
+  # What bounds this is the caller -- `Raxol.Headless.McpTools` confines the path
+  # to a configured root, and the programmatic callers pass their own file.
+  #
+  # Rescued for availability, not safety: a module body that raises at compile
+  # time would otherwise take this singleton GenServer down and with it every
+  # unrelated session it holds.
+  defp compile_modules(module_asts, path) do
+    modules =
+      module_asts
+      |> Enum.flat_map(fn mod_ast -> Code.compile_quoted(mod_ast, path) end)
+      |> Enum.map(fn {module, _bytecode} -> module end)
+
+    case Enum.find(modules, &tea_module?/1) do
+      nil -> {:error, :no_tea_module_found}
+      tea_module -> {:ok, tea_module}
+    end
+  rescue
+    e -> {:error, {:compile_failed, path, Exception.message(e)}}
+  end
+
+  defp tea_module?(mod) do
+    Code.ensure_loaded?(mod) and function_exported?(mod, :view, 1)
   end
 
   # Extract top-level defmodule blocks from AST, ignoring other expressions.

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -360,6 +360,22 @@ defmodule Raxol.Headless do
   defp resolve_module(module) when is_atom(module),
     do: resolve_named_module(module)
 
+  defp resolve_module(path) when is_binary(path) do
+    full_path =
+      if Path.type(path) == :absolute,
+        do: path,
+        else: Path.join(File.cwd!(), path)
+
+    if File.exists?(full_path) do
+      compile_and_find_module(full_path)
+    else
+      {:error, {:file_not_found, full_path}}
+    end
+  end
+
+  # Split out from the clause above so it can carry a spec of its own: the two
+  # `resolve_module/1` clauses answer with different error vocabularies, and one
+  # `@spec` over both could only state their union.
   @spec resolve_named_module(module()) ::
           {:ok, module()} | {:error, module_refusal()}
   defp resolve_named_module(module) do
@@ -372,19 +388,6 @@ defmodule Raxol.Headless do
 
       true ->
         {:error, {:module_not_found, module}}
-    end
-  end
-
-  defp resolve_module(path) when is_binary(path) do
-    full_path =
-      if Path.type(path) == :absolute,
-        do: path,
-        else: Path.join(File.cwd!(), path)
-
-    if File.exists?(full_path) do
-      compile_and_find_module(full_path)
-    else
-      {:error, {:file_not_found, full_path}}
     end
   end
 

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -38,6 +38,13 @@ defmodule Raxol.Headless do
   @default_height 40
   @default_dispatch_wait_ms 50
 
+  # Deliberately SHORTER than the 5s the other calls in this module give
+  # themselves: the compile happens inside `handle_call`, so this budget is also
+  # the longest an unrelated session's `screenshot/1` can be made to wait. One
+  # bad script should not be able to fail a healthy session's call, and 2s is
+  # generous for compiling a single script.
+  @default_compile_timeout_ms 2_000
+
   defmodule Session do
     @moduledoc false
     defstruct [:id, :module, :lifecycle_pid, :synchronizer_pid, :width, :height]
@@ -368,21 +375,79 @@ defmodule Raxol.Headless do
   # What bounds this is the caller -- `Raxol.Headless.McpTools` confines the path
   # to a configured root, and the programmatic callers pass their own file.
   #
-  # Rescued for availability, not safety: a module body that raises at compile
-  # time would otherwise take this singleton GenServer down and with it every
-  # unrelated session it holds.
+  # Which is why the compile does not happen HERE. This is a singleton GenServer
+  # holding every other caller's session, and a module body can end its own
+  # process in three ways -- `raise`, `throw`, `exit` -- of which a `rescue` sees
+  # one. Worse, it need not end at all: `:timer.sleep(:infinity)` at module scope
+  # does not kill this process, it WEDGES it, and no `try` can interrupt that.
+  #
+  # So the compile runs in a monitored child on a budget, which answers all four
+  # the same way: a crash arrives as `:DOWN`, a timeout is brutal-killed, and the
+  # caller gets an error instead of an unrelated session losing its manager.
   defp compile_modules(module_asts, path) do
+    with {:ok, modules} <- compile_off_thread(module_asts, path) do
+      case Enum.find(modules, &tea_module?/1) do
+        nil -> {:error, :no_tea_module_found}
+        tea_module -> {:ok, tea_module}
+      end
+    end
+  end
+
+  defp compile_off_thread(module_asts, path) do
+    parent = self()
+    budget = compile_timeout_ms()
+
+    {pid, ref} =
+      spawn_monitor(fn ->
+        send(parent, {:compiled, self(), compile_quoted_all(module_asts, path)})
+      end)
+
+    receive do
+      {:compiled, ^pid, result} ->
+        Process.demonitor(ref, [:flush])
+        result
+
+      # A body that killed itself untrappably (`Process.exit(self(), :kill)`), or
+      # took a linked compiler process down with it.
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        {:error, {:compile_failed, path, Exception.format_exit(reason)}}
+    after
+      budget ->
+        Process.demonitor(ref, [:flush])
+        Process.exit(pid, :brutal_kill)
+        {:error, {:compile_timed_out, path, budget}}
+    end
+  end
+
+  # `catch` alongside `rescue`: `Code.compile_quoted/2` EXECUTES module bodies,
+  # so a bare `throw` or `exit` at module scope is as reachable as a `raise` and
+  # `rescue` sees neither.
+  defp compile_quoted_all(module_asts, path) do
     modules =
       module_asts
       |> Enum.flat_map(fn mod_ast -> Code.compile_quoted(mod_ast, path) end)
       |> Enum.map(fn {module, _bytecode} -> module end)
 
-    case Enum.find(modules, &tea_module?/1) do
-      nil -> {:error, :no_tea_module_found}
-      tea_module -> {:ok, tea_module}
-    end
+    {:ok, modules}
   rescue
     e -> {:error, {:compile_failed, path, Exception.message(e)}}
+  catch
+    :throw, value ->
+      {:error, {:compile_failed, path, "threw #{inspect(value)}"}}
+
+    :exit, reason ->
+      {:error, {:compile_failed, path, Exception.format_exit(reason)}}
+  end
+
+  # A compile budget is a property of the deployment, not of this module: how
+  # long a legitimate script may take to compile depends on the script. It is
+  # also what makes the wedge case assertable without a test that sleeps.
+  defp compile_timeout_ms do
+    Application.get_env(
+      :raxol,
+      :headless_compile_timeout_ms,
+      @default_compile_timeout_ms
+    )
   end
 
   defp tea_module?(mod) do

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -44,6 +44,7 @@ defmodule Raxol.Headless do
   # bad script should not be able to fail a healthy session's call, and 2s is
   # generous for compiling a single script.
   @default_compile_timeout_ms 2_000
+  @max_compile_timeout_ms 4_500
 
   defmodule Session do
     @moduledoc false
@@ -104,8 +105,10 @@ defmodule Raxol.Headless do
   `Raxol.Core.Boundary.Path.confine/3`. The programmatic callers
   (`Raxol.Recording.Video`, `Raxol.MCP.Test`) pass a path they already chose.
 
-  The `module` argument carries no such hazard: loading a beam runs nothing at
-  module scope, and the TEA contract above is checked before anything starts.
+  The `module` argument does not compile source, but loading a beam can execute
+  an `@on_load` callback. The TEA contract is checked after the module loads and
+  before a session starts; callers must therefore treat the VM's code path as
+  trusted deployment input.
 
   ## Options
 
@@ -527,11 +530,17 @@ defmodule Raxol.Headless do
   # long a legitimate script may take to compile depends on the script. It is
   # also what makes the wedge case assertable without a test that sleeps.
   defp compile_timeout_ms do
-    Application.get_env(
-      :raxol,
-      :headless_compile_timeout_ms,
-      @default_compile_timeout_ms
-    )
+    case Application.get_env(
+           :raxol,
+           :headless_compile_timeout_ms,
+           @default_compile_timeout_ms
+         ) do
+      timeout when is_integer(timeout) and timeout > 0 ->
+        min(timeout, @max_compile_timeout_ms)
+
+      _invalid ->
+        @default_compile_timeout_ms
+    end
   end
 
   # The gate is the three callbacks, never the `@behaviour` attribute.

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -77,10 +77,11 @@ defmodule Raxol.Headless do
   Starts a headless session.
 
   First argument is either a module atom or a file path string. Either way the
-  module has to be a Raxol application: it declares
-  `Raxol.Core.Runtime.Application`, or exports `init/1`, `update/2` and
-  `view/1`. When given a path, the file is compiled and the first module
-  meeting that contract is used.
+  module has to be a Raxol application: it must export `init/1`, `update/2` and
+  `view/1`. Declaring `Raxol.Core.Runtime.Application` is not sufficient on its
+  own, since the attribute can be present with none of the callbacks behind it.
+  When given a path, the file is compiled and the first module meeting that
+  contract is used.
 
   ## Options
 
@@ -509,47 +510,40 @@ defmodule Raxol.Headless do
     )
   end
 
-  # `Raxol.Core.Runtime.Application` is the formal TEA behaviour, so it is asked
-  # first: a module that declares it has said what it is, and that beats
-  # inferring it from exports.
+  # The gate is the three callbacks, never the `@behaviour` attribute.
   #
-  # It cannot be the WHOLE test, though, because the runtime itself does not
-  # require it. `Lifecycle.Initializer` decides on
-  # `function_exported?(mod, :init, 1)` and never reads the attribute, so a
-  # module implementing the three callbacks without `use`-ing the behaviour runs
-  # correctly today -- `Raxol.Examples.Demos.IntegratedAccessibilityDemo` in
-  # this repo is exactly that, the only one of the 53 TEA modules on this tree
-  # that does not declare it. Refusing it would break a public API that has
-  # always started it.
+  # Declaring `Raxol.Core.Runtime.Application` and implementing none of it
+  # compiles: Elixir warns about the missing callbacks, it does not refuse. So
+  # accepting the attribute ADMITS a module that cannot be driven, and `start/2`
+  # answers `{:ok, id}` for it and then renders an empty frame forever. A silent
+  # do-nothing session is worse than the clean error it replaced.
   #
-  # The fallback is the full triple rather than `view/1` alone because `view/1`
-  # is only the part this module happens to consume: a screenshot needs it, but
-  # the runtime drives `init/1` and `update/2` too, and a gate should name the
-  # contract it is gating.
+  # Nothing is lost by leaving the attribute out. Surveyed across every module
+  # compiled on this tree: the set that declares the behaviour WITHOUT exporting
+  # the triple is empty, so the attribute decides no case the exports do not
+  # already decide.
+  #
+  # The test cannot run the other way round and REQUIRE the attribute either,
+  # because the runtime does not: `Lifecycle.Initializer` reads
+  # `function_exported?(mod, :init, 1)` and never the attribute, and
+  # `Raxol.Examples.Demos.IntegratedAccessibilityDemo` exports the triple
+  # without declaring it. That module runs correctly today, and refusing it
+  # would break a public API that has always started it.
+  #
+  # The triple rather than `view/1` alone because `view/1` is only the part this
+  # module consumes: a screenshot needs it, but the runtime drives `init/1` and
+  # `update/2` too, and a gate should name the contract it gates.
   @spec tea_module?(term()) :: boolean()
   defp tea_module?(mod) when is_atom(mod) do
-    # Both halves answer for a LOADED module only, and under `mix mcp.server`
-    # code loads on demand -- so without this a module that is compiled and
-    # sitting on the code path gets refused for being unloaded rather than for
-    # failing the contract. Loading a beam runs nothing at module scope; the
-    # compile branch is what executes code, and it is confined separately.
-    Code.ensure_loaded?(mod) and
-      (tea_behaviour?(mod) or tea_callbacks_exported?(mod))
+    # Answers for a LOADED module only, and under `mix mcp.server` code loads on
+    # demand -- so without this a module that is compiled and sitting on the
+    # code path gets refused for being unloaded rather than for failing the
+    # contract. Loading a beam runs nothing at module scope; the compile branch
+    # is what executes code, and it is confined separately.
+    Code.ensure_loaded?(mod) and tea_callbacks_exported?(mod)
   end
 
   defp tea_module?(_other), do: false
-
-  # `module_info/1`, not `__info__/1`: the latter exists only on Elixir modules,
-  # so an Erlang module named by a caller would raise here instead of being
-  # refused. `@behaviour` compiles to the Erlang `behaviour` attribute, and
-  # repeating the attribute appends entries rather than replacing them.
-  @spec tea_behaviour?(module()) :: boolean()
-  defp tea_behaviour?(mod) do
-    mod.module_info(:attributes)
-    |> Keyword.get_values(:behaviour)
-    |> List.flatten()
-    |> Enum.member?(Raxol.Core.Runtime.Application)
-  end
 
   @spec tea_callbacks_exported?(module()) :: boolean()
   defp tea_callbacks_exported?(mod) do

--- a/lib/raxol/headless.ex
+++ b/lib/raxol/headless.ex
@@ -83,6 +83,30 @@ defmodule Raxol.Headless do
   When given a path, the file is compiled and the first module meeting that
   contract is used.
 
+  ## Passing a path executes code
+
+  Compiling a `defmodule` runs its body, so **whoever chooses the path string
+  chooses what runs in this VM**, with the VM's privileges. That is arbitrary
+  code execution, not a file read, and it is a property of this function rather
+  than of any one caller.
+
+  The AST filter that keeps only `defmodule` nodes is a convenience -- it skips
+  an example script's boot code -- and never a sandbox. What bounds the compile
+  is a monitored child on a budget, which bounds the DAMAGE to this process
+  (a body that raises, throws, exits, or never returns is answered rather than
+  taking the session manager down with it). It does not bound what the body may
+  do while it runs.
+
+  So the path argument is only ever as safe as the caller that chooses it.
+  Callers that take one from outside the VM must confine it themselves:
+  `Raxol.Headless.McpTools` refuses the argument entirely unless a deployment
+  sets `RAXOL_HEADLESS_PATH_ROOT`, and then confines it under that root with
+  `Raxol.Core.Boundary.Path.confine/3`. The programmatic callers
+  (`Raxol.Recording.Video`, `Raxol.MCP.Test`) pass a path they already chose.
+
+  The `module` argument carries no such hazard: loading a beam runs nothing at
+  module scope, and the TEA contract above is checked before anything starts.
+
   ## Options
 
     * `:id` - Session identifier (default: module name as atom)

--- a/lib/raxol/headless/mcp_tools.ex
+++ b/lib/raxol/headless/mcp_tools.ex
@@ -35,7 +35,10 @@ defmodule Raxol.Headless.McpTools do
             path: %{
               type: "string",
               description:
-                "File path to an example script (e.g. \"examples/demo.exs\"). Mutually exclusive with module."
+                "Script path RELATIVE to the configured headless path root, e.g. " <>
+                  "\"examples/demo.exs\". Disabled unless RAXOL_HEADLESS_PATH_ROOT " <>
+                  "(or config :raxol, :headless_path_root) is set, because starting " <>
+                  "from a path compiles the file. Mutually exclusive with module."
             },
             id: %{
               type: "string",
@@ -291,8 +294,10 @@ defmodule Raxol.Headless.McpTools do
         opts = build_start_opts(id, width, height)
         do_start(module_or_path, opts)
 
+      # Already a human-readable sentence, unlike the `inspect`ed terms the other
+      # callbacks report.
       {:error, reason} ->
-        {:error, inspect(reason)}
+        {:error, reason}
     end
   end
 
@@ -376,17 +381,83 @@ defmodule Raxol.Headless.McpTools do
     end
   end
 
+  # `"module"` arrives from an MCP client, and atoms are never garbage collected:
+  # minting one per distinct string lets a caller looping on a wrong name grow the
+  # atom table until the VM aborts. `Raxol.Application` registers these tools at
+  # startup, so this is a reachable surface rather than a dev-only one.
+  #
+  # A miss is answered rather than minted. Nothing is lost by it: an atom for a
+  # module that has never been loaded only fails later at `Raxol.Headless.start/2`.
+  #
+  # `safe_to_atom/1` and `parse_key/1` in this module already resolve the same way
+  # (existing-only, and an explicit allowlist).
   defp resolve_module_or_path(%{"module" => mod}) when is_binary(mod) do
     {:ok, String.to_existing_atom("Elixir." <> mod)}
   rescue
-    ArgumentError -> {:ok, String.to_atom("Elixir." <> mod)}
+    ArgumentError ->
+      {:error, "unknown module #{inspect(mod)}: it is not loaded in this VM"}
   end
 
-  defp resolve_module_or_path(%{"path" => path}) when is_binary(path),
-    do: {:ok, path}
+  # Starting from a path is ARBITRARY CODE EXECUTION, not a file read.
+  # `Raxol.Headless.start/2` runs the file through `Code.compile_quoted/2`, and
+  # compiling a `defmodule` executes its body -- so whoever chooses this string
+  # chooses what runs in this VM. The AST filter that keeps only `defmodule`
+  # nodes is a convenience (it skips an example's boot code), never a sandbox.
+  #
+  # So the branch is off unless a deployment opts in by naming a root, and the
+  # candidate is confined under it. Unset is the default, and it REFUSES rather
+  # than falling back to the cwd: an MCP server's working directory is not a
+  # security boundary anyone chose.
+  #
+  # Containment is `Raxol.Core.Boundary.Path.confine/3`, the repo's shared
+  # primitive -- lexical check, then a real-path resolution of BOTH sides, then a
+  # re-check, so a symlink pointing out of the root is refused rather than
+  # followed. Deciding this on the lexical path alone is the bug it exists to
+  # prevent. `:ref_format` additionally requires an Elixir extension, since a
+  # path that cannot be compiled has no business reaching the compiler.
+  #
+  # Note `confine/3` joins the request under the root, so an ABSOLUTE path is
+  # jailed rather than honoured. That is the intent, and it costs nothing: the
+  # documented use (`examples/demo.exs`) was always relative.
+  defp resolve_module_or_path(%{"path" => path}) when is_binary(path) do
+    case headless_path_root() do
+      nil ->
+        {:error,
+         "starting from a path is disabled: it compiles the file, which executes " <>
+           "module bodies. Set RAXOL_HEADLESS_PATH_ROOT (or config :raxol, " <>
+           ":headless_path_root) to the directory scripts may be started from."}
 
+      root ->
+        confine_path(root, path)
+    end
+  end
+
+  # Deliberately does NOT mention 'path'. That branch compiles whatever it is
+  # given, so steering a caller who fat-fingered a module name onto it would
+  # trade a refused lookup for something much worse.
   defp resolve_module_or_path(_),
     do: {:error, "Either 'module' or 'path' is required"}
+
+  defp confine_path(root, path) do
+    case Raxol.Core.Boundary.Path.confine(root, path, ref_format: ~r/\.exs?$/) do
+      {:ok, real} ->
+        {:ok, real}
+
+      {:error, :malformed_ref} ->
+        {:error, "path must name an .ex or .exs file"}
+
+      {:error, reason} ->
+        {:error,
+         "path is outside the configured headless path root (#{reason})"}
+    end
+  end
+
+  defp headless_path_root do
+    case System.get_env("RAXOL_HEADLESS_PATH_ROOT") do
+      root when is_binary(root) and root != "" -> root
+      _ -> Application.get_env(:raxol, :headless_path_root)
+    end
+  end
 
   @special_keys ~w(tab enter escape backspace up down left right home end page_up page_down delete insert f1 f2 f3 f4 f5 f6 f7 f8 f9 f10 f11 f12)
 

--- a/lib/raxol/headless/mcp_tools.ex
+++ b/lib/raxol/headless/mcp_tools.ex
@@ -16,12 +16,17 @@ defmodule Raxol.Headless.McpTools do
       %{
         name: "raxol_start",
         description: """
-        Starts a headless Raxol session. Accepts either a module name
-        (atom) or a file path to an example script. Returns the session ID.
+        Starts a headless Raxol session from a module name. The module must be
+        a Raxol application: it has to export init/1, update/2 and view/1.
+        Returns the session ID.
+
+        A "path" argument also exists, but it is DISABLED unless the deployment
+        sets RAXOL_HEADLESS_PATH_ROOT, because starting from a path compiles the
+        file. Prefer "module"; the path property below has the details.
 
         Examples:
           {"module": "RaxolDemo"}
-          {"path": "examples/demo.exs", "id": "demo"}
+          {"module": "RaxolDemo", "id": "demo"}
           {"module": "RaxolDemo", "width": 120, "height": 40}
         """,
         inputSchema: %{

--- a/lib/raxol/headless/mcp_tools.ex
+++ b/lib/raxol/headless/mcp_tools.ex
@@ -411,6 +411,9 @@ defmodule Raxol.Headless.McpTools do
   # is precisely what this tool is asked to do. So the code path decides, and the
   # atom is minted only once a beam file for that exact name is found there:
   # bounded by what is on disk, not by what a caller can type.
+  defp resolve_module_or_path(%{"module" => _mod, "path" => _path}),
+    do: {:error, "'module' and 'path' are mutually exclusive"}
+
   defp resolve_module_or_path(%{"module" => mod}) when is_binary(mod) do
     case existing_module(mod) do
       {:ok, module} ->
@@ -506,15 +509,17 @@ defmodule Raxol.Headless.McpTools do
   # code executes, answering a different file silently is the worse of the two
   # available behaviours -- so the mismatch is named instead.
   #
-  defp confine_path(root, path) when path != "" do
+  defp confine_path(root, path) when is_binary(path) and path != "" do
     case anchored_kind(path) do
       nil -> do_confine_path(root, path)
       kind -> {:error, absolute_refusal(path, kind)}
     end
   end
 
-  defp confine_path(_root, _path),
+  defp confine_path(_root, path) when is_binary(path),
     do: {:error, "path must not be empty"}
+
+  defp confine_path(_root, _path), do: {:error, "path must be a string"}
 
   # `nil` for a genuinely relative path; otherwise what it is anchored at.
   #

--- a/lib/raxol/headless/mcp_tools.ex
+++ b/lib/raxol/headless/mcp_tools.ex
@@ -519,8 +519,6 @@ defmodule Raxol.Headless.McpTools do
   defp confine_path(_root, path) when is_binary(path),
     do: {:error, "path must not be empty"}
 
-  defp confine_path(_root, _path), do: {:error, "path must be a string"}
-
   # `nil` for a genuinely relative path; otherwise what it is anchored at.
   #
   # `Path.type/1` alone is not enough, because it is OS-dependent in exactly the

--- a/lib/raxol/headless/mcp_tools.ex
+++ b/lib/raxol/headless/mcp_tools.ex
@@ -386,16 +386,20 @@ defmodule Raxol.Headless.McpTools do
   # atom table until the VM aborts. `Raxol.Application` registers these tools at
   # startup, so this is a reachable surface rather than a dev-only one.
   #
-  # A miss is answered rather than minted. Nothing is lost by it: an atom for a
-  # module that has never been loaded only fails later at `Raxol.Headless.start/2`.
-  #
-  # `safe_to_atom/1` and `parse_key/1` in this module already resolve the same way
-  # (existing-only, and an explicit allowlist).
+  # But the atom table alone answers the wrong question. Under `mix mcp.server`
+  # the VM loads code on demand, so a module that is compiled and sitting on the
+  # code path has no atom until something reaches for it -- and reaching for it
+  # is precisely what this tool is asked to do. So the code path decides, and the
+  # atom is minted only once a beam file for that exact name is found there:
+  # bounded by what is on disk, not by what a caller can type.
   defp resolve_module_or_path(%{"module" => mod}) when is_binary(mod) do
-    {:ok, String.to_existing_atom("Elixir." <> mod)}
-  rescue
-    ArgumentError ->
-      {:error, "unknown module #{inspect(mod)}: it is not loaded in this VM"}
+    case existing_module(mod) do
+      {:ok, module} ->
+        {:ok, module}
+
+      :error ->
+        {:error, "unknown module #{inspect(mod)}: it is not loaded in this VM"}
+    end
   end
 
   # Starting from a path is ARBITRARY CODE EXECUTION, not a file read.
@@ -437,6 +441,36 @@ defmodule Raxol.Headless.McpTools do
   # trade a refused lookup for something much worse.
   defp resolve_module_or_path(_),
     do: {:error, "Either 'module' or 'path' is required"}
+
+  # `:code.where_is_file/1` walks the code path for the beam, which is what
+  # `Code.ensure_loaded?/1` would have to find anyway -- asking first just means
+  # a name that exists nowhere never becomes an atom.
+  defp existing_module(name) do
+    prefixed = "Elixir." <> name
+
+    case atom_if_exists(prefixed) do
+      {:ok, module} -> {:ok, module}
+      :error -> beam_on_code_path(prefixed)
+    end
+  end
+
+  defp atom_if_exists(prefixed) do
+    {:ok, String.to_existing_atom(prefixed)}
+  rescue
+    ArgumentError -> :error
+  end
+
+  # The mint stays bounded because the file has to be there: `where_is_file/1`
+  # appends the name to each code-path directory and stats it, so the reachable
+  # set is the beams already on disk, which a caller supplying names cannot
+  # grow. The `Elixir.` prefix leads, so a separator-bearing name looks for a
+  # directory literally called `Elixir.<something>` and finds nothing.
+  defp beam_on_code_path(prefixed) do
+    case :code.where_is_file(String.to_charlist(prefixed <> ".beam")) do
+      :non_existing -> :error
+      _path -> {:ok, String.to_atom(prefixed)}
+    end
+  end
 
   defp confine_path(root, path) do
     case Raxol.Core.Boundary.Path.confine(root, path, ref_format: ~r/\.exs?$/) do

--- a/lib/raxol/headless/mcp_tools.ex
+++ b/lib/raxol/headless/mcp_tools.ex
@@ -43,7 +43,9 @@ defmodule Raxol.Headless.McpTools do
                 "Script path RELATIVE to the configured headless path root, e.g. " <>
                   "\"examples/demo.exs\". Disabled unless RAXOL_HEADLESS_PATH_ROOT " <>
                   "(or config :raxol, :headless_path_root) is set, because starting " <>
-                  "from a path compiles the file. Mutually exclusive with module."
+                  "from a path compiles the file. An absolute path is REFUSED " <>
+                  "rather than resolved under the root, so the file that runs is " <>
+                  "always the file you named. Mutually exclusive with module."
             },
             id: %{
               type: "string",
@@ -494,7 +496,61 @@ defmodule Raxol.Headless.McpTools do
     end
   end
 
-  defp confine_path(root, path) do
+  # An absolute path is REFUSED here rather than left to `confine/3`.
+  #
+  # `confine/3` is safe either way: it does `Path.join(root, requested)`, so
+  # `/etc/evil.exs` is jailed to `<root>/etc/evil.exs` and never honoured. But
+  # jailing it means the tool compiles a DIFFERENT file than the one it was
+  # asked for and says nothing, and the schema already documents this argument
+  # as relative to the root. For an argument whose whole job is choosing which
+  # code executes, answering a different file silently is the worse of the two
+  # available behaviours -- so the mismatch is named instead.
+  #
+  defp confine_path(root, path) when path != "" do
+    case anchored_kind(path) do
+      nil -> do_confine_path(root, path)
+      kind -> {:error, absolute_refusal(path, kind)}
+    end
+  end
+
+  defp confine_path(_root, _path),
+    do: {:error, "path must not be empty"}
+
+  # `nil` for a genuinely relative path; otherwise what it is anchored at.
+  #
+  # `Path.type/1` alone is not enough, because it is OS-dependent in exactly the
+  # direction that hurts: on Unix `Path.type("c:/x")` is `:relative`, so the
+  # same argument would be refused on Windows and rewritten under the root on
+  # Unix. `Raxol.Core.Boundary.Path` settled this question one layer down --
+  # a drive or UNC anchor counts on EVERY host, because one rule erring toward
+  # refusal beats two rules disagreeing about the same string -- and this
+  # mirrors it rather than inventing a second answer.
+  defp anchored_kind(path) do
+    cond do
+      Path.type(path) != :relative -> Path.type(path)
+      drive_anchored?(path) -> :drive_absolute
+      unc_anchored?(path) -> :unc_absolute
+      true -> nil
+    end
+  end
+
+  defp drive_anchored?(<<letter, ?:, _::binary>>)
+       when letter in ?A..?Z or letter in ?a..?z,
+       do: true
+
+  defp drive_anchored?(_), do: false
+
+  defp unc_anchored?(<<sep, sep, _::binary>>) when sep in [?/, ?\\], do: true
+  defp unc_anchored?(_), do: false
+
+  defp absolute_refusal(path, kind) do
+    "path must be RELATIVE to the configured headless path root, and " <>
+      "#{inspect(path)} is #{kind}. It would be jailed under the root rather " <>
+      "than honoured, so the file that ran would not be the file you named. " <>
+      "Drop the leading separator or drive."
+  end
+
+  defp do_confine_path(root, path) do
     case Raxol.Core.Boundary.Path.confine(root, path, ref_format: ~r/\.exs?$/) do
       {:ok, real} ->
         {:ok, real}

--- a/lib/raxol/headless/mcp_tools.ex
+++ b/lib/raxol/headless/mcp_tools.ex
@@ -303,8 +303,20 @@ defmodule Raxol.Headless.McpTools do
 
   defp do_start(module_or_path, opts) do
     case Raxol.Headless.start(module_or_path, opts) do
-      {:ok, session_id} -> {:ok, "Session started: #{session_id}"}
-      {:error, reason} -> {:error, inspect(reason)}
+      {:ok, session_id} ->
+        {:ok, "Session started: #{session_id}"}
+
+      # Spelled out rather than `inspect`ed because this is the refusal an
+      # operator is most likely to hit by naming a real module that simply is
+      # not an app, and the tuple alone does not say what the contract IS.
+      {:error, {:not_a_raxol_application, module}} ->
+        {:error,
+         "#{inspect(module)} exists but is not a Raxol application: it neither " <>
+           "declares Raxol.Core.Runtime.Application nor exports init/1, " <>
+           "update/2 and view/1"}
+
+      {:error, reason} ->
+        {:error, inspect(reason)}
     end
   end
 
@@ -397,8 +409,13 @@ defmodule Raxol.Headless.McpTools do
       {:ok, module} ->
         {:ok, module}
 
+      # Not "it is not loaded": the code path is what decided, and a module
+      # being unloaded is the normal state under `mix mcp.server` rather than a
+      # reason to refuse anything. What is missing is the beam itself.
       :error ->
-        {:error, "unknown module #{inspect(mod)}: it is not loaded in this VM"}
+        {:error,
+         "unknown module #{inspect(mod)}: no compiled module by that name is " <>
+           "loadable in this VM"}
     end
   end
 

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
@@ -847,7 +847,7 @@ defmodule Raxol.AgentClientProtocol.Client.FsSandbox do
         {"/", rest}
 
       [anchor | rest] = split ->
-        case drive_root(anchor) do
+        case absolute_anchor(anchor) do
           nil -> {base, split}
           root -> {root, rest}
         end
@@ -861,13 +861,29 @@ defmodule Raxol.AgentClientProtocol.Client.FsSandbox do
   # splits the same string. A bare drive is drive-RELATIVE on Windows rather than
   # absolute, but anchoring it at the drive root refuses it, which is the safe
   # direction for a boundary.
-  defp drive_root(<<letter, ?:>>) when letter in ?A..?Z or letter in ?a..?z,
+  defp absolute_anchor(<<letter, ?:>>) when letter in ?A..?Z or letter in ?a..?z,
     do: <<letter, ?:, ?/>>
 
-  defp drive_root(<<letter, ?:, ?/>>) when letter in ?A..?Z or letter in ?a..?z,
-    do: <<letter, ?:, ?/>>
+  defp absolute_anchor(<<letter, ?:, ?/>>)
+       when letter in ?A..?Z or letter in ?a..?z,
+       do: <<letter, ?:, ?/>>
 
-  defp drive_root(_), do: nil
+  # UNC, the same anchor bug one shape over. `:filename.split/1` on Windows gives
+  # a UNC path its own `"//"` component (both `"//host/share/x"` and the
+  # `"\\\\host\\share\\x"` spelling land there), which is no drive letter -- so it
+  # took the very relative branch the drive case was fixed out of.
+  #
+  # The clause matches TWO IDENTICAL separators, mirroring the `Slash, Slash`
+  # guard `:filename.win32_splitb/1` decides UNC by. That also covers the shape
+  # Unix produces: a backslash is an ordinary character there, so
+  # `"\\\\host\\share\\x"` never splits at all and arrives whole as the anchor,
+  # relative-looking. Same link, contained on Unix and escaping on Windows, which
+  # is exactly the per-host divergence this function exists to remove -- so the
+  # whole anchor is returned as the root and refused on both.
+  defp absolute_anchor(<<sep, sep, _::binary>> = unc) when sep in [?/, ?\\],
+    do: unc
+
+  defp absolute_anchor(_), do: nil
 
   defp slice(content, nil, _limit), do: content
 

--- a/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
+++ b/packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex
@@ -815,17 +815,59 @@ defmodule Raxol.AgentClientProtocol.Client.FsSandbox do
     case :file.read_link(candidate) do
       {:ok, target} ->
         # A symlink resolves against its REAL parent (`base`): an absolute target
-        # restarts from the filesystem root, a relative one (possibly with `..`)
-        # is spliced ahead of the remaining components and resolved against base.
-        case Path.split(to_string(target)) do
-          ["/" | target_rest] -> walk_real("/", target_rest ++ rest, depth + 1)
-          target_rest -> walk_real(base, target_rest ++ rest, depth + 1)
-        end
+        # restarts from its own anchor, a relative one (possibly with `..`) is
+        # spliced ahead of the remaining components and resolved against base.
+        {anchor, target_rest} = anchor_target(to_string(target), base)
+        walk_real(anchor, target_rest ++ rest, depth + 1)
 
       {:error, _not_a_symlink_or_missing} ->
         walk_real(candidate, rest, depth)
     end
   end
+
+  # Split a symlink target into the base it resolves against and the components
+  # to walk from there.
+  #
+  # `Path.split/1` is `:filename.split/1`, whose notion of "absolute" is
+  # OS-dependent: a Windows absolute target splits as `["c:/", "tmp", ...]`,
+  # keeping the drive as its own anchor, while the SAME string on Unix splits as
+  # `["c:", "tmp", ...]` with no anchor at all. Matching only the POSIX `"/"`
+  # anchor therefore sent every Windows-absolute target down the relative branch,
+  # where it was spliced onto `base` and landed back INSIDE the root -- an escape
+  # the post-resolution re-check could not see, because nothing had left.
+  #
+  # A drive anchor counts on EVERY host rather than only on Windows. Deciding it
+  # per-host would mean the same link is contained on one platform and not on
+  # another, and one rule errs the safe way: on Unix a target of `c:/outside/x`
+  # names a directory literally called `c:`, so treating it as absolute refuses a
+  # pathological-but-legal relative path instead of admitting a real escape.
+  defp anchor_target(target, base) do
+    case Path.split(target) do
+      ["/" | rest] ->
+        {"/", rest}
+
+      [anchor | rest] = split ->
+        case drive_root(anchor) do
+          nil -> {base, split}
+          root -> {root, rest}
+        end
+
+      [] ->
+        {base, []}
+    end
+  end
+
+  # `"c:/"` is how Windows splits a drive-absolute target; `"c:"` is how Unix
+  # splits the same string. A bare drive is drive-RELATIVE on Windows rather than
+  # absolute, but anchoring it at the drive root refuses it, which is the safe
+  # direction for a boundary.
+  defp drive_root(<<letter, ?:>>) when letter in ?A..?Z or letter in ?a..?z,
+    do: <<letter, ?:, ?/>>
+
+  defp drive_root(<<letter, ?:, ?/>>) when letter in ?A..?Z or letter in ?a..?z,
+    do: <<letter, ?:, ?/>>
+
+  defp drive_root(_), do: nil
 
   defp slice(content, nil, _limit), do: content
 

--- a/packages/raxol_agent_client_protocol/test/support/boundary_vectors/path_reject_vectors.json
+++ b/packages/raxol_agent_client_protocol/test/support/boundary_vectors/path_reject_vectors.json
@@ -156,6 +156,36 @@
         }
       ],
       "expect": "symlink_escape"
+    },
+    {
+      "name": "drive_absolute_symlink_escape",
+      "root": "root",
+      "requested": "link",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/link",
+          "target": "c:/outside/secret.txt"
+        }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "drive_absolute_ancestor_symlink_escape",
+      "root": "root",
+      "requested": "esc/secret.txt",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/esc",
+          "target": "c:/outside"
+        }
+      ],
+      "expect": "symlink_escape"
     }
   ]
 }

--- a/packages/raxol_agent_client_protocol/test/support/boundary_vectors/path_reject_vectors.json
+++ b/packages/raxol_agent_client_protocol/test/support/boundary_vectors/path_reject_vectors.json
@@ -186,6 +186,66 @@
         }
       ],
       "expect": "symlink_escape"
+    },
+    {
+      "name": "unc_absolute_symlink_escape",
+      "root": "root",
+      "requested": "link",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/link",
+          "target": "//host/share/secret.txt"
+        }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "unc_absolute_ancestor_symlink_escape",
+      "root": "root",
+      "requested": "esc/secret.txt",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/esc",
+          "target": "//host/share"
+        }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "unc_backslash_symlink_escape",
+      "root": "root",
+      "requested": "link",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/link",
+          "target": "\\\\host\\share\\secret.txt"
+        }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "unc_backslash_ancestor_symlink_escape",
+      "root": "root",
+      "requested": "esc/secret.txt",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/esc",
+          "target": "\\\\host\\share"
+        }
+      ],
+      "expect": "symlink_escape"
     }
   ]
 }

--- a/packages/raxol_core/lib/raxol/core/boundary/path.ex
+++ b/packages/raxol_core/lib/raxol/core/boundary/path.ex
@@ -145,15 +145,57 @@ defmodule Raxol.Core.Boundary.Path do
     case :file.read_link(candidate) do
       {:ok, target} ->
         # A symlink resolves against its REAL parent (`base`): an absolute target
-        # restarts from the filesystem root, a relative one (possibly with `..`)
-        # is spliced ahead of the remaining components and resolved against base.
-        case Path.split(to_string(target)) do
-          ["/" | target_rest] -> walk_real("/", target_rest ++ rest, depth + 1)
-          target_rest -> walk_real(base, target_rest ++ rest, depth + 1)
-        end
+        # restarts from its own anchor, a relative one (possibly with `..`) is
+        # spliced ahead of the remaining components and resolved against base.
+        {anchor, target_rest} = anchor_target(to_string(target), base)
+        walk_real(anchor, target_rest ++ rest, depth + 1)
 
       {:error, _not_a_symlink_or_missing} ->
         walk_real(candidate, rest, depth)
     end
   end
+
+  # Split a symlink target into the base it resolves against and the components
+  # to walk from there.
+  #
+  # `Path.split/1` is `:filename.split/1`, whose notion of "absolute" is
+  # OS-dependent: a Windows absolute target splits as `["c:/", "tmp", ...]`,
+  # keeping the drive as its own anchor, while the SAME string on Unix splits as
+  # `["c:", "tmp", ...]` with no anchor at all. Matching only the POSIX `"/"`
+  # anchor therefore sent every Windows-absolute target down the relative branch,
+  # where it was spliced onto `base` and landed back INSIDE the root -- an escape
+  # `escape_gate/2` could not see, because nothing had left.
+  #
+  # A drive anchor counts on EVERY host rather than only on Windows. Deciding it
+  # per-host would mean the same link is contained on one platform and not on
+  # another, and one rule errs the safe way: on Unix a target of `c:/outside/x`
+  # names a directory literally called `c:`, so treating it as absolute refuses a
+  # pathological-but-legal relative path instead of admitting a real escape.
+  defp anchor_target(target, base) do
+    case Path.split(target) do
+      ["/" | rest] ->
+        {"/", rest}
+
+      [anchor | rest] = split ->
+        case drive_root(anchor) do
+          nil -> {base, split}
+          root -> {root, rest}
+        end
+
+      [] ->
+        {base, []}
+    end
+  end
+
+  # `"c:/"` is how Windows splits a drive-absolute target; `"c:"` is how Unix
+  # splits the same string. A bare drive is drive-RELATIVE on Windows rather than
+  # absolute, but anchoring it at the drive root refuses it, which is the safe
+  # direction for a boundary.
+  defp drive_root(<<letter, ?:>>) when letter in ?A..?Z or letter in ?a..?z,
+    do: <<letter, ?:, ?/>>
+
+  defp drive_root(<<letter, ?:, ?/>>) when letter in ?A..?Z or letter in ?a..?z,
+    do: <<letter, ?:, ?/>>
+
+  defp drive_root(_), do: nil
 end

--- a/packages/raxol_core/lib/raxol/core/boundary/path.ex
+++ b/packages/raxol_core/lib/raxol/core/boundary/path.ex
@@ -177,7 +177,7 @@ defmodule Raxol.Core.Boundary.Path do
         {"/", rest}
 
       [anchor | rest] = split ->
-        case drive_root(anchor) do
+        case absolute_anchor(anchor) do
           nil -> {base, split}
           root -> {root, rest}
         end
@@ -191,11 +191,27 @@ defmodule Raxol.Core.Boundary.Path do
   # splits the same string. A bare drive is drive-RELATIVE on Windows rather than
   # absolute, but anchoring it at the drive root refuses it, which is the safe
   # direction for a boundary.
-  defp drive_root(<<letter, ?:>>) when letter in ?A..?Z or letter in ?a..?z,
+  defp absolute_anchor(<<letter, ?:>>) when letter in ?A..?Z or letter in ?a..?z,
     do: <<letter, ?:, ?/>>
 
-  defp drive_root(<<letter, ?:, ?/>>) when letter in ?A..?Z or letter in ?a..?z,
-    do: <<letter, ?:, ?/>>
+  defp absolute_anchor(<<letter, ?:, ?/>>)
+       when letter in ?A..?Z or letter in ?a..?z,
+       do: <<letter, ?:, ?/>>
 
-  defp drive_root(_), do: nil
+  # UNC, the same anchor bug one shape over. `:filename.split/1` on Windows gives
+  # a UNC path its own `"//"` component (both `"//host/share/x"` and the
+  # `"\\\\host\\share\\x"` spelling land there), which is no drive letter -- so it
+  # took the very relative branch the drive case was fixed out of.
+  #
+  # The clause matches TWO IDENTICAL separators, mirroring the `Slash, Slash`
+  # guard `:filename.win32_splitb/1` decides UNC by. That also covers the shape
+  # Unix produces: a backslash is an ordinary character there, so
+  # `"\\\\host\\share\\x"` never splits at all and arrives whole as the anchor,
+  # relative-looking. Same link, contained on Unix and escaping on Windows, which
+  # is exactly the per-host divergence this function exists to remove -- so the
+  # whole anchor is returned as the root and refused on both.
+  defp absolute_anchor(<<sep, sep, _::binary>> = unc) when sep in [?/, ?\\],
+    do: unc
+
+  defp absolute_anchor(_), do: nil
 end

--- a/packages/raxol_core/test/raxol/core/stores/naming_test.exs
+++ b/packages/raxol_core/test/raxol/core/stores/naming_test.exs
@@ -6,6 +6,35 @@ defmodule Raxol.Core.Stores.NamingTest do
   defmodule SomeStore do
   end
 
+  # Both tests spawn a process and give it `assert_receive`'s 100ms to answer.
+  # That budget is for the BEHAVIOUR, and the first `registered_name!/1` call
+  # anywhere in a run spends more than it on loading code on demand: measured at
+  # 112ms, 181ms and 182ms, against a 100ms deadline.
+  #
+  # It is not one module. Loading `Naming` up front is not enough, because the
+  # failing path raises, and `raise` + the `inspect(module)` inside the message
+  # pull in `RuntimeError`, `Exception`, `Inspect`, `Inspect.Atom` and
+  # `Inspect.Opts` -- all five confirmed cold via `:code.is_loaded/1` at that
+  # point. So the warm-up has to be the CALL, not a module list that would
+  # quietly stop covering the path the day the message changes.
+  #
+  # `setup_all` has no registered name either, so this takes the same branch the
+  # second test asserts on, and rescues it the same way.
+  #
+  # This is why the failure looked like a flake without being one: it failed 17
+  # runs in 20 in isolation, but only occasionally in a full run, where whether
+  # some earlier test had already loaded that machinery decided it -- and test
+  # order is seeded per run. Raising the timeout would only widen the race.
+  setup_all do
+    try do
+      Naming.registered_name!(SomeStore)
+    rescue
+      e -> Exception.message(e)
+    end
+
+    :ok
+  end
+
   test "returns the registered name of the calling process" do
     name = :"core_stores_naming_#{System.unique_integer([:positive])}"
     parent = self()

--- a/packages/raxol_core/test/support/boundary_vectors/path_reject_vectors.json
+++ b/packages/raxol_core/test/support/boundary_vectors/path_reject_vectors.json
@@ -156,6 +156,36 @@
         }
       ],
       "expect": "symlink_escape"
+    },
+    {
+      "name": "drive_absolute_symlink_escape",
+      "root": "root",
+      "requested": "link",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/link",
+          "target": "c:/outside/secret.txt"
+        }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "drive_absolute_ancestor_symlink_escape",
+      "root": "root",
+      "requested": "esc/secret.txt",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/esc",
+          "target": "c:/outside"
+        }
+      ],
+      "expect": "symlink_escape"
     }
   ]
 }

--- a/packages/raxol_core/test/support/boundary_vectors/path_reject_vectors.json
+++ b/packages/raxol_core/test/support/boundary_vectors/path_reject_vectors.json
@@ -186,6 +186,66 @@
         }
       ],
       "expect": "symlink_escape"
+    },
+    {
+      "name": "unc_absolute_symlink_escape",
+      "root": "root",
+      "requested": "link",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/link",
+          "target": "//host/share/secret.txt"
+        }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "unc_absolute_ancestor_symlink_escape",
+      "root": "root",
+      "requested": "esc/secret.txt",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/esc",
+          "target": "//host/share"
+        }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "unc_backslash_symlink_escape",
+      "root": "root",
+      "requested": "link",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/link",
+          "target": "\\\\host\\share\\secret.txt"
+        }
+      ],
+      "expect": "symlink_escape"
+    },
+    {
+      "name": "unc_backslash_ancestor_symlink_escape",
+      "root": "root",
+      "requested": "esc/secret.txt",
+      "setup": [
+        {
+          "dir": "root"
+        },
+        {
+          "symlink": "root/esc",
+          "target": "\\\\host\\share"
+        }
+      ],
+      "expect": "symlink_escape"
     }
   ]
 }

--- a/test/raxol/boundary_vector_parity_test.exs
+++ b/test/raxol/boundary_vector_parity_test.exs
@@ -1,0 +1,106 @@
+defmodule Raxol.BoundaryVectorParityTest do
+  @moduledoc """
+  The two copies of the shared path-confinement conformance corpus must be
+  byte-identical.
+
+  `Raxol.Core.Boundary.Path` and `Raxol.AgentClientProtocol.Client.FsSandbox`
+  are deliberate duplicates: the Agent Client Protocol package must stay
+  zero-raxol-dep, so it cannot consume raxol_core. Three places in the tree say
+  the duplication is safe BECAUSE both bind to one corpus:
+
+    * `packages/raxol_core/lib/raxol/core/boundary/path.ex` -- "both bind to the
+      same shared conformance vectors ... so drift is a red test, not a silent
+      fork"
+    * `packages/raxol_agent_client_protocol/lib/raxol/agent_client_protocol/client.ex`
+      -- "The two are bound to the SAME shared conformance vectors"
+    * `packages/raxol_core/test/support/boundary_vectors/README.md` -- "Change a
+      path vector and you must update both copies ... or neither"
+
+  All three stated a rule that nothing ran. The corpora are two directories of
+  JSON copied by hand, so adding a vector to one and forgetting the other turned
+  that package red against a corpus the sibling had never seen, while the
+  sibling stayed green against its stale copy -- which reads as "the sibling is
+  fine" and is the exact silent fork the duplication was allowed on condition of
+  avoiding.
+
+  This lives in the ROOT suite because it is the only one that structurally owns
+  both packages: neither package can see the other's test tree from its own
+  `mix test`, and raxol_core must not grow a path dependency on the Agent Client
+  Protocol package just to check a file.
+  """
+
+  use ExUnit.Case, async: true
+
+  @core "packages/raxol_core/test/support/boundary_vectors"
+  @acp "packages/raxol_agent_client_protocol/test/support/boundary_vectors"
+
+  # Only the `path_*` files are shared. `term_text_vectors.json` drives
+  # `Boundary.TermText`, a different boundary with no ACP counterpart, and
+  # `README.md` documents the corpus rather than being part of it -- so a rule
+  # of "every file in one exists in the other" would be wrong in the direction
+  # that produces false failures.
+  @shared "path_*_vectors.json"
+
+  defp shared_names(dir) do
+    dir
+    |> Path.join(@shared)
+    |> Path.wildcard()
+    |> Enum.map(&Path.basename/1)
+    |> Enum.sort()
+  end
+
+  test "both packages carry the same set of shared path vector files" do
+    core = shared_names(@core)
+    acp = shared_names(@acp)
+
+    assert core != [],
+           "no #{@shared} under #{@core}; this test is checking nothing"
+
+    assert core == acp,
+           """
+           The shared path-vector file sets have diverged.
+
+             #{@core}: #{inspect(core)}
+             #{@acp}: #{inspect(acp)}
+
+           A new vector FILE has to be copied into both trees, the same as a new
+           vector inside one. Only #{@shared} is shared; term_text_vectors.json
+           is raxol_core's alone.
+           """
+  end
+
+  test "every shared path vector file is byte-identical across the two copies" do
+    for name <- shared_names(@core) do
+      core_path = Path.join(@core, name)
+      acp_path = Path.join(@acp, name)
+
+      # Compared as BYTES, not as decoded JSON. The README's rule is "copy
+      # verbatim", and a decoded comparison would pass on two files that differ
+      # in key order or whitespace -- which is a copy nobody actually made, and
+      # the next hand-merge between them is where a vector goes missing.
+      assert File.read!(core_path) == File.read!(acp_path),
+             """
+             #{name} differs between the two boundary vector trees.
+
+               #{core_path}
+               #{acp_path}
+
+             `Raxol.Core.Boundary.Path` and
+             `Raxol.AgentClientProtocol.Client.FsSandbox` are duplicate
+             implementations kept honest ONLY by both running this corpus. A
+             vector added to one tree and not the other leaves the sibling
+             green against a case it has never been asked about.
+
+             Copy the file across verbatim:
+
+                 cp #{core_path} #{acp_path}
+
+             Then make sure the sibling implementation actually passes it. If it
+             cannot -- because the vector exercises a `Path.confine/3`-only
+             feature such as the `ref_format` ref-shape gate -- the vector still
+             belongs in both files; it is the ACP-side test that skips it, per
+             #{@core}/README.md.
+             """
+    end
+  end
+end

--- a/test/raxol/headless/mcp_tools_test.exs
+++ b/test/raxol/headless/mcp_tools_test.exs
@@ -30,6 +30,170 @@ defmodule Raxol.Headless.McpToolsTest do
     end
   end
 
+  # `raxol_start`'s `"path"` compiles the file it is given, and compiling a
+  # `defmodule` executes its body -- so this branch is arbitrary code execution
+  # with the BEAM's privileges, reachable from any connected MCP client. These
+  # tests drive the real tool callback; nothing here is stubbed.
+  describe "raxol_start path containment" do
+    setup do
+      root =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol-headless-root-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(Path.join(root, "inside"))
+      File.chmod!(root, 0o700)
+
+      File.write!(
+        Path.join(root, "inside/ok.exs"),
+        "defmodule NoView do\nend\n"
+      )
+
+      prev = System.get_env("RAXOL_HEADLESS_PATH_ROOT")
+
+      on_exit(fn ->
+        if prev,
+          do: System.put_env("RAXOL_HEADLESS_PATH_ROOT", prev),
+          else: System.delete_env("RAXOL_HEADLESS_PATH_ROOT")
+
+        File.rm_rf!(root)
+      end)
+
+      System.delete_env("RAXOL_HEADLESS_PATH_ROOT")
+      %{root: root}
+    end
+
+    defp start_tool,
+      do: Enum.find(McpTools.tools(), &(&1.name == "raxol_start")).callback
+
+    # The tool reaches `Raxol.Headless` only once resolution ACCEPTS the path,
+    # and whether that server is running is not what these assert on. Catching
+    # the exit keeps the subject the refusal, not the session manager.
+    defp call_start(args) do
+      start_tool().(args)
+    catch
+      :exit, reason -> {:reached_headless, reason}
+    end
+
+    test "a path is refused outright when no root is configured" do
+      assert {:error, message} = call_start(%{"path" => "examples/demo.exs"})
+      assert message =~ "RAXOL_HEADLESS_PATH_ROOT"
+      assert message =~ "disabled"
+    end
+
+    test "a path inside the configured root is accepted", %{root: root} do
+      System.put_env("RAXOL_HEADLESS_PATH_ROOT", root)
+
+      # Not `{:error, _}` from RESOLUTION: it either reached Headless or came
+      # back with Headless's own answer. Either way the path was let through.
+      result = call_start(%{"path" => "inside/ok.exs"})
+
+      refute match?({:error, "starting from a path is disabled" <> _}, result)
+      refute match?({:error, "path is outside" <> _}, result)
+    end
+
+    test "a .. traversal out of the root is refused", %{root: root} do
+      System.put_env("RAXOL_HEADLESS_PATH_ROOT", Path.join(root, "inside"))
+
+      assert {:error, message} =
+               call_start(%{"path" => "../../../etc/passwd.exs"})
+
+      assert message =~ "outside the configured headless path root"
+    end
+
+    # `Raxol.Headless` is not running here, so an ACCEPTED path surfaces as a
+    # `:noproc` exit whose payload carries the path that would have been handed
+    # downstream. That is exactly what needs pinning: not whether the call
+    # succeeded, but WHICH file it resolved to.
+    defp resolved_target(args) do
+      case call_start(args) do
+        {:reached_headless,
+         {:noproc,
+          {GenServer, :call,
+           [_server, {:start_session, target, _opts}, _timeout]}}} ->
+          {:resolved, target}
+
+        other ->
+          other
+      end
+    end
+
+    test "an absolute path is jailed under the root, never honoured verbatim",
+         %{root: root} do
+      System.put_env("RAXOL_HEADLESS_PATH_ROOT", root)
+
+      # `confine/3` JOINS the request under the root, so an absolute path is
+      # remapped rather than refused -- it lands at <root>/etc/evil.exs, which
+      # is the safe outcome and the one worth pinning. Refusing would be fine
+      # too; silently honouring `/etc/evil.exs` would not.
+      assert {:resolved, target} = resolved_target(%{"path" => "/etc/evil.exs"})
+
+      refute target == "/etc/evil.exs"
+      assert String.ends_with?(target, "/etc/evil.exs")
+      assert target =~ Path.basename(root)
+    end
+
+    test "a symlink inside the root pointing outside it is refused", %{
+      root: root
+    } do
+      # The case that passes if containment is decided on the LEXICAL path:
+      # `<root>/escape.exs` is textually inside, and resolves outside.
+      outside =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol-outside-#{System.unique_integer([:positive])}.exs"
+        )
+
+      File.write!(outside, "defmodule Escaped do\nend\n")
+      on_exit(fn -> File.rm(outside) end)
+
+      link = Path.join(root, "escape.exs")
+
+      case File.ln_s(outside, link) do
+        :ok ->
+          System.put_env("RAXOL_HEADLESS_PATH_ROOT", root)
+
+          assert {:error, message} = call_start(%{"path" => "escape.exs"})
+          assert message =~ "outside the configured headless path root"
+
+        {:error, _} ->
+          # No symlink support on this filesystem; the lexical cases still ran.
+          :ok
+      end
+    end
+
+    test "a non-Elixir file is refused before it reaches the compiler", %{
+      root: root
+    } do
+      File.write!(Path.join(root, "notes.txt"), "hello")
+      System.put_env("RAXOL_HEADLESS_PATH_ROOT", root)
+
+      assert {:error, message} = call_start(%{"path" => "notes.txt"})
+      assert message =~ ".ex or .exs"
+    end
+
+    test "an unknown module is refused rather than minted as an atom" do
+      # Atoms are never collected, so minting one per distinct MCP-supplied
+      # string grows the atom table without bound.
+      name = "NoSuchHeadlessModule#{System.unique_integer([:positive])}"
+
+      assert {:error, message} = call_start(%{"module" => name})
+      assert message =~ "not loaded"
+
+      assert_raise ArgumentError, fn ->
+        String.to_existing_atom("Elixir." <> name)
+      end
+    end
+
+    test "the module refusal does not steer the caller onto the path branch" do
+      assert {:error, message} =
+               call_start(%{"module" => "NoSuchHeadlessModuleEver"})
+
+      refute message =~ "path"
+    end
+  end
+
   describe "tools/0" do
     test "returns 6 tool definitions" do
       tools = McpTools.tools()

--- a/test/raxol/headless/mcp_tools_test.exs
+++ b/test/raxol/headless/mcp_tools_test.exs
@@ -203,54 +203,6 @@ defmodule Raxol.Headless.McpToolsTest do
 
       refute message =~ "path"
     end
-
-    # The atom table is not the same question as "does this module exist".
-    # Interactive code loading -- `mix mcp.server`, the documented workflow -- is
-    # the normal case, and there a module's atom does not exist until something
-    # loads it. Refusing on the atom table alone therefore refuses modules that
-    # are compiled and sitting on the code path, which is what `raxol_start`
-    # asks for. An OTP release boots `:embedded` with everything pre-loaded, so
-    # this hides on fly.io and shows up locally.
-    #
-    # Compiled by a SEPARATE OS PROCESS on purpose: compiling it here would mint
-    # the atom in this VM and the test would pass against either version.
-    test "a compiled-but-unloaded module on the code path resolves" do
-      name = "HeadlessUnloadedProbe#{System.unique_integer([:positive])}"
-      dir = compile_out_of_vm(name)
-
-      # No one in this VM has ever named it.
-      assert_raise ArgumentError, fn ->
-        String.to_existing_atom("Elixir." <> name)
-      end
-
-      Code.append_path(dir)
-      on_exit(fn -> Code.delete_path(dir) end)
-
-      assert {:resolved, target} = resolved_target(%{"module" => name})
-      assert Atom.to_string(target) == "Elixir." <> name
-    end
-
-    defp compile_out_of_vm(name) do
-      dir =
-        Path.join(
-          System.tmp_dir!(),
-          "raxol-unloaded-#{System.unique_integer([:positive])}"
-        )
-
-      File.mkdir_p!(dir)
-      source = Path.join(dir, "probe.ex")
-      File.write!(source, "defmodule #{name} do\n  def view(_), do: :ok\nend\n")
-      on_exit(fn -> File.rm_rf!(dir) end)
-
-      elixirc =
-        System.find_executable("elixirc") ||
-          flunk("elixirc is required to compile a module outside this VM")
-
-      case System.cmd(elixirc, ["-o", dir, source], stderr_to_stdout: true) do
-        {_output, 0} -> dir
-        {output, status} -> flunk("elixirc exited #{status}: #{output}")
-      end
-    end
   end
 
   # Resolving a name is not the same as accepting it. These run the tool with a
@@ -301,6 +253,84 @@ defmodule Raxol.Headless.McpToolsTest do
       assert missing =~ "unknown module"
       refute missing =~ "is not a Raxol application"
       refute not_an_app =~ "unknown module"
+    end
+
+    # The atom table is not the same question as "does this module exist".
+    # Interactive code loading -- `mix mcp.server`, the documented workflow --
+    # is the normal case, and there a module's atom does not exist until
+    # something loads it. Refusing on the atom table alone therefore refuses
+    # modules that are compiled and sitting on the code path, which is what
+    # `raxol_start` asks for. An OTP release boots `:embedded` with everything
+    # pre-loaded, so this hides on fly.io and shows up locally.
+    #
+    # It lives in THIS describe, behind a real `Raxol.Headless`, because the
+    # contract gate runs server-side. Asserted from a block with no server, the
+    # call exits `:noproc` before ever reaching the gate, and the test passes on
+    # an artefact of the downed server rather than on the answer an operator
+    # gets.
+    #
+    # Compiled by a SEPARATE OS PROCESS on purpose: compiling it here would mint
+    # the atom in this VM and the test would pass against either version.
+    test "a compiled-but-unloaded module on the code path starts" do
+      name = "HeadlessUnloadedProbe#{System.unique_integer([:positive])}"
+      dir = compile_out_of_vm(name)
+
+      # No one in this VM has ever named it.
+      assert_raise ArgumentError, fn ->
+        String.to_existing_atom("Elixir." <> name)
+      end
+
+      Code.append_path(dir)
+      on_exit(fn -> Code.delete_path(dir) end)
+
+      assert {:ok, message} =
+               start_tool_result(%{"module" => name, "id" => "unloaded_probe"})
+
+      assert message =~ "unloaded_probe"
+
+      # The session dies with the `Raxol.Headless` the setup started, so in the
+      # normal case there is nothing to clean up -- and an unguarded stop races
+      # that teardown and exits `:noproc`. Guarded rather than dropped because
+      # the setup REUSES an already-running server when it finds one, and then
+      # the session really would outlive this test.
+      on_exit(fn ->
+        if Process.whereis(Raxol.Headless),
+          do: Raxol.Headless.stop("unloaded_probe")
+      end)
+    end
+
+    # The full TEA triple, not `view/1` alone: this fixture stands in for a real
+    # application, and a gate that names `init/1, update/2 and view/1` has to be
+    # given something that satisfies it or the test is measuring the gate's
+    # refusal instead of the code-path lookup it is about.
+    defp compile_out_of_vm(name) do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol-unloaded-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      source = Path.join(dir, "probe.ex")
+
+      File.write!(source, """
+      defmodule #{name} do
+        def init(_), do: %{}
+        def update(_msg, model), do: model
+        def view(_), do: :ok
+      end
+      """)
+
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      elixirc =
+        System.find_executable("elixirc") ||
+          flunk("elixirc is required to compile a module outside this VM")
+
+      case System.cmd(elixirc, ["-o", dir, source], stderr_to_stdout: true) do
+        {_output, 0} -> dir
+        {output, status} -> flunk("elixirc exited #{status}: #{output}")
+      end
     end
   end
 

--- a/test/raxol/headless/mcp_tools_test.exs
+++ b/test/raxol/headless/mcp_tools_test.exs
@@ -199,6 +199,54 @@ defmodule Raxol.Headless.McpToolsTest do
 
       refute message =~ "path"
     end
+
+    # The atom table is not the same question as "does this module exist".
+    # Interactive code loading -- `mix mcp.server`, the documented workflow -- is
+    # the normal case, and there a module's atom does not exist until something
+    # loads it. Refusing on the atom table alone therefore refuses modules that
+    # are compiled and sitting on the code path, which is what `raxol_start`
+    # asks for. An OTP release boots `:embedded` with everything pre-loaded, so
+    # this hides on fly.io and shows up locally.
+    #
+    # Compiled by a SEPARATE OS PROCESS on purpose: compiling it here would mint
+    # the atom in this VM and the test would pass against either version.
+    test "a compiled-but-unloaded module on the code path resolves" do
+      name = "HeadlessUnloadedProbe#{System.unique_integer([:positive])}"
+      dir = compile_out_of_vm(name)
+
+      # No one in this VM has ever named it.
+      assert_raise ArgumentError, fn ->
+        String.to_existing_atom("Elixir." <> name)
+      end
+
+      Code.append_path(dir)
+      on_exit(fn -> Code.delete_path(dir) end)
+
+      assert {:resolved, target} = resolved_target(%{"module" => name})
+      assert Atom.to_string(target) == "Elixir." <> name
+    end
+
+    defp compile_out_of_vm(name) do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol-unloaded-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      source = Path.join(dir, "probe.ex")
+      File.write!(source, "defmodule #{name} do\n  def view(_), do: :ok\nend\n")
+      on_exit(fn -> File.rm_rf!(dir) end)
+
+      elixirc =
+        System.find_executable("elixirc") ||
+          flunk("elixirc is required to compile a module outside this VM")
+
+      case System.cmd(elixirc, ["-o", dir, source], stderr_to_stdout: true) do
+        {_output, 0} -> dir
+        {output, status} -> flunk("elixirc exited #{status}: #{output}")
+      end
+    end
   end
 
   describe "tools/0" do

--- a/test/raxol/headless/mcp_tools_test.exs
+++ b/test/raxol/headless/mcp_tools_test.exs
@@ -134,14 +134,13 @@ defmodule Raxol.Headless.McpToolsTest do
       assert target =~ Path.basename(root)
     end
 
-    # Unix only. `confine/3` resolves a symlink target through
-    # `walk_real/3`, which recognizes an absolute target by the POSIX
-    # `["/" | rest]` shape alone -- a Windows `c:/...` target does not match it
-    # and is spliced onto the base as if relative, landing back inside the root.
-    # The escape is real there and goes undetected; that is a defect in the
-    # shared primitive, not in this caller, and it is filed separately. Running
-    # this here would assert a refusal the platform cannot currently make.
-    @tag :unix_only
+    # Runs on every platform, Windows included. It did not always: `walk_real/3`
+    # recognized an absolute symlink target by the POSIX `["/" | rest]` shape
+    # alone, so a Windows `c:/...` target was spliced onto the base as if
+    # relative and landed back inside the root. Fixed in
+    # `Raxol.Core.Boundary.Path` under a shared conformance vector
+    # (`drive_absolute_symlink_escape`), so this asserting on Windows is the
+    # end-to-end half of that proof.
     test "a symlink inside the root pointing outside it is refused", %{
       root: root
     } do

--- a/test/raxol/headless/mcp_tools_test.exs
+++ b/test/raxol/headless/mcp_tools_test.exs
@@ -186,7 +186,11 @@ defmodule Raxol.Headless.McpToolsTest do
       name = "NoSuchHeadlessModule#{System.unique_integer([:positive])}"
 
       assert {:error, message} = call_start(%{"module" => name})
-      assert message =~ "not loaded"
+
+      # The refusal says the BEAM is missing, not that the module is unloaded:
+      # unloaded is the ordinary state under `mix mcp.server`, and saying so
+      # sends an operator looking for a loading problem that is not there.
+      assert message =~ "no compiled module by that name is loadable"
 
       assert_raise ArgumentError, fn ->
         String.to_existing_atom("Elixir." <> name)
@@ -246,6 +250,57 @@ defmodule Raxol.Headless.McpToolsTest do
         {_output, 0} -> dir
         {output, status} -> flunk("elixirc exited #{status}: #{output}")
       end
+    end
+  end
+
+  # Resolving a name is not the same as accepting it. These run the tool with a
+  # real `Raxol.Headless` behind it, because the contract gate lives there and
+  # the point of the tool's wording is what an operator reads at the end of the
+  # whole call.
+  describe "raxol_start module contract" do
+    setup do
+      case Process.whereis(Raxol.Headless) do
+        nil -> start_supervised!({Raxol.Headless, [name: Raxol.Headless]})
+        pid -> pid
+      end
+
+      :ok
+    end
+
+    defp start_tool_result(args),
+      do:
+        Enum.find(McpTools.tools(), &(&1.name == "raxol_start")).callback.(args)
+
+    # A `BaseManager` GenServer, so it exports `init/1` and nothing else the
+    # runtime wants. It is one of the 527 modules on this tree that would have
+    # satisfied a bare `Code.ensure_loaded?/1`, and starting it ran its
+    # GenServer `init/1` outside any supervisor.
+    test "a real module that is not a Raxol application is refused" do
+      assert {:error, message} =
+               start_tool_result(%{
+                 "module" => "Raxol.Terminal.Buffer.BufferServer",
+                 "id" => "not_an_app"
+               })
+
+      assert message =~ "is not a Raxol application"
+      assert message =~ "init/1, update/2 and view/1"
+    end
+
+    # The two refusals send an operator in opposite directions -- go compile it
+    # versus go pick a different module -- so the wording has to separate them.
+    test "a missing module and a non-application module read differently" do
+      assert {:error, missing} =
+               start_tool_result(%{"module" => "NoSuchHeadlessAppAtAll"})
+
+      assert {:error, not_an_app} =
+               start_tool_result(%{
+                 "module" => "Raxol.Terminal.Buffer.BufferServer",
+                 "id" => "not_an_app_again"
+               })
+
+      assert missing =~ "unknown module"
+      refute missing =~ "is not a Raxol application"
+      refute not_an_app =~ "unknown module"
     end
   end
 

--- a/test/raxol/headless/mcp_tools_test.exs
+++ b/test/raxol/headless/mcp_tools_test.exs
@@ -134,6 +134,14 @@ defmodule Raxol.Headless.McpToolsTest do
       assert target =~ Path.basename(root)
     end
 
+    # Unix only. `confine/3` resolves a symlink target through
+    # `walk_real/3`, which recognizes an absolute target by the POSIX
+    # `["/" | rest]` shape alone -- a Windows `c:/...` target does not match it
+    # and is spliced onto the base as if relative, landing back inside the root.
+    # The escape is real there and goes undetected; that is a defect in the
+    # shared primitive, not in this caller, and it is filed separately. Running
+    # this here would assert a refusal the platform cannot currently make.
+    @tag :unix_only
     test "a symlink inside the root pointing outside it is refused", %{
       root: root
     } do

--- a/test/raxol/headless/mcp_tools_test.exs
+++ b/test/raxol/headless/mcp_tools_test.exs
@@ -82,13 +82,27 @@ defmodule Raxol.Headless.McpToolsTest do
       assert message =~ "disabled"
     end
 
-    test "a path inside the configured root is accepted", %{root: root} do
+    test "a path inside the configured root resolves to the file named", %{
+      root: root
+    } do
       System.put_env("RAXOL_HEADLESS_PATH_ROOT", root)
 
-      # Not `{:error, _}` from RESOLUTION: it either reached Headless or came
-      # back with Headless's own answer. Either way the path was let through.
-      result = call_start(%{"path" => "inside/ok.exs"})
+      # Asserts WHICH file, not merely that resolution did not refuse. A test
+      # that only ruled out the refusal branches would still pass if the path
+      # were silently rewritten -- which is exactly the behaviour the absolute
+      # case below now refuses, so the accepting case has to prove the opposite
+      # rather than assume it.
+      assert {:resolved, target} = resolved_target(%{"path" => "inside/ok.exs"})
 
+      # Compared against the root's REAL path, because that is what `confine/3`
+      # documents itself as returning -- and it is load-bearing on macOS, where
+      # `System.tmp_dir!()` hands back `/tmp`, a symlink to `/private/tmp`.
+      # Asserting the lexical path here would fail for the right behaviour.
+      real_root = File.cd!(root, &File.cwd!/0)
+
+      assert target == Path.join(real_root, "inside/ok.exs")
+
+      result = call_start(%{"path" => "inside/ok.exs"})
       refute match?({:error, "starting from a path is disabled" <> _}, result)
       refute match?({:error, "path is outside" <> _}, result)
     end
@@ -119,19 +133,42 @@ defmodule Raxol.Headless.McpToolsTest do
       end
     end
 
-    test "an absolute path is jailed under the root, never honoured verbatim",
+    # `confine/3` alone would JOIN this under the root, landing it at
+    # <root>/etc/evil.exs. That is safe -- `/etc/evil.exs` is never honoured --
+    # but it means the tool compiles a different file than the one it was asked
+    # for and says nothing, while the schema documents the argument as relative.
+    # For the argument that decides which code executes, a silent substitution
+    # is the worse of the two safe behaviours, so the mismatch is named.
+    test "an absolute path is refused, not silently jailed under the root",
          %{root: root} do
       System.put_env("RAXOL_HEADLESS_PATH_ROOT", root)
 
-      # `confine/3` JOINS the request under the root, so an absolute path is
-      # remapped rather than refused -- it lands at <root>/etc/evil.exs, which
-      # is the safe outcome and the one worth pinning. Refusing would be fine
-      # too; silently honouring `/etc/evil.exs` would not.
-      assert {:resolved, target} = resolved_target(%{"path" => "/etc/evil.exs"})
+      assert {:error, message} = call_start(%{"path" => "/etc/evil.exs"})
 
-      refute target == "/etc/evil.exs"
-      assert String.ends_with?(target, "/etc/evil.exs")
-      assert target =~ Path.basename(root)
+      assert message =~ "must be RELATIVE"
+      assert message =~ "would not be the file you named"
+    end
+
+    # The refusal must not be a leading-slash check. A Windows drive path is
+    # absolute too, and `/foo` on Windows is volume-relative -- neither is the
+    # relative path the caller was asked for, and both would otherwise be
+    # rewritten under the root.
+    test "a drive-absolute path is refused as well", %{root: root} do
+      System.put_env("RAXOL_HEADLESS_PATH_ROOT", root)
+
+      assert {:error, message} = call_start(%{"path" => "c:/windows/evil.exs"})
+
+      assert message =~ "must be RELATIVE"
+    end
+
+    test "an empty path is refused rather than resolving to the root", %{
+      root: root
+    } do
+      System.put_env("RAXOL_HEADLESS_PATH_ROOT", root)
+
+      assert {:error, message} = call_start(%{"path" => ""})
+
+      assert message =~ "must not be empty"
     end
 
     # Runs on every platform, Windows included. It did not always: `walk_real/3`

--- a/test/raxol/headless_test.exs
+++ b/test/raxol/headless_test.exs
@@ -444,6 +444,32 @@ defmodule Raxol.HeadlessTest do
       assert {:ok, :after_mojibake} =
                Headless.start(TestApp, id: :after_mojibake)
     end
+
+    # Declaring `@behaviour Raxol.Core.Runtime.Application` and implementing
+    # none of it compiles: Elixir warns about the missing callbacks, it does not
+    # refuse. So a gate that accepts the ATTRIBUTE admits a module nothing can
+    # drive, and the session that follows renders an empty frame forever -- a
+    # silent do-nothing where there used to be a clean error. Reachable from
+    # `mix raxol.render`, `Raxol.MCP.Test.start_session/2` and `raxol_start`'s
+    # `path` once a root is configured.
+    #
+    # `tea_module?/1` is shared with the module branch, so this pins the compile
+    # branch specifically: it is the one that regressed when the check moved
+    # from exports to the attribute.
+    test "a module that declares the behaviour but implements nothing is refused",
+         %{dir: dir} do
+      n = System.unique_integer([:positive])
+      path = Path.join(dir, "decl_only_#{n}.exs")
+
+      File.write!(path, """
+      defmodule HeadlessDeclOnly#{n} do
+        @behaviour Raxol.Core.Runtime.Application
+      end
+      """)
+
+      assert {:error, :no_tea_module_found} =
+               Headless.start(path, id: :decl_only)
+    end
   end
 
   describe "custom dimensions" do

--- a/test/raxol/headless_test.exs
+++ b/test/raxol/headless_test.exs
@@ -103,6 +103,39 @@ defmodule Raxol.HeadlessTest do
                Headless.start(NoSuchModule, id: :bad)
     end
 
+    # `Raxol.start_link/2` CALLS `init/1`, so admitting a module on "a beam
+    # exists for this name" starts whatever was named. 527 modules on this tree
+    # export `init/1` against 53 that implement TEA, and this is one of the
+    # former: a `BaseManager` GenServer whose `init/1` would have run here
+    # outside any supervisor.
+    test "refuses a real module that is not a Raxol application" do
+      assert {:error,
+              {:not_a_raxol_application, Raxol.Terminal.Buffer.BufferServer}} =
+               Headless.start(Raxol.Terminal.Buffer.BufferServer, id: :not_app)
+    end
+
+    # The gate asks the behaviour first, but it cannot ask ONLY that: the
+    # runtime does not, and `Raxol.Examples.Demos.IntegratedAccessibilityDemo`
+    # is a TEA app in this repo that never declares it. This module is that
+    # shape deliberately -- three callbacks, no `use`, no `@behaviour`.
+    defmodule UndeclaredApp do
+      def init(_context), do: %{}
+      def update(_message, model), do: {model, []}
+      def view(_model), do: Raxol.Core.Renderer.View.text("undeclared")
+    end
+
+    test "accepts a TEA app that never declared the behaviour" do
+      refute Raxol.Core.Runtime.Application in List.flatten(
+               Keyword.get_values(
+                 UndeclaredApp.module_info(:attributes),
+                 :behaviour
+               )
+             )
+
+      assert {:ok, :undeclared} =
+               Headless.start(UndeclaredApp, id: :undeclared)
+    end
+
     test "returns error for missing file" do
       assert {:error, {:file_not_found, _}} =
                Headless.start("nonexistent.exs", id: :bad)
@@ -222,7 +255,9 @@ defmodule Raxol.HeadlessTest do
   describe "file loading" do
     test "loads module from example script" do
       {:ok, id} =
-        Headless.start("examples/getting_started/counter.exs", id: :counter_test)
+        Headless.start("examples/getting_started/counter.exs",
+          id: :counter_test
+        )
 
       assert id == :counter_test
       Process.sleep(300)

--- a/test/raxol/headless_test.exs
+++ b/test/raxol/headless_test.exs
@@ -323,14 +323,91 @@ defmodule Raxol.HeadlessTest do
       assert {:error, {:compile_timed_out, ^path, 150}} =
                Headless.start(path, id: :wedge)
 
-      # Not just alive: still able to compile, after a compile was brutal-killed
-      # out from under the code server.
+      # Not just alive: still able to compile, after a compile was killed out
+      # from under the code server.
       assert Process.whereis(Headless) == manager
 
       good = script(dir, ~s|def noop, do: :ok|)
 
       assert {:error, :no_tea_module_found} =
                Headless.start(good, id: :after_wedge)
+    end
+
+    # The case above passes even when the kill does not land, because a
+    # non-trapping body dies of anything. `:brutal_kill` is a Supervisor
+    # shutdown SPEC; to `Process.exit/2` it is an ordinary, trappable reason, so
+    # a body that traps exits outlived its own budget -- one leaked process per
+    # hostile call, each still holding the code server's claim on the module
+    # name it was compiling, which denies that name to every later script for
+    # the life of the VM. So this asserts the corpse and the freed name, not
+    # merely that the caller was answered.
+    test "a body that traps exits is killed anyway, freeing its module name", %{
+      dir: dir
+    } do
+      prev = Application.get_env(:raxol, :headless_compile_timeout_ms)
+      Application.put_env(:raxol, :headless_compile_timeout_ms, 150)
+
+      on_exit(fn ->
+        if prev,
+          do: Application.put_env(:raxol, :headless_compile_timeout_ms, prev),
+          else: Application.delete_env(:raxol, :headless_compile_timeout_ms)
+      end)
+
+      # The compiling process IS the module body's process, so the body can hand
+      # its own pid back here. Nothing else can: the compile runs in a child the
+      # manager spawns and never names.
+      Process.register(self(), :headless_trap_probe)
+      n = System.unique_integer([:positive])
+      name = "HeadlessTrapProbe#{n}"
+      wedge = Path.join(dir, "trap_#{n}.exs")
+
+      File.write!(wedge, """
+      defmodule #{name} do
+        Process.flag(:trap_exit, true)
+        send(:headless_trap_probe, {:compiling, self()})
+        :timer.sleep(:infinity)
+      end
+      """)
+
+      assert {:error, {:compile_timed_out, ^wedge, 150}} =
+               Headless.start(wedge, id: :trap_wedge)
+
+      assert_received {:compiling, compiler}
+
+      # Monitoring after the fact races with a kill that already landed, and
+      # `:noproc` is that race resolving the right way.
+      ref = Process.monitor(compiler)
+      assert_receive {:DOWN, ^ref, :process, ^compiler, reason}, 1_000
+      assert reason in [:killed, :noproc]
+
+      # The point of killing it rather than merely answering the caller: the
+      # module name it held is usable again.
+      good = Path.join(dir, "trap_ok_#{n}.exs")
+      File.write!(good, "defmodule #{name} do\n  def noop, do: :ok\nend\n")
+
+      assert {:error, :no_tea_module_found} =
+               Headless.start(good, id: :after_trap)
+    end
+
+    # `Code.string_to_quoted/2` charlist-converts its input before parsing, so
+    # invalid encoding RAISES instead of answering -- inside `handle_call`, which
+    # takes the singleton and every unrelated session it holds. Reachable through
+    # the confined path too: the root check tests only the extension, so any
+    # binary file named `*.exs` inside the root is this.
+    test "a file that is not valid UTF-8 is answered, not raised", %{dir: dir} do
+      path = Path.join(dir, "mojibake.exs")
+      File.write!(path, <<0xFF, 0xFE, "defmodule Mojibake do\nend\n">>)
+      manager = Process.whereis(Headless)
+
+      assert {:error, {:unparseable_file, ^path, message}} =
+               Headless.start(path, id: :mojibake)
+
+      assert is_binary(message)
+
+      assert Process.whereis(Headless) == manager
+
+      assert {:ok, :after_mojibake} =
+               Headless.start(TestApp, id: :after_mojibake)
     end
   end
 

--- a/test/raxol/headless_test.exs
+++ b/test/raxol/headless_test.exs
@@ -232,6 +232,108 @@ defmodule Raxol.HeadlessTest do
     end
   end
 
+  # `Code.compile_quoted/2` EXECUTES module bodies, so whoever chooses the script
+  # chooses what runs here -- and here is the singleton holding every other
+  # caller's session. The body can end its own process three ways, of which a
+  # `rescue` sees one, and it need not end at all: a body that never returns does
+  # not kill this GenServer, it wedges it. Each case asserts BOTH halves: the
+  # answer the caller gets, and that unrelated callers are still served.
+  describe "start/2 with a script that misbehaves at compile time" do
+    setup do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "raxol_headless_compile_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf!(dir) end)
+      %{dir: dir}
+    end
+
+    # A fresh module name per script: these are compiled for real into this VM,
+    # and reusing a name would only add redefinition noise.
+    defp script(dir, body) do
+      n = System.unique_integer([:positive])
+      path = Path.join(dir, "hostile_#{n}.exs")
+      File.write!(path, "defmodule HostileScript#{n} do\n  #{body}\nend\n")
+      path
+    end
+
+    test "a body that raises is answered, not propagated", %{dir: dir} do
+      path = script(dir, ~s|raise "boom at module scope"|)
+      manager = Process.whereis(Headless)
+
+      assert {:error, {:compile_failed, ^path, message}} =
+               Headless.start(path, id: :raiser)
+
+      assert message =~ "boom at module scope"
+
+      assert Process.whereis(Headless) == manager
+      assert {:ok, :after_raise} = Headless.start(TestApp, id: :after_raise)
+    end
+
+    test "a body that throws is answered, which `rescue` alone never did", %{
+      dir: dir
+    } do
+      path = script(dir, ~s|throw(:thrown_at_module_scope)|)
+      manager = Process.whereis(Headless)
+
+      assert {:error, {:compile_failed, ^path, message}} =
+               Headless.start(path, id: :thrower)
+
+      assert message =~ "thrown_at_module_scope"
+
+      assert Process.whereis(Headless) == manager
+      assert {:ok, :after_throw} = Headless.start(TestApp, id: :after_throw)
+    end
+
+    test "a body that exits is answered, which `rescue` alone never did", %{
+      dir: dir
+    } do
+      path = script(dir, ~s|exit(:exited_at_module_scope)|)
+      manager = Process.whereis(Headless)
+
+      assert {:error, {:compile_failed, ^path, message}} =
+               Headless.start(path, id: :exiter)
+
+      assert message =~ "exited_at_module_scope"
+
+      assert Process.whereis(Headless) == manager
+      assert {:ok, :after_exit} = Headless.start(TestApp, id: :after_exit)
+    end
+
+    test "a body that never returns is answered on a budget", %{dir: dir} do
+      prev = Application.get_env(:raxol, :headless_compile_timeout_ms)
+      Application.put_env(:raxol, :headless_compile_timeout_ms, 150)
+
+      on_exit(fn ->
+        if prev,
+          do: Application.put_env(:raxol, :headless_compile_timeout_ms, prev),
+          else: Application.delete_env(:raxol, :headless_compile_timeout_ms)
+      end)
+
+      path = script(dir, ~s|:timer.sleep(:infinity)|)
+      manager = Process.whereis(Headless)
+
+      # The ANSWER, not the clock. A wedge and a slow compile look identical on a
+      # stopwatch, and timing assertions are this repo's most reliable source of
+      # macOS flakes -- what makes this case a wedge is that no answer ever comes,
+      # so the answer coming at all is the whole proof.
+      assert {:error, {:compile_timed_out, ^path, 150}} =
+               Headless.start(path, id: :wedge)
+
+      # Not just alive: still able to compile, after a compile was brutal-killed
+      # out from under the code server.
+      assert Process.whereis(Headless) == manager
+
+      good = script(dir, ~s|def noop, do: :ok|)
+
+      assert {:error, :no_tea_module_found} =
+               Headless.start(good, id: :after_wedge)
+    end
+  end
+
   describe "custom dimensions" do
     test "respects width and height options" do
       {:ok, _} = Headless.start(TestApp, id: :dim_test, width: 60, height: 15)


### PR DESCRIPTION
`raxol_start`'s `"path"` argument compiles the file it is given, and compiling a
`defmodule` executes its body. That is arbitrary code execution with the BEAM's
privileges, reachable from any connected MCP client, and `Raxol.Application`
registers these tools at startup -- so it is a production surface, not a dev-only
one.

## What this does

**The `path` branch is off unless a deployment opts in.** Unset
`RAXOL_HEADLESS_PATH_ROOT` refuses the argument outright rather than falling back
to the cwd, because an MCP server's working directory is not a boundary anyone
chose. Set, the request is confined under that root by
`Raxol.Core.Boundary.Path.confine/3` -- lexical check, real-path resolution of
both sides, re-check -- so a symlink pointing out of the root is refused rather
than followed, and `:ref_format` additionally requires an Elixir extension.

**An absolute path is refused, not rewritten.** `confine/3` would JOIN it under
the root, so `/etc/evil.exs` lands at `<root>/etc/evil.exs`. That is safe, but it
means the tool compiles a different file than the one it was asked for and says
nothing, while the schema documents the argument as relative. For the argument
that decides which code executes, a silent substitution is the worse of the two
safe behaviours. Not a leading-slash check: `Path.type/1` is OS-dependent in the
direction that hurts (on Unix `Path.type("c:/x")` is `:relative`), so this
mirrors what `Boundary.Path` already settled one layer down -- a drive or UNC
anchor counts on every host.

**The module branch gates on the TEA contract, not on "a beam exists".**
`Raxol.start_link/2` CALLS `init/1`, so admitting any loadable module starts
whatever was named: 527 modules on this tree export `init/1` against 53 that
implement TEA, and `Raxol.Terminal.Buffer.BufferServer` is one of the 527 -- its
GenServer `init/1` ran here outside any supervisor. The gate lives in
`Raxol.Headless` rather than in the MCP tool because that is the one point every
entry reaches. It asks the three callbacks and never the `@behaviour` attribute:
declaring the behaviour and implementing none of it compiles, so accepting the
attribute admits a module nothing can drive, and the session then renders an
empty frame forever.

**Unknown module names no longer mint atoms.** Atoms are never collected. The
code path decides, and the atom appears only once a beam for that exact name is
found there -- bounded by what is on disk, not by what a caller can type.

**A hostile compile is answered instead of taken personally.** The compile runs
in a monitored child on a budget, so a module body that raises, throws, exits, or
never returns yields an error rather than killing the singleton that holds every
other caller's session. `:kill`, not `:brutal_kill` -- the latter is a Supervisor
shutdown SPEC and `Process.exit/2` reads it as a trappable reason, so a trapping
body would outlive its own budget while still holding the code server's claim on
the module name.

## The Windows anchor fix

`walk_real/3` recognized an absolute symlink target by the POSIX `["/" | rest]`
shape alone. `Path.split/1` is `:filename.split/1`, whose notion of "absolute" is
OS-dependent: a Windows absolute target splits as `["c:/", "tmp", ...]` while the
SAME string on Unix splits as `["c:", "tmp", ...]` with no anchor. So every
Windows-absolute target took the relative branch, got spliced onto the base, and
landed back INSIDE the root -- an escape the post-resolution re-check could not
see, because nothing had left. UNC is the same bug one shape over.

Fixed in both copies with six new shared vectors.

## Changes from review

- **The corpus is now a real drift guard (`a37a846`).** Three places in the tree
  said the two duplicate confinements are safe BECAUSE both bind to one
  corpus -- `Boundary.Path`'s moduledoc ("drift is a red test, not a silent
  fork"), `FsSandbox`'s, and the corpus README ("update both copies ... or
  neither"). Nothing ran that rule. They are two directories of JSON copied by
  hand, so adding a vector to one and forgetting the other turns that package red
  against a case the sibling has never been asked about, while the sibling stays
  green -- which reads as "the sibling is fine". This PR widens the duplicated
  surface by 60 lines, so the guard lands with it. It compares BYTES rather than
  decoded JSON, since the README's rule is "copy verbatim" and a decoded
  comparison passes on two files nobody actually copied.
- **Absolute paths refused rather than jailed** (above). The previous test pinned
  the jailing and its own comment allowed either; this picks the one that cannot
  mislead. Empty paths, which previously resolved to the root itself, are refused
  too.
- **`Raxol.Headless.start/2` documents that a path argument is code execution.**
  That is a property of the function, not of one caller's comment, and
  `Recording.Video` and `MCP.Test` reach it too.
- **The accepting test asserts WHICH file resolved**, rather than only that no
  refusal fired -- against the root's REAL path, load-bearing on macOS where
  `tmp_dir!()` hands back the `/tmp` symlink.
- **The `mix.lock` commit is gone.** #916 landed the `phoenix`/`req` half
  upstream, so `git rebase` dropped it as already-applied. This PR no longer
  touches `mix.lock`.

## What this does NOT close

`Raxol.Agent.Actions.Fs.resolve/2` -- the confinement the agent's fs tools
actually run -- is still bound to none of the shared vectors, and
`Boundary.Path` still has no production callers. That is ADR-0032's Gap 4 and
#913's stated next step, not this PR's.

## Testing

- `test/raxol/headless/mcp_tools_test.exs` + `test/raxol/headless_test.exs`: 48 passed
- `test/raxol/boundary_vector_parity_test.exs`: 2 passed, and proven to FAIL both
  ways -- renaming one vector in the ACP copy trips the byte check, removing
  `path_accept_vectors.json` trips the file-set check
- `packages/raxol_core`: 917 passed
- `packages/raxol_agent_client_protocol/test/client_test.exs` (the FsSandbox
  vector site): 16 passed
- root `mix format --check-formatted` clean, Elixir 1.20.2 / OTP 29

## Manual testing

- [ ] With `RAXOL_HEADLESS_PATH_ROOT` unset, `raxol_start {"path": "examples/demo.exs"}` refuses and names the variable
- [ ] With it set, `{"path": "examples/demo.exs"}` starts and `{"path": "/etc/passwd.exs"}` refuses
- [ ] `{"module": "Raxol.Terminal.Buffer.BufferServer"}` refuses without starting anything
