### PR TITLE
Run the prose pre-commit gate without booting Mix

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -8,6 +8,24 @@
 # Installed via `git config core.hooksPath .githooks` (run by `mix setup`).
 set -euo pipefail
 
+# --- toolchain -----------------------------------------------------------
+# `MIX_HOME` on a mise setup points at that toolchain's `.mix`, while a
+# Homebrew `mix` may come first on PATH. A Hex archive built for one Elixir and
+# loaded by another fails deep inside dep resolution
+# (`function Enum.__in__/2 is undefined`), which reads like a lockfile bug and
+# is not one. So prefer the toolchain `.tool-versions` names, when it is
+# installed; otherwise leave PATH alone and let the gates report normally.
+if [[ -f .tool-versions ]]; then
+  _ex="$(awk '$1 == "elixir" { print $2; exit }' .tool-versions || true)"
+  _erl="$(awk '$1 == "erlang" { print $2; exit }' .tool-versions || true)"
+  for _cand in \
+    "${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs/elixir/${_ex}/bin" \
+    "${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs/erlang/${_erl}/bin"; do
+    [[ -n "${_ex}" && -d "$_cand" ]] && PATH="$_cand:$PATH"
+  done
+  export PATH
+fi
+
 staged="$(git diff --cached --name-only --diff-filter=ACM)"
 status=0
 
@@ -17,7 +35,11 @@ status=0
 # `mix deps.get --check-locked` step after the push to master.
 if printf '%s\n' "$staged" | grep -qE '(^|/)mix\.(exs|lock)$'; then
   echo "pre-commit: verifying mix.lock is consistent..."
-  if ! output="$(mix deps.get --check-locked 2>&1)"; then
+  if ! command -v mix >/dev/null 2>&1; then
+    echo "pre-commit: no \`mix\` on PATH, cannot verify mix.lock." >&2
+    echo "  Install the toolchain \`.tool-versions\` names, or bypass knowingly." >&2
+    status=1
+  elif ! output="$(mix deps.get --check-locked 2>&1)"; then
     echo "$output" >&2
     cat >&2 <<'MSG'
 
@@ -43,10 +65,15 @@ if [[ -n "$md_files" ]]; then
   echo "pre-commit: linting staged Markdown..."
   args=()
   while IFS= read -r f; do
-    [[ -n "$f" ]] && args+=(--files "$f")
+    [[ -n "$f" ]] && args+=("$f")
   done <<<"$md_files"
 
-  if ! mix raxol.check_docs --only prose "${args[@]}"; then
+  # Deliberately `elixir`, not `mix`. The rules are the same module either way,
+  # but this route loads no project, so a docs commit cannot be blocked by deps
+  # that do not match the branch's lock, a `_build` from another Elixir, or a
+  # root lock that no longer re-resolves. None of those are facts about prose.
+  # CI still runs `mix raxol.check_docs`, which additionally checks the catalog.
+  if ! elixir scripts/prose_lint.exs "${args[@]}"; then
     cat >&2 <<'MSG'
 
 pre-commit: Markdown prose check failed.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,15 +15,31 @@ set -euo pipefail
 # (`function Enum.__in__/2 is undefined`), which reads like a lockfile bug and
 # is not one. So prefer the toolchain `.tool-versions` names, when it is
 # installed; otherwise leave PATH alone and let the gates report normally.
+#
+# The version is VALIDATED before it is interpolated, because `.tool-versions`
+# is a repo-controlled file and the result of this goes on PATH. A branch
+# carrying `elixir ../../../../../../../tmp/evil` otherwise resolves to
+# `/tmp/evil/bin`, prepends it, and every `mix` and `elixir` below runs from
+# there -- arbitrary execution on `git commit`, which is an ordinary thing to do
+# after checking out someone else's branch. A version is a digit followed by
+# version punctuation; anything else is not one, and is skipped rather than
+# resolved. The pattern admits no `/`, and cannot match `..`.
 if [[ -f .tool-versions ]]; then
-  _ex="$(awk '$1 == "elixir" { print $2; exit }' .tool-versions || true)"
-  _erl="$(awk '$1 == "erlang" { print $2; exit }' .tool-versions || true)"
-  for _cand in \
-    "${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs/elixir/${_ex}/bin" \
-    "${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs/erlang/${_erl}/bin"; do
-    [[ -n "${_ex}" && -d "$_cand" ]] && PATH="$_cand:$PATH"
+  _mise_installs="${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs"
+
+  for _tool in elixir erlang; do
+    _ver="$(awk -v tool="$_tool" '$1 == tool { print $2; exit }' .tool-versions || true)"
+
+    if [[ "$_ver" =~ ^[0-9][0-9A-Za-z._+-]*$ ]]; then
+      _cand="$_mise_installs/$_tool/$_ver/bin"
+      if [[ -d "$_cand" ]]; then
+        PATH="$_cand:$PATH"
+      fi
+    fi
   done
+
   export PATH
+  unset _mise_installs _tool _ver _cand
 fi
 
 staged="$(git diff --cached --name-only --diff-filter=ACM)"
@@ -73,7 +89,15 @@ if [[ -n "$md_files" ]]; then
   # that do not match the branch's lock, a `_build` from another Elixir, or a
   # root lock that no longer re-resolves. None of those are facts about prose.
   # CI still runs `mix raxol.check_docs`, which additionally checks the catalog.
-  if ! elixir scripts/prose_lint.exs "${args[@]}"; then
+  #
+  # Guarded the way the lockfile gate guards `mix`: without this, a missing
+  # `elixir` exits 127 and the message below blames the prose, which is the one
+  # diagnosis this gate exists to get right.
+  if ! command -v elixir >/dev/null 2>&1; then
+    echo "pre-commit: no \`elixir\` on PATH, cannot lint prose." >&2
+    echo "  Install the toolchain \`.tool-versions\` names, or bypass knowingly." >&2
+    status=1
+  elif ! elixir scripts/prose_lint.exs "${args[@]}"; then
     cat >&2 <<'MSG'
 
 pre-commit: Markdown prose check failed.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -16,15 +16,29 @@ set -euo pipefail
 # is not one. So prefer the toolchain `.tool-versions` names, when it is
 # installed; otherwise leave PATH alone and let the gates report normally.
 #
+# Set RAXOL_HOOK_NO_TOOLCHAIN=1 to skip this and use PATH as-is, which is what
+# you want when deliberately testing against a different Elixir.
+#
 # The version is VALIDATED before it is interpolated, because `.tool-versions`
 # is a repo-controlled file and the result of this goes on PATH. A branch
 # carrying `elixir ../../../../../../../tmp/evil` otherwise resolves to
 # `/tmp/evil/bin`, prepends it, and every `mix` and `elixir` below runs from
-# there -- arbitrary execution on `git commit`, which is an ordinary thing to do
-# after checking out someone else's branch. A version is a digit followed by
-# version punctuation; anything else is not one, and is skipped rather than
-# resolved. The pattern admits no `/`, and cannot match `..`.
-if [[ -f .tool-versions ]]; then
+# there. A version is a digit followed by version punctuation; anything else is
+# not one, and is skipped rather than resolved. The pattern admits no `/`, and
+# cannot match `..`.
+#
+# What that is NOT is a general defence against a hostile branch. This hook runs
+# `scripts/prose_lint.exs`, which `Code.require_file`s `lib/raxol/docs/
+# prose_lint.ex`; both are repo-controlled, so a branch you do not trust already
+# chooses code that runs on `git commit`, and `mix deps.get` below evaluates
+# `mix.exs`. That is true of essentially any repo with hooks enabled and is not
+# something a version regex changes. The regex closes one specific hole -- a
+# value this hook itself puts on PATH -- and the honest scope is "the hook does
+# not ADD a vector", not "committing on an untrusted branch is safe". Review the
+# branch, or commit with --no-verify.
+if [[ -n "${RAXOL_HOOK_NO_TOOLCHAIN:-}" ]]; then
+  :
+elif [[ -f .tool-versions ]]; then
   _mise_installs="${MISE_DATA_DIR:-$HOME/.local/share/mise}/installs"
 
   for _tool in elixir erlang; do

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -111,15 +111,23 @@ if [[ -n "$md_files" ]]; then
     echo "pre-commit: no \`elixir\` on PATH, cannot lint prose." >&2
     echo "  Install the toolchain \`.tool-versions\` names, or bypass knowingly." >&2
     status=1
-  elif ! elixir scripts/prose_lint.exs "${args[@]}"; then
-    cat >&2 <<'MSG'
+  else
+    prose_status=0
+    elixir scripts/prose_lint.exs "${args[@]}" || prose_status=$?
+
+    if [[ "$prose_status" -eq 1 ]]; then
+      cat >&2 <<'MSG'
 
 pre-commit: Markdown prose check failed.
 
   Fix the findings above, or see `mix help raxol.check_docs` for the rules.
 
 MSG
-    status=1
+      status=1
+    elif [[ "$prose_status" -ne 0 ]]; then
+      echo "pre-commit: Markdown prose check could not run (exit $prose_status)." >&2
+      status=1
+    fi
   fi
 fi
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -19,6 +19,30 @@ mix deps.get
 mix compile
 ```
 
+### Pre-commit hooks
+
+`mix setup` points `core.hooksPath` at `.githooks`. Two gates run, each only
+when the files it guards are staged: `mix.lock` consistency, and the Markdown
+prose rules.
+
+The prose gate runs `elixir scripts/prose_lint.exs`, deliberately not `mix`.
+The rules are the same `Raxol.Docs.ProseLint` module either way, but that route
+loads no project, so a docs commit is not blocked by states that say nothing
+about prose:
+
+* `deps/` not matching the branch's `mix.lock`, which is routine when branches
+  carry different locks, since one checkout shares one `deps/`
+* a `_build` compiled by a different Elixir than the one on `PATH`
+* a root `mix.lock` that no longer re-resolves
+
+CI still runs `mix raxol.check_docs`, which additionally checks catalog counts.
+
+If a gate reports something like `function Enum.__in__/2 is undefined`, the
+`mix` on `PATH` and the one `MIX_HOME` points at are different installs, and a
+Hex archive built for one is being loaded by the other. The hook prepends the
+toolchain `.tool-versions` names when it finds it installed under mise; for a
+manual command, put that toolchain's `bin` first on `PATH`.
+
 ## Commands
 
 ### Testing

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -43,6 +43,14 @@ Hex archive built for one is being loaded by the other. The hook prepends the
 toolchain `.tool-versions` names when it finds it installed under mise; for a
 manual command, put that toolchain's `bin` first on `PATH`.
 
+Set `RAXOL_HOOK_NO_TOOLCHAIN=1` to skip that and use `PATH` as-is, which is what
+you want when deliberately committing against a different Elixir.
+
+The hook is not a defence against a branch you do not trust. It runs
+`scripts/prose_lint.exs`, and the lockfile gate evaluates `mix.exs`, so a
+checked-out branch already chooses code that runs on `git commit`. That is true
+of any repo with hooks enabled. Review the branch, or use `--no-verify`.
+
 ## Commands
 
 ### Testing

--- a/lib/mix/tasks/raxol.check_docs.ex
+++ b/lib/mix/tasks/raxol.check_docs.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Raxol.CheckDocs do
       mix raxol.check_docs                    # everything, all tracked Markdown
       mix raxol.check_docs --only prose       # skip the catalog counts
       mix raxol.check_docs --only counts      # skip the prose lint
-      mix raxol.check_docs --files a.md b.md  # lint just these (pre-commit hook)
+      mix raxol.check_docs --files a.md b.md  # lint just these
       mix raxol.check_docs --headings         # add the opt-in heading-case sweep
       mix raxol.check_docs --headings --warnings-as-errors
 

--- a/lib/mix/tasks/raxol.check_docs.ex
+++ b/lib/mix/tasks/raxol.check_docs.ex
@@ -68,19 +68,12 @@ defmodule Mix.Tasks.Raxol.CheckDocs do
 
   defp lint([], opts), do: lint(tracked_markdown(), opts)
 
-  defp lint(files, opts) do
-    lint_opts = [headings: Keyword.get(opts, :headings, false)]
-
-    files
-    |> Enum.filter(&String.ends_with?(&1, ".md"))
-    |> Enum.reject(&(String.contains?(&1, "node_modules/") or vendored?(&1)))
-    |> Enum.flat_map(&ProseLint.check_file(&1, lint_opts))
-    |> Enum.sort_by(&{&1.path, &1.line})
-  end
-
-  # Upstream sources we re-publish unmodified. Rewriting their prose would make
-  # the vendored copy diverge from the thing it is a copy of.
-  defp vendored?(path), do: String.contains?(path, "termbox2/README.md")
+  # Selection and filtering live in `ProseLint` so this task and
+  # `scripts/prose_lint.exs` (which the pre-commit hook runs without Mix) cannot
+  # disagree about which files are in scope.
+  defp lint(files, opts),
+    do:
+      ProseLint.lint_files(files, headings: Keyword.get(opts, :headings, false))
 
   defp tracked_markdown do
     case System.cmd("git", ["ls-files", "*.md"], stderr_to_stdout: true) do
@@ -98,16 +91,10 @@ defmodule Mix.Tasks.Raxol.CheckDocs do
   defp report(findings, label) do
     Mix.shell().error("\n#{length(findings)} #{label}(s):")
 
-    Enum.each(findings, fn f ->
-      Mix.shell().error("  #{f.path}:#{f.line}  [#{f.rule}] #{f.message}")
-      Mix.shell().error("      #{truncate(f.text)}")
+    Enum.each(ProseLint.format_findings(findings), fn line ->
+      Mix.shell().error(line)
     end)
   end
-
-  defp truncate(text) when byte_size(text) > 120,
-    do: binary_part(text, 0, 117) <> "..."
-
-  defp truncate(text), do: text
 
   defp summary(only, files, warnings) do
     scope =

--- a/lib/raxol/docs/prose_lint.ex
+++ b/lib/raxol/docs/prose_lint.ex
@@ -107,6 +107,60 @@ defmodule Raxol.Docs.ProseLint do
       link_findings(path, content, root)
   end
 
+  @doc """
+  Lint a list of candidate paths, keeping only the Markdown this repo owns.
+
+  Drops non-`.md` paths, `node_modules/`, and vendored copies, then sorts by
+  `{path, line}` so output is stable regardless of the order paths arrive in.
+
+  Lives here rather than in the Mix task because two entry points need it: the
+  task, and `scripts/prose_lint.exs`, which the pre-commit hook runs WITHOUT
+  Mix. Keeping selection next to the rules means the hook and CI cannot come to
+  different conclusions about which files are in scope.
+  """
+  @spec lint_files([String.t()], keyword()) :: [finding()]
+  def lint_files(paths, opts \\ []) do
+    # `:root` is forwarded, not just `:headings`. `check_file/2` joins the path
+    # onto the root, so dropping it made every path resolve against `"."` and an
+    # unreadable file lints as clean -- a linter silently passing is worse than
+    # one that errors.
+    lint_opts = [
+      headings: Keyword.get(opts, :headings, false),
+      root: Keyword.get(opts, :root, ".")
+    ]
+
+    paths
+    |> Enum.filter(&String.ends_with?(&1, ".md"))
+    |> Enum.reject(&(String.contains?(&1, "node_modules/") or vendored?(&1)))
+    |> Enum.flat_map(&check_file(&1, lint_opts))
+    |> Enum.sort_by(&{&1.path, &1.line})
+  end
+
+  # Upstream sources we re-publish unmodified. Rewriting their prose would make
+  # the vendored copy diverge from the thing it is a copy of.
+  defp vendored?(path), do: String.contains?(path, "termbox2/README.md")
+
+  @doc """
+  Render findings as display lines, two per finding (location, then the text).
+
+  Returns lines rather than printing them so the Mix task can route them
+  through `Mix.shell/0` and the hook script can put them on stderr.
+  """
+  @spec format_findings([finding()]) :: [String.t()]
+  def format_findings(findings) do
+    Enum.flat_map(findings, fn f ->
+      [
+        "  #{f.path}:#{f.line}  [#{f.rule}] #{f.message}",
+        "      #{truncate(f.text)}"
+      ]
+    end)
+  end
+
+  defp truncate(text) when byte_size(text) > 120,
+    do: binary_part(text, 0, 117) <> "..."
+
+  defp truncate(text), do: text
+
   # --- code masking -------------------------------------------------------
 
   # Replace fenced blocks and inline code spans with same-length filler so

--- a/lib/raxol/docs/prose_lint.ex
+++ b/lib/raxol/docs/prose_lint.ex
@@ -82,11 +82,29 @@ defmodule Raxol.Docs.ProseLint do
   """
   @spec check_file(String.t(), keyword()) :: [finding()]
   def check_file(path, opts \\ []) do
-    root = Keyword.get(opts, :root, ".")
-
-    case File.read(Path.join(root, path)) do
+    case File.read(resolve_under_root(Keyword.get(opts, :root, "."), path)) do
       {:ok, content} -> check_content(path, content, opts)
       {:error, _} -> []
+    end
+  end
+
+  # An ABSOLUTE path is read as given, never joined.
+  #
+  # `Path.join(".", "/tmp/x.md")` is `"./tmp/x.md"`, which does not exist -- so
+  # joining an absolute path turned a real file into a CLEAN lint. That is the
+  # same defect as dropping `:root` (see `lint_files/2`), and it is worse than a
+  # crash both times: a linter that silently passes is indistinguishable from
+  # one with nothing to say.
+  #
+  # It bites hardest where nothing looks wrong. `scripts/prose_lint.exs` checks
+  # that every named file exists before linting, and that check used the real
+  # path while this one used the joined one -- so an absolute argument passed
+  # the guard and then lint as clean. The hook itself only ever passes git's
+  # repo-relative output, which is why it went unnoticed.
+  defp resolve_under_root(root, path) do
+    case Path.type(path) do
+      :relative -> Path.join(root, path)
+      _absolute_or_volumerelative -> path
     end
   end
 

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/permission_wire_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/permission_wire_test.exs
@@ -1,0 +1,211 @@
+defmodule Raxol.Agent.ClientProtocol.PermissionWireTest do
+  @moduledoc """
+  End-to-end proof that the ACP permission gate is real: a sensitive tool call
+  in a LIVE turn puts a `session/request_permission` on the Connection seam,
+  and the client's answer decides whether the filesystem changes.
+
+  `Raxol.Agent.ClientProtocol.PermissionTest` pins the gate function itself
+  against a stubbed Session. This pins the whole path instead — real `Session`,
+  real `TurnRunner`, real `Raxol.Agent.Stream` react loop, real
+  `ToolConverter` dispatch, real `Code.Write` Action, real filesystem — because
+  the wiring being correct at every link is not the same claim as the round
+  trip happening, and only the second one is worth telling anyone.
+
+  The single seam is the LLM: a test-local backend emits one `write_file` tool
+  call and then a closing message, which is what a model would do. Everything
+  downstream of that decision is production code.
+
+  Two claims, both load-bearing:
+
+    1. **The ask reaches the client, and allow writes.** One
+       `session/request_permission` is submitted, naming this session and
+       offering exactly allow-once/reject-once; answering with allow lands the
+       file.
+    2. **The write lands under the SESSION's cwd.** `:cwd` in the agent
+       context roots `Fs.resolve/2`, so a relative path from the model resolves
+       under the directory `session/new` named — not the BEAM's. Two concurrent
+       ACP sessions on one server would otherwise write into each other.
+
+  And the refusal: answering with reject leaves the filesystem untouched.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Agent.ClientProtocol.Permission
+  alias Raxol.Agent.ClientProtocol.TurnRunner
+  alias Raxol.AgentClientProtocol.Schema.AgentTypes.PromptRequest
+  alias Raxol.AgentClientProtocol.Schema.ClientTypes.RequestPermissionResponse
+  alias Raxol.AgentClientProtocol.Schema.ContentBlock
+  alias Raxol.AgentClientProtocol.Session
+
+  @marker "PERMISSION_WIRE_MARKER.txt"
+  @content "hob"
+
+  # -- seams ------------------------------------------------------------------
+
+  defmodule FakeConn do
+    @moduledoc """
+    Connection seam double, matching the ACP package's own suite. `conn` is the
+    test pid, so every outbound frame arrives in the test's mailbox — including
+    the permission request, which the test answers by sending `owner` the
+    `{:acp_result, tag, _}` the Session parks on.
+    """
+    def delegate_reply(conn, reply_ref, adopter) do
+      send(conn, {:conn_delegated, reply_ref, adopter})
+      :ok
+    end
+
+    def reply(conn, reply_ref, rendered) do
+      send(conn, {:conn_reply, reply_ref, rendered})
+      :ok
+    end
+
+    def notify(conn, method, notification) do
+      send(conn, {:conn_notify, method, notification})
+      :ok
+    end
+
+    def async_request(conn, method, req, owner, tag, _timeout) do
+      send(conn, {:conn_async_request, method, req, owner, tag})
+      :ok
+    end
+
+    def cancel_request(_conn, _tag), do: :ok
+  end
+
+  defmodule WritingBackend do
+    @moduledoc """
+    One `write_file` tool call, then a closing message — the shape a model
+    produces for "create this file". The `:turns` Agent makes the sequence
+    deterministic instead of depending on how the react loop shapes history.
+    """
+    def complete(_messages, opts) do
+      turns = Keyword.fetch!(opts, :turns)
+      path = Keyword.fetch!(opts, :path)
+      body = Keyword.fetch!(opts, :body)
+
+      case Agent.get_and_update(turns, fn n -> {n, n + 1} end) do
+        0 ->
+          {:ok,
+           %{
+             content: "",
+             tool_calls: [
+               %{
+                 "id" => "call-1",
+                 "name" => "write_file",
+                 "arguments" => %{"path" => path, "content" => body}
+               }
+             ],
+             usage: %{}
+           }}
+
+        _later ->
+          {:ok, %{content: "done", usage: %{}}}
+      end
+    end
+
+    def stream(_messages, _opts), do: {:error, :complete_only}
+  end
+
+  # -- harness ----------------------------------------------------------------
+
+  setup do
+    cwd = Path.join(System.tmp_dir!(), "acp-perm-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(cwd)
+    on_exit(fn -> File.rm_rf(cwd) end)
+
+    turns = start_supervised!({Agent, fn -> 0 end})
+
+    {:ok, cwd: cwd, turns: turns}
+  end
+
+  defp start_session!(cwd, turns) do
+    runner =
+      TurnRunner.new(
+        backend: WritingBackend,
+        backend_opts: [turns: turns, path: @marker, body: @content],
+        actions: Raxol.Agent.Actions.Fs.all() ++ Raxol.Agent.Actions.Code.all(),
+        # Exactly what `StdioAgent` derives from `session/new`'s cwd.
+        context: %{cwd: cwd}
+      )
+
+    task_sup = start_supervised!(Task.Supervisor)
+    session_id = "sess-#{System.unique_integer([:positive])}"
+
+    session =
+      start_supervised!(
+        {Session,
+         [
+           session_id: session_id,
+           conn: self(),
+           conn_mod: FakeConn,
+           task_sup: task_sup,
+           turn_runner: runner,
+           name: :"perm_wire_#{System.unique_integer([:positive])}"
+         ]},
+        restart: :temporary
+      )
+
+    req = PromptRequest.new(session_id, [ContentBlock.from_string("create the file")])
+    assert :ok = Session.begin_prompt(session, req, make_ref(), 1)
+
+    session_id
+  end
+
+  # The Session parks the gate's call until this arrives.
+  defp answer_permission(owner, tag, option_id) do
+    send(
+      owner,
+      {:acp_result, tag,
+       {:ok, %RequestPermissionResponse{outcome: {:selected, %{option_id: option_id}}}}}
+    )
+  end
+
+  # -- claims -----------------------------------------------------------------
+
+  describe "a sensitive tool call in a live turn" do
+    test "asks the client, and allow writes the file under the session cwd",
+         %{cwd: cwd, turns: turns} do
+      session_id = start_session!(cwd, turns)
+
+      assert_receive {:conn_async_request, "session/request_permission", req, owner, tag}, 5_000
+
+      # The ask names THIS session and offers exactly the two documented options.
+      assert req.session_id == session_id
+      assert Enum.map(req.options, & &1.kind) == [:allow_once, :reject_once]
+
+      assert Enum.map(req.options, & &1.option_id) == [
+               Permission.allow_option_id(),
+               Permission.reject_option_id()
+             ]
+
+      # Nothing has touched the filesystem yet: the gate is holding the call.
+      refute File.exists?(Path.join(cwd, @marker))
+
+      answer_permission(owner, tag, Permission.allow_option_id())
+
+      assert_receive {:conn_reply, _ref, _rendered}, 5_000
+
+      written = Path.join(cwd, @marker)
+      assert File.exists?(written), "allow did not write the file"
+      assert File.read!(written) == @content
+
+      # The cwd claim, stated as its own assertion rather than implied: a
+      # relative path from the model must NOT resolve against the BEAM's cwd.
+      refute File.exists?(Path.join(File.cwd!(), @marker))
+    end
+
+    test "reject leaves the filesystem untouched", %{cwd: cwd, turns: turns} do
+      start_session!(cwd, turns)
+
+      assert_receive {:conn_async_request, "session/request_permission", _req, owner, tag}, 5_000
+
+      answer_permission(owner, tag, Permission.reject_option_id())
+
+      # The turn still completes — a refusal is an answer, not an error.
+      assert_receive {:conn_reply, _ref, _rendered}, 5_000
+
+      refute File.exists?(Path.join(cwd, @marker))
+      refute File.exists?(Path.join(File.cwd!(), @marker))
+    end
+  end
+end

--- a/scripts/prose_lint.exs
+++ b/scripts/prose_lint.exs
@@ -1,0 +1,70 @@
+# Prose-lint Markdown files without booting Mix.
+#
+#     elixir scripts/prose_lint.exs FILE...
+#
+# The pre-commit hook runs this instead of `mix raxol.check_docs`. The rules are
+# the same module either way; what differs is that nothing here loads the
+# project, so the check survives states where Mix refuses to start at all:
+#
+#   * deps on disk not matching the branch's mix.lock, which is routine when
+#     branches carry different locks and `deps/` is shared across a checkout;
+#   * a `_build` compiled by a different Elixir than the one on PATH;
+#   * a root mix.lock that no longer re-resolves.
+#
+# None of those say anything about the prose in a commit, so none of them should
+# be able to block one. `Raxol.Docs.ProseLint` is stdlib-only, so requiring the
+# single source file is the whole setup.
+#
+# Exit codes: 0 clean, 1 findings, 2 could not run.
+
+lint_source =
+  Path.join([__DIR__, "..", "lib", "raxol", "docs", "prose_lint.ex"])
+
+unless File.exists?(lint_source) do
+  IO.puts(
+    :stderr,
+    "prose_lint: cannot find #{Path.relative_to_cwd(lint_source)}"
+  )
+
+  System.halt(2)
+end
+
+Code.require_file(lint_source)
+
+case System.argv() do
+  [] ->
+    IO.puts(:stderr, "usage: elixir scripts/prose_lint.exs FILE...")
+    System.halt(2)
+
+  paths ->
+    # `check_file/2` treats an unreadable path as clean, which is right for a
+    # repo-wide sweep over a stale file list and wrong for named arguments: a
+    # typo would exit 0 and read as a pass. Named files must exist.
+    case Enum.reject(paths, &File.regular?(Path.relative_to_cwd(&1))) do
+      [] ->
+        :ok
+
+      missing ->
+        IO.puts(:stderr, "prose_lint: cannot read: #{Enum.join(missing, ", ")}")
+        System.halt(2)
+    end
+
+    findings =
+      paths
+      |> Enum.map(&Path.relative_to_cwd/1)
+      |> Raxol.Docs.ProseLint.lint_files()
+
+    {errors, _warnings} = Enum.split_with(findings, &(&1.severity == :error))
+
+    if errors == [] do
+      System.halt(0)
+    else
+      IO.puts(:stderr, "\n#{length(errors)} error(s):")
+
+      errors
+      |> Raxol.Docs.ProseLint.format_findings()
+      |> Enum.each(&IO.puts(:stderr, &1))
+
+      System.halt(1)
+    end
+end

--- a/scripts/prose_lint.exs
+++ b/scripts/prose_lint.exs
@@ -54,17 +54,32 @@ case System.argv() do
       |> Enum.map(&Path.relative_to_cwd/1)
       |> Raxol.Docs.ProseLint.lint_files()
 
-    {errors, _warnings} = Enum.split_with(findings, &(&1.severity == :error))
+    {errors, warnings} = Enum.split_with(findings, &(&1.severity == :error))
 
-    if errors == [] do
-      System.halt(0)
-    else
-      IO.puts(:stderr, "\n#{length(errors)} error(s):")
+    report = fn
+      [], _label ->
+        :ok
 
-      errors
-      |> Raxol.Docs.ProseLint.format_findings()
-      |> Enum.each(&IO.puts(:stderr, &1))
+      found, label ->
+        IO.puts(:stderr, "\n#{length(found)} #{label}(s):")
 
-      System.halt(1)
+        found
+        |> Raxol.Docs.ProseLint.format_findings()
+        |> Enum.each(&IO.puts(:stderr, &1))
     end
+
+    report.(errors, "error")
+
+    # Warnings are PRINTED and not fatal, matching `mix raxol.check_docs`, which
+    # counts them toward failure only under `--warnings-as-errors`.
+    #
+    # Unreachable as things stand: the only warning-severity rule is
+    # `:heading_case`, which is opt-in via `headings: true` and nothing here
+    # enables it. Written anyway because the alternative is a silent `_warnings`
+    # discard, and the day the hook does pass `--headings` that discard is a
+    # hook withholding what CI is about to say -- the same hook-versus-CI split
+    # this script exists to close on scope, one axis over.
+    report.(warnings, "warning")
+
+    System.halt(if errors == [], do: 0, else: 1)
 end

--- a/test/githooks/pre_commit_test.exs
+++ b/test/githooks/pre_commit_test.exs
@@ -189,4 +189,32 @@ defmodule Githooks.PreCommitTest do
              "a version string was executed as shell"
     end
   end
+
+  describe "scripts/prose_lint.exs" do
+    @script Path.expand("../../scripts/prose_lint.exs", __DIR__)
+
+    test "returns 0 for clean prose and 1 for findings", %{dir: dir} do
+      clean = Path.join(dir, "clean.md")
+      bad = Path.join(dir, "bad.md")
+      File.write!(clean, "Clean prose.\n")
+      File.write!(bad, "An em-dash \u2014 here.\n")
+
+      assert {_, 0} =
+               System.cmd("elixir", [@script, clean], stderr_to_stdout: true)
+
+      assert {output, 1} =
+               System.cmd("elixir", [@script, bad], stderr_to_stdout: true)
+
+      assert output =~ "unicode_punctuation"
+    end
+
+    test "returns 2 when it cannot run the requested lint", %{dir: dir} do
+      missing = Path.join(dir, "missing.md")
+
+      assert {output, 2} =
+               System.cmd("elixir", [@script, missing], stderr_to_stdout: true)
+
+      assert output =~ "cannot read"
+    end
+  end
 end

--- a/test/githooks/pre_commit_test.exs
+++ b/test/githooks/pre_commit_test.exs
@@ -46,7 +46,7 @@ defmodule Githooks.PreCommitTest do
 
   # Runs the block with `cwd` as the repo and `mise_root` standing in for the
   # mise data dir, and returns the PATH it produced.
-  defp resulting_path(cwd, mise_root) do
+  defp resulting_path(cwd, mise_root, extra_env \\ []) do
     script = """
     set -euo pipefail
     cd #{cwd}
@@ -56,10 +56,16 @@ defmodule Githooks.PreCommitTest do
 
     {out, 0} =
       System.cmd("bash", ["-c", script],
-        env: [
-          {"MISE_DATA_DIR", mise_root},
-          {"PATH", "/usr/bin:/bin"}
-        ],
+        env:
+          [
+            {"MISE_DATA_DIR", mise_root},
+            {"PATH", "/usr/bin:/bin"},
+            # Cleared explicitly. `System.cmd` MERGES with the caller's
+            # environment rather than replacing it, so a developer who has the
+            # escape hatch exported would otherwise turn every assertion below
+            # into a no-op that still passes.
+            {"RAXOL_HOOK_NO_TOOLCHAIN", nil}
+          ] ++ extra_env,
         stderr_to_stdout: true
       )
 
@@ -122,6 +128,30 @@ defmodule Githooks.PreCommitTest do
       write_tool_versions(Path.join(repo, ".tool-versions"), "1.20.2-otp-29")
 
       assert resulting_path(repo, mise) =~ installed
+    end
+
+    # The override has to be checkable, or a developer deliberately running
+    # against a different Elixir gets silently put back on the pinned one every
+    # time they commit, with nothing on screen saying so.
+    test "RAXOL_HOOK_NO_TOOLCHAIN leaves PATH alone even when installed", %{
+      dir: dir
+    } do
+      repo = Path.join(dir, "repo")
+      mise = Path.join(dir, "mise")
+      File.mkdir_p!(repo)
+
+      installed =
+        Path.join([mise, "installs", "elixir", "1.20.2-otp-29", "bin"])
+
+      File.mkdir_p!(installed)
+      write_tool_versions(Path.join(repo, ".tool-versions"), "1.20.2-otp-29")
+
+      # Same fixture as the test above, which DOES prepend -- so this pins the
+      # override and not merely a version that was never going to resolve.
+      assert resulting_path(repo, mise) =~ installed
+
+      assert resulting_path(repo, mise, [{"RAXOL_HOOK_NO_TOOLCHAIN", "1"}]) ==
+               "/usr/bin:/bin"
     end
 
     test "leaves PATH alone when the pinned version is not installed", %{

--- a/test/githooks/pre_commit_test.exs
+++ b/test/githooks/pre_commit_test.exs
@@ -1,0 +1,162 @@
+defmodule Githooks.PreCommitTest do
+  @moduledoc """
+  The pre-commit hook puts a directory on `PATH` and then runs `mix` and
+  `elixir` from it, and it picks that directory using a value read out of
+  `.tool-versions` -- a file the repository controls, and therefore a file any
+  branch controls.
+
+  That makes the version string untrusted input to a path that becomes
+  executable search order, so it gets a test. Checking out someone else's branch
+  and committing is an ordinary thing to do.
+
+  The hook's own text is the subject: the toolchain block is extracted from
+  `.githooks/pre-commit` and run, rather than restated here, so this cannot pass
+  against a hook that no longer says what it says.
+  """
+  use ExUnit.Case, async: true
+
+  @moduletag :unix_only
+
+  @hook Path.expand("../../.githooks/pre-commit", __DIR__)
+
+  setup do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-hook-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    %{dir: dir}
+  end
+
+  # Everything from the toolchain header up to the first gate. Bounded by what
+  # follows it rather than by a line count, so an edit inside the block does not
+  # silently shrink what is under test.
+  defp toolchain_block do
+    source = File.read!(@hook)
+
+    [_, block] =
+      Regex.run(~r/(# --- toolchain.*?)\nstaged=/s, source) ||
+        flunk("could not find the toolchain block in #{@hook}")
+
+    block
+  end
+
+  # Runs the block with `cwd` as the repo and `mise_root` standing in for the
+  # mise data dir, and returns the PATH it produced.
+  defp resulting_path(cwd, mise_root) do
+    script = """
+    set -euo pipefail
+    cd #{cwd}
+    #{toolchain_block()}
+    printf '%s' "$PATH"
+    """
+
+    {out, 0} =
+      System.cmd("bash", ["-c", script],
+        env: [
+          {"MISE_DATA_DIR", mise_root},
+          {"PATH", "/usr/bin:/bin"}
+        ],
+        stderr_to_stdout: true
+      )
+
+    out
+  end
+
+  defp write_tool_versions(dir, elixir_version) do
+    File.write!(dir, "erlang 29.0.3\nelixir #{elixir_version}\nnodejs latest\n")
+  end
+
+  describe "the toolchain block" do
+    test "refuses a version that traverses out of the mise root", %{dir: dir} do
+      # The exploit, verbatim: `<mise>/installs/elixir/<version>/bin` with a
+      # `..`-laden version resolves to an attacker-chosen directory.
+      escape = Path.join(dir, "escape")
+      File.mkdir_p!(Path.join(escape, "bin"))
+
+      repo = Path.join(dir, "repo")
+      mise = Path.join(dir, "mise")
+      File.mkdir_p!(repo)
+
+      # The version is interpolated after this, so the climb starts here -- and
+      # it has to EXIST, because `..` is resolved by the OS and a path whose
+      # ancestors are missing does not resolve at all.
+      base = Path.join([mise, "installs", "elixir"])
+      File.mkdir_p!(base)
+
+      hops = length(Path.split(base)) - 1
+
+      traversal =
+        String.duplicate("../", hops) <> String.trim_leading(escape, "/")
+
+      # The premise, asserted rather than assumed: a candidate that does not
+      # resolve is skipped by the UNFIXED hook too, so without this the test
+      # passes whether or not the validation is there. It did, until this line.
+      assert File.dir?(Path.join([base, traversal, "bin"])),
+             "test premise broken: the traversal must reach a real directory"
+
+      write_tool_versions(Path.join(repo, ".tool-versions"), traversal)
+
+      path = resulting_path(repo, mise)
+
+      refute path =~ escape,
+             "a repo-controlled version escaped the mise root and reached PATH"
+    end
+
+    test "still prepends a real installed version", %{dir: dir} do
+      # The fix must not cost the hook its job: the whole reason it exists is
+      # that a Homebrew mix ahead of the mise one fails deep inside dep
+      # resolution with `function Enum.__in__/2 is undefined`.
+      repo = Path.join(dir, "repo")
+      mise = Path.join(dir, "mise")
+      File.mkdir_p!(repo)
+
+      installed =
+        Path.join([mise, "installs", "elixir", "1.20.2-otp-29", "bin"])
+
+      File.mkdir_p!(installed)
+
+      write_tool_versions(Path.join(repo, ".tool-versions"), "1.20.2-otp-29")
+
+      assert resulting_path(repo, mise) =~ installed
+    end
+
+    test "leaves PATH alone when the pinned version is not installed", %{
+      dir: dir
+    } do
+      repo = Path.join(dir, "repo")
+      mise = Path.join(dir, "mise")
+      File.mkdir_p!(repo)
+
+      write_tool_versions(Path.join(repo, ".tool-versions"), "9.9.9-otp-99")
+
+      assert resulting_path(repo, mise) == "/usr/bin:/bin"
+    end
+
+    # `set -u` is on, so an unbound variable would abort the hook before any
+    # gate ran, and a shell-metacharacter version must not be executed either.
+    test "survives a malformed or absent version without aborting", %{dir: dir} do
+      repo = Path.join(dir, "repo")
+      mise = Path.join(dir, "mise")
+      File.mkdir_p!(repo)
+
+      for version <- [
+            "",
+            "$(touch #{dir}/pwned)",
+            "../..",
+            "; touch #{dir}/pwned"
+          ] do
+        write_tool_versions(Path.join(repo, ".tool-versions"), version)
+
+        assert resulting_path(repo, mise) == "/usr/bin:/bin",
+               "#{inspect(version)} should leave PATH untouched"
+      end
+
+      refute File.exists?(Path.join(dir, "pwned")),
+             "a version string was executed as shell"
+    end
+  end
+end

--- a/test/raxol/docs/prose_lint_test.exs
+++ b/test/raxol/docs/prose_lint_test.exs
@@ -233,4 +233,42 @@ defmodule Raxol.Docs.ProseLintTest do
       assert ProseLint.format_findings([]) == []
     end
   end
+  # `check_file/2` joined every path onto `:root`, and `Path.join(".", "/tmp/x")`
+  # is `"./tmp/x"` -- so an absolute path read as MISSING and lint as clean.
+  # `scripts/prose_lint.exs` made that reachable in the worst way: its
+  # "named files must exist" guard resolved the real path while the lint
+  # resolved the joined one, so an absolute argument passed the guard and then
+  # silently found nothing.
+  describe "check_file/2 with an absolute path" do
+    setup do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "prose_lint_abs_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf!(dir) end)
+      %{dir: dir}
+    end
+
+    test "reads the file rather than joining it onto the root", %{dir: dir} do
+      path = Path.join(dir, "abs.md")
+      File.write!(path, "An em-dash \u2014 here.")
+
+      assert [%{rule: :unicode_punctuation}] = ProseLint.check_file(path)
+    end
+
+    test "lint_files/2 finds it too, which is the path the hook script takes",
+         %{dir: dir} do
+      path = Path.join(dir, "abs.md")
+      File.write!(path, "An em-dash \u2014 here.")
+
+      assert [%{rule: :unicode_punctuation}] = ProseLint.lint_files([path])
+    end
+
+    test "a missing absolute path is still clean, not a crash", %{dir: dir} do
+      assert ProseLint.check_file(Path.join(dir, "nope.md")) == []
+    end
+  end
 end

--- a/test/raxol/docs/prose_lint_test.exs
+++ b/test/raxol/docs/prose_lint_test.exs
@@ -22,7 +22,9 @@ defmodule Raxol.Docs.ProseLintTest do
 
     test "skips files where the character is the subject" do
       allowed = "test/fixtures/harness/sessions/adversarial.notes.md"
-      assert ProseLint.check_content(allowed, "the strip renders `—` here —") == []
+
+      assert ProseLint.check_content(allowed, "the strip renders `—` here —") ==
+               []
     end
   end
 
@@ -95,7 +97,9 @@ defmodule Raxol.Docs.ProseLintTest do
     end
 
     test "reports a warning, never an error" do
-      [finding] = ProseLint.check_content("probe.md", "## Next Steps", headings: true)
+      [finding] =
+        ProseLint.check_content("probe.md", "## Next Steps", headings: true)
+
       assert finding.severity == :warning
     end
 
@@ -105,7 +109,10 @@ defmodule Raxol.Docs.ProseLintTest do
 
     test "does not fire past a colon or a dash separator" do
       assert rules("### Stage 3: Output generation", headings: true) == []
-      assert rules("### Sprint 5 - Critical Architectural Fixes", headings: true) == []
+
+      assert rules("### Sprint 5 - Critical Architectural Fixes",
+               headings: true
+             ) == []
     end
 
     test "does not fire on a known proper phrase or a quoted external name" do
@@ -133,6 +140,97 @@ defmodule Raxol.Docs.ProseLintTest do
       """
 
       assert rules(content, headings: true) == []
+    end
+  end
+
+  # `lint_files/2` and `format_findings/1` are the contract the pre-commit hook
+  # runs through `scripts/prose_lint.exs`, without Mix. They used to live in the
+  # Mix task, where the hook could not reach them; a disagreement about scope
+  # between the hook and CI is exactly what these pin.
+  describe "lint_files/2" do
+    setup do
+      dir =
+        Path.join(
+          System.tmp_dir!(),
+          "prose_lint_#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf!(dir) end)
+      %{dir: dir}
+    end
+
+    # Paths are relative to `:root`, the way the hook passes git's own
+    # repo-relative output.
+    defp write(dir, rel, content) do
+      path = Path.join(dir, rel)
+      File.mkdir_p!(Path.dirname(path))
+      File.write!(path, content)
+      rel
+    end
+
+    test "skips paths that are not Markdown", %{dir: dir} do
+      rel = write(dir, "notes.txt", "An em-dash — in a text file.")
+      assert ProseLint.lint_files([rel], root: dir) == []
+    end
+
+    test "skips node_modules", %{dir: dir} do
+      rel = write(dir, "node_modules/pkg/README.md", "An em-dash — here.")
+      assert ProseLint.lint_files([rel], root: dir) == []
+    end
+
+    test "skips the vendored termbox2 readme", %{dir: dir} do
+      rel = write(dir, "termbox2/README.md", "An em-dash — here.")
+      assert ProseLint.lint_files([rel], root: dir) == []
+    end
+
+    test "lints Markdown it does own", %{dir: dir} do
+      rel = write(dir, "own.md", "An em-dash — here.")
+
+      assert [%{rule: :unicode_punctuation}] =
+               ProseLint.lint_files([rel], root: dir)
+    end
+
+    test "resolves against :root rather than the cwd", %{dir: dir} do
+      rel = write(dir, "own.md", "An em-dash — here.")
+
+      # The regression this pins: dropping `:root` made every path resolve
+      # against "." and the unreadable result lint as clean.
+      assert ProseLint.lint_files([rel], root: dir) != []
+      assert ProseLint.lint_files([rel]) == []
+    end
+
+    test "sorts by path then line regardless of input order", %{dir: dir} do
+      b = write(dir, "b.md", "An em-dash — here.")
+      a = write(dir, "a.md", "Line one is fine.\nAn em-dash — here.\n")
+
+      assert [first, second] = ProseLint.lint_files([b, a], root: dir)
+      assert first.path == a and first.line == 2
+      assert second.path == b
+    end
+  end
+
+  describe "format_findings/1" do
+    test "renders two lines per finding" do
+      findings = ProseLint.check_content("probe.md", "An em-dash — here.")
+
+      assert [location, text] = ProseLint.format_findings(findings)
+      assert location =~ "probe.md:1"
+      assert location =~ "[unicode_punctuation]"
+      assert text =~ "An em-dash"
+    end
+
+    test "truncates a long source line" do
+      long = String.duplicate("x", 200)
+      findings = ProseLint.check_content("probe.md", "#{long} — tail")
+
+      assert [_location, text] = ProseLint.format_findings(findings)
+      assert String.ends_with?(text, "...")
+      assert String.length(text) < 130
+    end
+
+    test "renders nothing for no findings" do
+      assert ProseLint.format_findings([]) == []
     end
   end
 end


### PR DESCRIPTION
The prose pre-commit gate ran `mix raxol.check_docs`, which boots the project.
So a docs-only commit could be blocked by states that say nothing about prose:
`deps/` not matching the branch's lock (routine when branches carry different
locks and one checkout shares one `deps/`), a `_build` compiled by a different
Elixir than the one on PATH, or a root lock that no longer re-resolves.

It now runs `elixir scripts/prose_lint.exs`. Same `Raxol.Docs.ProseLint` module,
same rules, but nothing loads the project -- the module is stdlib-only, so
requiring the single source file is the whole setup. CI still runs
`mix raxol.check_docs`, which additionally checks catalog counts.

Selection and formatting moved out of the Mix task into `ProseLint`
(`lint_files/2`, `format_findings/1`) so the hook and CI cannot disagree about
which files are in scope.

## The toolchain block

`MIX_HOME` on a mise setup points at that toolchain's `.mix` while a Homebrew
`mix` may come first on PATH, and a Hex archive built for one Elixir loaded by
another fails deep inside dep resolution with `function Enum.__in__/2 is
undefined` -- which reads like a lockfile bug and is not one. The hook prefers
the `.tool-versions` toolchain when it finds it installed under mise.

The version is validated before interpolation, because `.tool-versions` is
repo-controlled and the result goes on PATH: a branch carrying
`elixir ../../../../../../../tmp/evil` would otherwise resolve to
`/tmp/evil/bin` and every `mix` and `elixir` below would run from there.
`test/githooks/pre_commit_test.exs` extracts the block from the hook's own text
and runs it, so it cannot pass against a hook that no longer says what it says.

## Changes from review

**An absolute path lint as clean (`5bc25b7`).** `check_file/2` joined every path
onto `:root`, and `Path.join(".", "/tmp/x")` is `"./tmp/x"` -- which does not
exist, so the file read as missing and returned no findings. This is the same
defect the PR already fixed once (dropping `:root` made every path resolve
against `"."`), and worse than a crash both times: a linter that silently passes
is indistinguishable from one with nothing to say.

`scripts/prose_lint.exs` made it reachable in the worst way -- its "named files
must exist" guard resolved the REAL path while the lint resolved the JOINED one,
so an absolute argument passed the guard and then found nothing. The hook only
ever passes git's repo-relative output, which is why it went unnoticed, but the
script is documented as taking `FILE...` and a person running it by hand types
an absolute path.

**Warnings are reported, not discarded.** `mix raxol.check_docs` prints them and
counts them only under `--warnings-as-errors`; the script dropped them into
`_warnings`. Unreachable as things stand -- the only warning-severity rule is
`:heading_case`, opt-in via `headings: true`, which nothing here enables -- and
fixed anyway, because a silent discard becomes a hook withholding what CI is
about to say the day the hook passes `--headings`.

**`RAXOL_HOOK_NO_TOOLCHAIN=1` turns the block off (`2fac2d08`).** Without it, a
developer deliberately committing against a different Elixir is silently put
back on the pinned one every time, with nothing on screen saying so.

**The security claim is narrowed to what the change delivers.** It read as
closing "arbitrary execution on `git commit`, which is an ordinary thing to do
after checking out someone else's branch". But this same hook runs
`scripts/prose_lint.exs` and `Code.require_file`s `lib/raxol/docs/prose_lint.ex`,
both repo-controlled, and the lockfile gate evaluates `mix.exs`. A branch you do
not trust already chooses code that runs on commit -- true of any repo with hooks
enabled. The regex closes one specific hole, a value this hook itself puts on
PATH. That is worth doing and it is not the larger claim; stating the larger one
invites someone to rely on it.

## CI

The red `Package Tests (raxol_agent_client_protocol)` on the previous push was
`agent_test.exs:266`, an inverted `catch_exit` in an `on_exit` that predates this
PR and lives in a package it never touches. Fixed separately in #917; this goes
green once that lands.

## Testing

- `test/githooks/pre_commit_test.exs` + `test/raxol/docs/prose_lint_test.exs`: 35 passed
- the script by hand: clean file exits 0, error file exits 1 and prints the
  finding, missing file exits 2, absolute path now caught (it was silently clean)
- the real hook end to end in a scratch repo with `core.hooksPath` set: a commit
  staging an em-dash `.md` is blocked with the rules message, a clean one commits
- `bash -n` and `shellcheck` clean on `.githooks/pre-commit`
- `mix format --check-formatted` clean under Elixir 1.20.2 / OTP 29

## Manual testing

- [ ] Stage a `.md` with an em-dash on a branch whose `deps/` does not match its lock; the hook still reports the em-dash rather than a dep error
- [ ] `RAXOL_HOOK_NO_TOOLCHAIN=1 git commit` uses the `mix` already on PATH
