### PR TITLE
Gate raxol_core and raxol_agent in per-PR CI

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -21,9 +21,11 @@
   # pulls the ungated packages (169 files of pre-existing drift) into the root
   # check, so a package joins here when it joins that matrix.
   subdirectories: [
+    "packages/raxol_agent",
     "packages/raxol_agent_client_protocol",
     "packages/raxol_cli",
     "packages/raxol_console",
+    "packages/raxol_core",
     "packages/raxol_earn",
     "packages/raxol_gateway",
     "packages/raxol_payments",

--- a/.github/workflows/ci-unified.yml
+++ b/.github/workflows/ci-unified.yml
@@ -181,9 +181,10 @@ jobs:
       - name: Check singleton allowlist
         run: bash scripts/check_singletons.sh
 
-      # raxol_agent is a local gate, not a per-PR CI package — but a
-      # schema_version bump that ships without a frozen golden journal is
-      # unrecoverable, so the guard runs here. Dependency-free by design.
+      # raxol_agent now has its own package-tests cell, but this guard stays
+      # here: a schema_version bump that ships without a frozen golden journal
+      # is unrecoverable, and this check is dependency-free, so it answers in
+      # seconds without waiting on that cell's compile. Deliberately redundant.
       - name: Check journal golden fixtures
         run: elixir scripts/check_journal_goldens.exs
 
@@ -290,10 +291,13 @@ jobs:
     name: Package Tests (${{ matrix.package }})
     needs: setup
     runs-on: ubuntu-latest
-    # A backstop, not a budget: the suites finish in single-digit minutes. If a
+    # A backstop, not a budget. Most suites finish in single-digit minutes; if a
     # live test ever escapes its exclusion it blocks on a network call, and the
-    # default 6h job timeout would let it sit there.
-    timeout-minutes: 20
+    # default 6h job timeout would let it sit there. Raised from 20 for
+    # raxol_agent, whose 2426 tests take ~6 minutes on an 8-core dev box on top
+    # of compiling main raxol and the termbox2 NIF, so 20 left no headroom on a
+    # two-core runner.
+    timeout-minutes: 35
     strategy:
       fail-fast: false
       matrix:
@@ -312,10 +316,25 @@ jobs:
         # the same reason the others were: nothing in per-PR CI ran it. It joins
         # already clean, so this adds a gate rather than fixing drift.
         #
+        # raxol_core and raxol_agent hold the containment boundaries and were
+        # gated by nothing. Raxol.Core.Boundary.Path is the centralized
+        # path-traversal confinement for the agent's fs tools; its 18 accept and
+        # reject vectors live in packages/raxol_core/test/support/boundary_vectors/
+        # and are copied verbatim into raxol_agent_client_protocol, which is the
+        # only thing that makes the module's own claim -- "drift is a red test,
+        # not a silent fork" -- true. Only the ACP copy had a red test available.
+        # A one-sided corpus is a fork with extra steps.
+        #
+        # The same hole covers the process-kill work now landing in raxol_core
+        # (killing an escaped port's whole process group by negative pgid): a
+        # wrong target there takes the VM or the host down, and its tests would
+        # have shipped unrun. raxol_agent is the package that consumes both, so
+        # both join together.
+        #
         # Keep on ONE line: test/raxol/formatter_delegation_test.exs parses this
         # matrix with `^\s*package: \[...\]` to prove every gated package is also
         # delegated by the root .formatter.exs. A block sequence parses as absent.
-        package: [raxol_gateway, raxol_telegram, raxol_cli, raxol_payments, raxol_earn, raxol_agent_client_protocol, raxol_console, raxol_symphony]
+        package: [raxol_core, raxol_agent, raxol_gateway, raxol_telegram, raxol_cli, raxol_payments, raxol_earn, raxol_agent_client_protocol, raxol_console, raxol_symphony]
 
     steps:
       - uses: actions/checkout@v7
@@ -362,6 +381,13 @@ jobs:
       # the live suite -- which compile-gates on the same one variable -- starts
       # issuing requests on every PR, forks included. ExUnit unions these with
       # the helper's list, so nothing here can un-exclude a tag.
+      #
+      # :skip_on_ci is the repo-wide "this needs a real workstation" marker, and
+      # the root suite honours it whenever SKIP_TERMBOX2_TESTS is set -- which is
+      # workflow-global here. raxol_agent's test_helper never wired it up, so its
+      # one tagged test (a chmod-0500 write-failure fault in the journal Writer)
+      # was inert. Excluding it here applies the convention rather than inventing
+      # a package-local one. No other gated package uses the tag.
       - name: Run package tests
         working-directory: packages/${{ matrix.package }}
         run: |
@@ -379,7 +405,8 @@ jobs:
             --exclude live_chain \
             --exclude live_bundler \
             --exclude live_acp_dev \
-            --exclude cli_signer
+            --exclude cli_signer \
+            --exclude skip_on_ci
 
       # Last, not first. The root Format Check reads the root .formatter.exs,
       # whose inputs cover only root lib/config/examples/test, so before this

--- a/packages/raxol_agent/lib/mix/tasks/raxol.acp.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.acp.ex
@@ -65,9 +65,7 @@ defmodule Mix.Tasks.Raxol.Acp do
     # comes up on stderr instead of putting every startup log line on the wire.
     # (`Serve` re-asserts this after boot.) Mix's own `==> dep` announcements go
     # to stdout too, hence the quiet shell and the skipped checks.
-    Application.put_env(:logger, :default_handler,
-      config: %{type: :standard_error}
-    )
+    Application.put_env(:logger, :default_handler, config: %{type: :standard_error})
 
     Application.put_env(:raxol, :skip_endpoint, true)
     Application.put_env(:raxol, :startup_mode, :mcp)

--- a/packages/raxol_agent/lib/mix/tasks/raxol.setup.ex
+++ b/packages/raxol_agent/lib/mix/tasks/raxol.setup.ex
@@ -104,9 +104,7 @@ defmodule Mix.Tasks.Raxol.Setup do
         do_connect_browser(provider)
 
       true ->
-        usage_error(
-          "give one of --op, --api-key, --browser, or --remove for #{provider}"
-        )
+        usage_error("give one of --op, --api-key, --browser, or --remove for #{provider}")
     end
   end
 
@@ -202,10 +200,7 @@ defmodule Mix.Tasks.Raxol.Setup do
     do: IO.puts("#{harness} credential validated ✓")
 
   defp report_validation(harness, {:rejected, status}),
-    do:
-      fail(
-        "#{harness} credential rejected (HTTP #{status}) — check the key/reference"
-      )
+    do: fail("#{harness} credential rejected (HTTP #{status}) — check the key/reference")
 
   defp report_validation(harness, {:reachable_error, status}),
     do: fail("#{harness} endpoint returned HTTP #{status}")
@@ -217,10 +212,7 @@ defmodule Mix.Tasks.Raxol.Setup do
     do: IO.puts("#{harness} stored (no validation endpoint for this provider)")
 
   defp report_validation(harness, {:no_key, _}),
-    do:
-      fail(
-        "#{harness} reference stored but no key resolved — is `op` signed in?"
-      )
+    do: fail("#{harness} reference stored but no key resolved — is `op` signed in?")
 
   defp report_validation(harness, :no_provider),
     do: fail("could not resolve a provider for #{harness}")

--- a/packages/raxol_agent/lib/raxol/agent/actions/fs.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/fs.ex
@@ -105,8 +105,7 @@ defmodule Raxol.Agent.Actions.Fs do
 
       with {:ok, abs} <- resolver.(path),
            {:ok, content} <- File.read(abs) do
-        {:ok,
-         slice(path, content, Map.get(params, :offset), Map.get(params, :limit))}
+        {:ok, slice(path, content, Map.get(params, :offset), Map.get(params, :limit))}
       else
         {:error, reason} -> {:error, reason}
       end

--- a/packages/raxol_agent/lib/raxol/agent/auth/loopback.ex
+++ b/packages/raxol_agent/lib/raxol/agent/auth/loopback.ex
@@ -157,8 +157,7 @@ defmodule Raxol.Agent.Auth.Loopback do
         {:done, {:ok, code}}
 
       %{"error" => error} when is_binary(error) ->
-        {:done,
-         {:error, {:oauth_error, error, Map.get(params, "error_description")}}}
+        {:done, {:error, {:oauth_error, error, Map.get(params, "error_description")}}}
 
       _ ->
         :continue

--- a/packages/raxol_agent/lib/raxol/agent/code/launcher.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/launcher.ex
@@ -220,9 +220,7 @@ defmodule Raxol.Agent.Code.Launcher do
         )
 
       is_binary(tenants) and keys not in [nil, ""] ->
-        usage_error!(
-          "--authorized-keys and --ssh-tenants are mutually exclusive"
-        )
+        usage_error!("--authorized-keys and --ssh-tenants are mutually exclusive")
 
       Keyword.get(parsed, :continue, false) || Keyword.get(parsed, :resume) ->
         usage_error!(

--- a/packages/raxol_agent/lib/raxol/agent/code/replay.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/replay.ex
@@ -55,12 +55,10 @@ defmodule Raxol.Agent.Code.Replay do
         store_events(session_id, opts)
 
       {:ok, records} ->
-        {:ok, :journal,
-         decode_records(records, to_offset: Keyword.get(opts, :to_offset))}
+        {:ok, :journal, decode_records(records, to_offset: Keyword.get(opts, :to_offset))}
 
       {:error, :damaged} ->
-        {:error,
-         "session #{session_id}: journal damaged — nothing safely replayable"}
+        {:error, "session #{session_id}: journal damaged — nothing safely replayable"}
     end
   end
 
@@ -107,8 +105,7 @@ defmodule Raxol.Agent.Code.Replay do
         {:ok, :store, events}
 
       {:error, :not_found} ->
-        {:error,
-         "session #{session_id} not found (no journal, no saved session)"}
+        {:error, "session #{session_id} not found (no journal, no saved session)"}
     end
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/code/store.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/store.ex
@@ -113,8 +113,7 @@ defmodule Raxol.Agent.Code.Store do
       "title" => Map.get(attrs, :title, ""),
       # A forked session records the id it was copied from.
       "parent" => Map.get(attrs, :parent),
-      "messages" =>
-        attrs |> Map.get(:messages, []) |> Enum.map(&encode_message/1),
+      "messages" => attrs |> Map.get(:messages, []) |> Enum.map(&encode_message/1),
       # Durable projection events, stored as-is (already JSON-encodable);
       # EventCodec decodes them back to projection shape on load.
       "events" => Map.get(attrs, :events, [])
@@ -168,8 +167,7 @@ defmodule Raxol.Agent.Code.Store do
         |> Map.get("messages", [])
         |> Enum.map(&decode_message/1)
         |> Enum.reject(&is_nil/1),
-      events:
-        Raxol.Agent.Code.EventCodec.decode_all(Map.get(json, "events", []))
+      events: Raxol.Agent.Code.EventCodec.decode_all(Map.get(json, "events", []))
     }
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
+++ b/packages/raxol_agent/lib/raxol/agent/emit_bridge.ex
@@ -328,8 +328,7 @@ defmodule Raxol.Agent.EmitBridge do
             {:ok, state, offset}
 
           {:error, detail} ->
-            {:error, drop_dead_journal(state, detail), :journal_append_failed,
-             detail}
+            {:error, drop_dead_journal(state, detail), :journal_append_failed, detail}
         end
 
       {:error, state, detail} ->

--- a/packages/raxol_agent/lib/raxol/agent/executor_config.ex
+++ b/packages/raxol_agent/lib/raxol/agent/executor_config.ex
@@ -30,8 +30,7 @@ defmodule Raxol.Agent.ExecutorConfig do
   # struct would be dropped whole by the codec; declaring the slice makes the
   # secret boundary explicit and keeps a session key out of a checkpoint on
   # disk. See `Raxol.Agent.Snapshot.Persist`.
-  @derive {Raxol.Agent.Snapshot.Persist,
-           persist: [:backend, :model, :opts], redact: [:auth]}
+  @derive {Raxol.Agent.Snapshot.Persist, persist: [:backend, :model, :opts], redact: [:auth]}
   # `auth` holds the raw API credential; keep it out of every `inspect/1`
   # (crash dumps, the Lifecycle's boot-options log line, IEx) — the routing
   # fields still show. Snapshot redaction above covers the on-disk path;

--- a/packages/raxol_agent/lib/raxol/agent/harness/mcp_tools.ex
+++ b/packages/raxol_agent/lib/raxol/agent/harness/mcp_tools.ex
@@ -92,8 +92,7 @@ defmodule Raxol.Agent.Harness.McpTools do
       },
       %{
         name: "harness_read_transcript",
-        description:
-          "Returns a session's conversation (role-prefixed messages).",
+        description: "Returns a session's conversation (role-prefixed messages).",
         inputSchema: %{
           type: "object",
           required: ["session_id"],
@@ -105,8 +104,7 @@ defmodule Raxol.Agent.Harness.McpTools do
       },
       %{
         name: "harness_list_sessions",
-        description:
-          "Lists saved coding-agent sessions, most recently updated first.",
+        description: "Lists saved coding-agent sessions, most recently updated first.",
         inputSchema: %{type: "object", properties: %{}},
         callback: &list_sessions/1
       }
@@ -170,8 +168,7 @@ defmodule Raxol.Agent.Harness.McpTools do
          {:ok, prompt} <- required(args, "prompt") do
       case Store.load(Store.default_dir(), key) do
         {:error, :not_found} ->
-          {:error,
-           "unknown session #{inspect(key)}; call harness_start_session first"}
+          {:error, "unknown session #{inspect(key)}; call harness_start_session first"}
 
         {:ok, session} ->
           run_turn(key, session, prompt, args)
@@ -421,8 +418,7 @@ defmodule Raxol.Agent.Harness.McpTools do
   # -- helpers ----------------------------------------------------------------
 
   defp mint_session_key,
-    do:
-      "sess-#{System.system_time(:second)}-#{System.unique_integer([:positive])}"
+    do: "sess-#{System.system_time(:second)}-#{System.unique_integer([:positive])}"
 
   # Session ids come off the wire: basename-sanitize so a crafted id cannot
   # escape the sessions directory (same rule the TUI store applies).

--- a/packages/raxol_agent/lib/raxol/agent/journal/file_store/writer.ex
+++ b/packages/raxol_agent/lib/raxol/agent/journal/file_store/writer.ex
@@ -212,8 +212,7 @@ defmodule Raxol.Agent.Journal.FileStore.Writer do
       offset: offset,
       schema_version: schema_version,
       immediate_types: immediate_types,
-      sync_ceiling_ms:
-        Keyword.get(opts, :sync_ceiling_ms, @default_sync_ceiling_ms),
+      sync_ceiling_ms: Keyword.get(opts, :sync_ceiling_ms, @default_sync_ceiling_ms),
       lock_path: lock_path
     }
 

--- a/packages/raxol_agent/lib/raxol/agent/session.ex
+++ b/packages/raxol_agent/lib/raxol/agent/session.ex
@@ -695,8 +695,7 @@ defmodule Raxol.Agent.Session do
   defp bridge_name_opts(session_id) do
     if Process.whereis(Raxol.Agent.Registry) do
       [
-        name:
-          {:via, Registry, {Raxol.Agent.Registry, {:emit_bridge, session_id}}}
+        name: {:via, Registry, {Raxol.Agent.Registry, {:emit_bridge, session_id}}}
       ]
     else
       []

--- a/packages/raxol_agent/lib/raxol/agent/thread_log_router.ex
+++ b/packages/raxol_agent/lib/raxol/agent/thread_log_router.ex
@@ -115,9 +115,7 @@ defmodule Raxol.Agent.ThreadLogRouter do
     audit_metadata = Map.drop(metadata, [:agent_id, :agent_module])
 
     _ =
-      ThreadLog.append(adapter, thread_id, kind, payload,
-        metadata: audit_metadata
-      )
+      ThreadLog.append(adapter, thread_id, kind, payload, metadata: audit_metadata)
 
     :ok
   end

--- a/packages/raxol_agent/test/invariants/contract_invariants_test.exs
+++ b/packages/raxol_agent/test/invariants/contract_invariants_test.exs
@@ -57,9 +57,7 @@ defmodule Raxol.Agent.Invariants.ContractInvariantsTest do
   setup do
     FaultJournal.ensure_registry(:duplicate, EmitBus.registry_name())
 
-    FaultJournal.ensure_running(
-      {Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences}
-    )
+    FaultJournal.ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
 
     # pump/3 emits into the NAMED SessionStreamer.
     start_supervised!(Raxol.Agent.SessionStreamer)
@@ -112,9 +110,7 @@ defmodule Raxol.Agent.Invariants.ContractInvariantsTest do
 
       for family <- @snapshot["enums"]["family"] do
         event =
-          EmitBus.build("s", :app_update, :durable, %{},
-            family: String.to_existing_atom(family)
-          )
+          EmitBus.build("s", :app_update, :durable, %{}, family: String.to_existing_atom(family))
 
         assert to_string(event.family) == family
       end
@@ -132,8 +128,7 @@ defmodule Raxol.Agent.Invariants.ContractInvariantsTest do
 
       stream = [
         {:text_delta, "chunk one"},
-        {:tool_use,
-         %{name: "read_file", arguments: %{path: "/x"}, id: "call-1"}},
+        {:tool_use, %{name: "read_file", arguments: %{path: "/x"}, id: "call-1"}},
         {:tool_result, %{name: "read_file", result: "contents"}},
         {:turn_complete, %{iteration: 1, usage: %{input_tokens: 1}}},
         {:done, %{content: "final answer", usage: %{output_tokens: 2}}}
@@ -261,11 +256,7 @@ defmodule Raxol.Agent.Invariants.ContractInvariantsTest do
 
           payload = Map.fetch!(neutral_payloads, neutral)
 
-          EmitBus.publish(
-            EmitBus.build(session_id, neutral_type, tier, payload,
-              turn_id: "t1"
-            )
-          )
+          EmitBus.publish(EmitBus.build(session_id, neutral_type, tier, payload, turn_id: "t1"))
 
           ev = await_event!(session_id)
 
@@ -314,18 +305,14 @@ defmodule Raxol.Agent.Invariants.ContractInvariantsTest do
       :ok = SessionStreamer.subscribe(session_id, streamer)
 
       # Open, then kill the writer to force the append-failure signal.
-      EmitBus.publish(
-        EmitBus.build(session_id, :turn_started, :durable, %{message: "p"})
-      )
+      EmitBus.publish(EmitBus.build(session_id, :turn_started, :durable, %{message: "p"}))
 
       _started = await_event!(session_id)
 
       %{journal: %FileStore{writer: writer}} = :sys.get_state(bridge)
       GenServer.stop(writer)
 
-      EmitBus.publish(
-        EmitBus.build(session_id, :app_update, :durable, %{message: "lost"})
-      )
+      EmitBus.publish(EmitBus.build(session_id, :app_update, :durable, %{message: "lost"}))
 
       failure = await_event!(session_id)
 

--- a/packages/raxol_agent/test/invariants/identity_invariants_test.exs
+++ b/packages/raxol_agent/test/invariants/identity_invariants_test.exs
@@ -45,9 +45,7 @@ defmodule Raxol.Agent.Invariants.IdentityInvariantsTest do
   setup do
     FaultJournal.ensure_registry(:duplicate, EmitBus.registry_name())
 
-    FaultJournal.ensure_running(
-      {Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences}
-    )
+    FaultJournal.ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
 
     base =
       Path.join(
@@ -445,9 +443,7 @@ defmodule Raxol.Agent.Invariants.IdentityInvariantsTest do
   # --- oracle helpers ----------------------------------------------------------
 
   defp publish(ctx, type, tier, payload) do
-    EmitBus.publish(
-      EmitBus.build(ctx.session_id, type, tier, payload, turn_id: "t1")
-    )
+    EmitBus.publish(EmitBus.build(ctx.session_id, type, tier, payload, turn_id: "t1"))
   end
 
   # Receive the next live durable event and assert I3 at the moment of first
@@ -483,9 +479,7 @@ defmodule Raxol.Agent.Invariants.IdentityInvariantsTest do
         )
     after
       2_000 ->
-        flunk(
-          "timed out waiting for #{inspect(type)} (schedule: #{inspect(ctx.schedule)})"
-        )
+        flunk("timed out waiting for #{inspect(type)} (schedule: #{inspect(ctx.schedule)})")
     end
   end
 
@@ -508,9 +502,7 @@ defmodule Raxol.Agent.Invariants.IdentityInvariantsTest do
         )
     after
       2_000 ->
-        flunk(
-          "timed out waiting for #{inspect(reason)} (schedule: #{inspect(ctx.schedule)})"
-        )
+        flunk("timed out waiting for #{inspect(reason)} (schedule: #{inspect(ctx.schedule)})")
     end
   end
 
@@ -555,9 +547,7 @@ defmodule Raxol.Agent.Invariants.IdentityInvariantsTest do
         writer
 
       %{journal: nil} ->
-        flunk(
-          "fault site needs an open journal; schedule must front-load durables"
-        )
+        flunk("fault site needs an open journal; schedule must front-load durables")
     end
   end
 

--- a/packages/raxol_agent/test/invariants/storage_invariants_test.exs
+++ b/packages/raxol_agent/test/invariants/storage_invariants_test.exs
@@ -662,9 +662,7 @@ defmodule Raxol.Agent.Invariants.StorageInvariantsTest do
             :ok
 
           {:error, reason} ->
-            flunk(
-              "HEAD torn after kill: #{inspect(reason)} — atomic write violated"
-            )
+            flunk("HEAD torn after kill: #{inspect(reason)} — atomic write violated")
         end
 
         FaultJournal.assert_all_fired!(harness, {:kill_after, n})

--- a/packages/raxol_agent/test/invariants/turn_invariants_test.exs
+++ b/packages/raxol_agent/test/invariants/turn_invariants_test.exs
@@ -56,9 +56,7 @@ defmodule Raxol.Agent.Invariants.TurnInvariantsTest do
   setup do
     FaultJournal.ensure_registry(:duplicate, EmitBus.registry_name())
 
-    FaultJournal.ensure_running(
-      {Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences}
-    )
+    FaultJournal.ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
 
     FaultJournal.ensure_running(
       {DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one}

--- a/packages/raxol_agent/test/raxol/agent/auth/flow_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/auth/flow_test.exs
@@ -121,8 +121,7 @@ defmodule Raxol.Agent.Auth.FlowTest do
       capture = fn url ->
         send(
           caller,
-          {:challenge,
-           url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()}
+          {:challenge, url |> URI.parse() |> Map.fetch!(:query) |> URI.decode_query()}
         )
 
         browser().(url)

--- a/packages/raxol_agent/test/raxol/agent/client_protocol/login_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/client_protocol/login_test.exs
@@ -95,9 +95,7 @@ defmodule Raxol.Agent.ClientProtocol.LoginTest do
         # The seam returns :ok even though the launch failed, so the flow does
         # not abandon a port the user can still redeem by hand.
         assert :ok =
-                 Keyword.fetch!(opts, :browser_fn).(
-                   "https://openrouter.ai/auth?x=1"
-                 )
+                 Keyword.fetch!(opts, :browser_fn).("https://openrouter.ai/auth?x=1")
 
         {:ok, %{provider: provider, validation: :valid}}
       end

--- a/packages/raxol_agent/test/raxol/agent/code/app_login_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_login_test.exs
@@ -242,8 +242,7 @@ defmodule Raxol.Agent.Code.AppLoginTest do
 
       {model, []} =
         App.update(
-          {:command_result,
-           {:browser_signin, ref, :openrouter, {:ok, %{validation: :valid}}}},
+          {:command_result, {:browser_signin, ref, :openrouter, {:ok, %{validation: :valid}}}},
           model
         )
 
@@ -332,8 +331,7 @@ defmodule Raxol.Agent.Code.AppLoginTest do
 
       model = type(model, "/login openai sk-good")
 
-      assert_receive {:command_result,
-                      {:login_validation, ref, :openai, :valid}} = msg
+      assert_receive {:command_result, {:login_validation, ref, :openai, :valid}} = msg
 
       assert ref == model.login_ref
 
@@ -350,8 +348,7 @@ defmodule Raxol.Agent.Code.AppLoginTest do
 
       model = type(model, "/login openai sk-bad")
 
-      assert_receive {:command_result,
-                      {:login_validation, _ref, :openai, {:rejected, 401}}} =
+      assert_receive {:command_result, {:login_validation, _ref, :openai, {:rejected, 401}}} =
                        msg
 
       {model, []} = App.update(msg, model)
@@ -367,8 +364,7 @@ defmodule Raxol.Agent.Code.AppLoginTest do
 
       model = type(model, "/login lm_studio")
 
-      assert_receive {:command_result,
-                      {:login_validation, _ref, :lm_studio, :unreachable}} = msg
+      assert_receive {:command_result, {:login_validation, _ref, :lm_studio, :unreachable}} = msg
 
       {model, []} = App.update(msg, model)
       assert model.status_line =~ "unreachable"
@@ -383,8 +379,7 @@ defmodule Raxol.Agent.Code.AppLoginTest do
 
       {model, []} =
         App.update(
-          {:command_result,
-           {:login_validation, stale, :openai, {:rejected, 401}}},
+          {:command_result, {:login_validation, stale, :openai, {:rejected, 401}}},
           model
         )
 

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -279,8 +279,7 @@ defmodule Raxol.Agent.Code.AppTest do
 
       {model, []} =
         App.update(
-          {:command_result,
-           {:models_list, ref, {:ok, ["gpt-4o-mini", "gpt-4o"]}}},
+          {:command_result, {:models_list, ref, {:ok, ["gpt-4o-mini", "gpt-4o"]}}},
           model
         )
 
@@ -302,8 +301,7 @@ defmodule Raxol.Agent.Code.AppTest do
 
       {model, []} =
         App.update(
-          {:command_result,
-           {:models_list, model.models_ref, {:ok, ["a", "b", "c"]}}},
+          {:command_result, {:models_list, model.models_ref, {:ok, ["a", "b", "c"]}}},
           model
         )
 
@@ -352,9 +350,7 @@ defmodule Raxol.Agent.Code.AppTest do
       test_pid = self()
 
       model =
-        connected_model(
-          models_fetcher: fn _o, _r, _a -> send(test_pid, :fetched) end
-        )
+        connected_model(models_fetcher: fn _o, _r, _a -> send(test_pid, :fetched) end)
 
       {model, []} = slash(model, "/model claude-sonnet-5")
 
@@ -706,14 +702,12 @@ defmodule Raxol.Agent.Code.AppTest do
       stored =
         [
           {"t1", 1, "turn_started", %{"prompt" => "one"}},
-          {"t1", 2, "item_started",
-           %{"item_id" => "i1", "item_type" => "message"}},
+          {"t1", 2, "item_started", %{"item_id" => "i1", "item_type" => "message"}},
           {"t1", 3, "item_completed",
            %{"item_id" => "i1", "item_type" => "message", "content" => "a"}},
           {"t1", 4, "turn_completed", %{"final" => true}},
           {"t2", 1, "turn_started", %{"prompt" => "two"}},
-          {"t2", 2, "item_started",
-           %{"item_id" => "i1", "item_type" => "message"}},
+          {"t2", 2, "item_started", %{"item_id" => "i1", "item_type" => "message"}},
           {"t2", 3, "item_completed",
            %{"item_id" => "i1", "item_type" => "message", "content" => "b"}},
           {"t2", 4, "turn_completed", %{"final" => true}}
@@ -1095,8 +1089,7 @@ defmodule Raxol.Agent.Code.AppTest do
 
       {model, []} =
         App.update(
-          {:command_result,
-           {:sessions_list, ref, Raxol.Agent.Code.Store.list(dir)}},
+          {:command_result, {:sessions_list, ref, Raxol.Agent.Code.Store.list(dir)}},
           model
         )
 
@@ -1134,8 +1127,7 @@ defmodule Raxol.Agent.Code.AppTest do
       {model, []} =
         App.update(
           {:command_result,
-           {:sessions_list, model.sessions_ref,
-            Raxol.Agent.Code.Store.list(dir)}},
+           {:sessions_list, model.sessions_ref, Raxol.Agent.Code.Store.list(dir)}},
           model
         )
 
@@ -1991,8 +1983,7 @@ defmodule Raxol.Agent.Code.AppTest do
 
       task = Task.async(fn -> auth.(tool, %{}, %{}) end)
 
-      assert_receive {:command_result,
-                      {:authorize_request, ref, from, "mcp__fs__write"}}
+      assert_receive {:command_result, {:authorize_request, ref, from, "mcp__fs__write"}}
 
       send(from, {:authorize_decision, ref, {:deny, :test_denied}})
       assert Task.await(task) == {:deny, :test_denied}

--- a/packages/raxol_agent/test/raxol/agent/code/replay_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/replay_test.exs
@@ -95,8 +95,7 @@ defmodule Raxol.Agent.Code.ReplayTest do
     stored =
       [
         {"t1", 1, "turn_started", %{"prompt" => "old prompt"}},
-        {"t1", 2, "item_started",
-         %{"item_id" => "i1", "item_type" => "message"}},
+        {"t1", 2, "item_started", %{"item_id" => "i1", "item_type" => "message"}},
         {"t1", 3, "item_completed",
          %{
            "item_id" => "i1",

--- a/packages/raxol_agent/test/raxol/agent/directive_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/directive_test.exs
@@ -69,8 +69,7 @@ defmodule Raxol.Agent.DirectiveTest do
       assert_receive {:command_result, :first, %{turn_id: "turn-orig"}}, 1_000
       assert_receive {:command_result, :second, %{turn_id: "turn-orig"}}, 1_000
 
-      assert_receive {:command_result, {:progress, 50},
-                      %{turn_id: "turn-orig"}},
+      assert_receive {:command_result, {:progress, 50}, %{turn_id: "turn-orig"}},
                      1_000
     end
 
@@ -92,8 +91,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("echo hello-from-shell")
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result,
-                      {:shell_result, %{exit_status: 0, output: output}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: 0, output: output}},
                       %{turn_id: nil}},
                      5_000
 
@@ -104,8 +102,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("exit 7")
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result, {:shell_result, %{exit_status: 7}},
-                      %{turn_id: nil}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: 7}}, %{turn_id: nil}},
                      5_000
     end
 
@@ -113,8 +110,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("sleep 5", timeout: 100)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result,
-                      {:shell_result, %{exit_status: :timeout}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: :timeout}},
                       %{turn_id: nil}},
                      2_000
     end
@@ -128,8 +124,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("cat", timeout: 5_000)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result,
-                      {:shell_result, %{exit_status: 0, output: ""}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: 0, output: ""}},
                       %{turn_id: nil}},
                      2_000
     end
@@ -139,8 +134,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.shell("cat | wc -l", timeout: 5_000)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result,
-                      {:shell_result, %{exit_status: 0, output: output}},
+      assert_receive {:command_result, {:shell_result, %{exit_status: 0, output: output}},
                       %{turn_id: nil}},
                      2_000
 
@@ -153,8 +147,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.send_agent("nobody", :payload)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:command_result,
-                      {:send_agent_error, :not_found, "nobody"},
+      assert_receive {:command_result, {:send_agent_error, :not_found, "nobody"},
                       %{turn_id: nil}},
                      1_000
     end
@@ -185,8 +178,7 @@ defmodule Raxol.Agent.DirectiveTest do
       directive = Directive.send_agent("causation-target", :payload)
       Executor.execute(directive, %{pid: self(), runtime_pid: self()})
 
-      assert_receive {:"$gen_cast",
-                      {:send_message, :payload, %{causation_id: ^span_id}}},
+      assert_receive {:"$gen_cast", {:send_message, :payload, %{causation_id: ^span_id}}},
                      1_000
     after
       Raxol.Core.Telemetry.TraceContext.clear()

--- a/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/emit_bridge_test.exs
@@ -66,9 +66,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
         start_supervised!({SessionStreamer, name: :bridge_test_streamer})
 
       bridge =
-        start_supervised!(
-          {EmitBridge, session_id: @session_id, streamer: streamer}
-        )
+        start_supervised!({EmitBridge, session_id: @session_id, streamer: streamer})
 
       # Give the bridge a moment to register its EmitBus subscription.
       _ = :sys.get_state(bridge)
@@ -180,8 +178,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
 
       main_bridge =
         start_supervised!(
-          {EmitBridge,
-           session_id: main_session, streamer: streamer, journal: main_journal},
+          {EmitBridge, session_id: main_session, streamer: streamer, journal: main_journal},
           id: :main_bridge
         )
 
@@ -327,8 +324,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
 
       bridge =
         start_supervised!(
-          {EmitBridge,
-           session_id: session, streamer: streamer, journal: journal},
+          {EmitBridge, session_id: session, streamer: streamer, journal: journal},
           id: :prov_default_bridge
         )
 
@@ -378,10 +374,7 @@ defmodule Raxol.Agent.EmitBridgeTest do
       {:ok, journal} = FileStore.open(session, base_dir: base)
 
       bridge =
-        start_supervised!(
-          {EmitBridge,
-           session_id: session, streamer: streamer, journal: journal}
-        )
+        start_supervised!({EmitBridge, session_id: session, streamer: streamer, journal: journal})
 
       _ = :sys.get_state(bridge)
       SessionStreamer.subscribe(session, streamer)

--- a/packages/raxol_agent/test/raxol/agent/event_forwarder_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/event_forwarder_test.exs
@@ -65,16 +65,12 @@ defmodule Raxol.Agent.EventForwarderTest do
       ]
 
       assert :ok =
-               EventForwarder.to_parent(stream, self(), "k",
-                 halt_on_error?: false
-               )
+               EventForwarder.to_parent(stream, self(), "k", halt_on_error?: false)
     end
 
     test "custom :tag" do
       :ok =
-        EventForwarder.to_parent([{:done, %{content: ""}}], self(), :alpha,
-          tag: :symphony
-        )
+        EventForwarder.to_parent([{:done, %{content: ""}}], self(), :alpha, tag: :symphony)
 
       assert_received {:symphony, :alpha, %{event: :turn_completed}}
     end
@@ -83,9 +79,7 @@ defmodule Raxol.Agent.EventForwarderTest do
       stream = [{:text_delta, "raw"}, {:done, %{content: ""}}]
 
       :ok =
-        EventForwarder.to_parent(stream, self(), "k",
-          transform: &Function.identity/1
-        )
+        EventForwarder.to_parent(stream, self(), "k", transform: &Function.identity/1)
 
       assert_received {:run_event, "k", {:text_delta, "raw"}}
       assert_received {:run_event, "k", {:done, _}}

--- a/packages/raxol_agent/test/raxol/agent/executor_config_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/executor_config_test.exs
@@ -130,8 +130,7 @@ defmodule Raxol.Agent.ExecutorConfigTest do
     test "a model embedding an executor never leaks the key into the envelope" do
       model = %{
         input: "hello",
-        executor:
-          ExecutorConfig.new(harness: :openai, auth: %{api_key: @secret})
+        executor: ExecutorConfig.new(harness: :openai, auth: %{api_key: @secret})
       }
 
       {:ok, envelope} = Snapshot.dump(model)

--- a/packages/raxol_agent/test/raxol/agent/harness/session_lane_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/harness/session_lane_test.exs
@@ -20,9 +20,7 @@ defmodule Raxol.Agent.Harness.SessionLaneTest do
   setup do
     start_supervised!({Registry, keys: :unique, name: Raxol.Agent.Registry})
 
-    start_supervised!(
-      {DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one}
-    )
+    start_supervised!({DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one})
 
     start_supervised!(Raxol.Agent.SessionStreamer)
     :ok
@@ -51,8 +49,7 @@ defmodule Raxol.Agent.Harness.SessionLaneTest do
 
       assert :ok = SessionLane.interrupt(session, %{turn_id: "turn-7"})
 
-      assert_receive {:harness_command,
-                      {:interrupt, ^session_id, %{turn_id: "turn-7"}}}
+      assert_receive {:harness_command, {:interrupt, ^session_id, %{turn_id: "turn-7"}}}
     end
 
     test "an empty payload dispatches an empty interrupt payload" do

--- a/packages/raxol_agent/test/raxol/agent/harness/tool_executor_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/harness/tool_executor_test.exs
@@ -350,8 +350,7 @@ defmodule Raxol.Agent.Harness.ToolExecutorTest do
           await_decision: fn _rid, _meta -> {:allow, "allow"} end
         )
 
-      assert {:approval_requested,
-              %{tool_name: "edit_file", request_id: rid, options: opts}} =
+      assert {:approval_requested, %{tool_name: "edit_file", request_id: rid, options: opts}} =
                Enum.find(events, &match?({:approval_requested, _}, &1))
 
       assert is_list(opts) and Enum.any?(opts, &(&1.kind == :allow_once))
@@ -634,8 +633,7 @@ defmodule Raxol.Agent.Harness.ToolExecutorTest do
           end
         )
 
-      assert {:tool_result,
-              %{name: "edit_file", result: {:error, :stale_approval}}} =
+      assert {:tool_result, %{name: "edit_file", result: {:error, :stale_approval}}} =
                Enum.find(events, &match?({:tool_result, _}, &1))
 
       # Our edit was NEVER applied -- the file keeps the drifted content.
@@ -649,8 +647,7 @@ defmodule Raxol.Agent.Harness.ToolExecutorTest do
       events =
         run(
           [
-            {:tool_calls,
-             [%{"name" => "delete_everything", "arguments" => %{}, "id" => "x"}]},
+            {:tool_calls, [%{"name" => "delete_everything", "arguments" => %{}, "id" => "x"}]},
             {:content, "ok"}
           ],
           actions: Workspace.all(),
@@ -850,8 +847,7 @@ defmodule Raxol.Agent.Harness.ToolExecutorTest do
                usage: %{},
                reasoning: "first I plan the read"
              }},
-            {:response,
-             %{content: "the answer", usage: %{}, reasoning: "now I conclude"}}
+            {:response, %{content: "the answer", usage: %{}, reasoning: "now I conclude"}}
           ],
           actions: Fs.all(),
           gate?: false
@@ -903,8 +899,7 @@ defmodule Raxol.Agent.Harness.ToolExecutorTest do
                metadata: %{
                  finish_reason: :length,
                  truncated: true,
-                 marker:
-                   "⚠ response truncated — hit token limit; raise AI_MAX_TOKENS"
+                 marker: "⚠ response truncated — hit token limit; raise AI_MAX_TOKENS"
                }
              }}
           ],
@@ -959,8 +954,7 @@ defmodule Raxol.Agent.Harness.ToolExecutorTest do
              usage: %{},
              reasoning: "first, read the file"
            }},
-          {:response,
-           %{content: "done reading", usage: %{}, reasoning: "now, answer"}}
+          {:response, %{content: "done reading", usage: %{}, reasoning: "now, answer"}}
         ])
 
       stream =
@@ -1058,8 +1052,7 @@ defmodule Raxol.Agent.Harness.ToolExecutorTest do
           {:reasoning, "got it"},
           {:chunk, "the file says "},
           {:chunk, "hello world"},
-          {:done,
-           %{content: "the file says hello world", tool_calls: [], usage: %{}}}
+          {:done, %{content: "the file says hello world", tool_calls: [], usage: %{}}}
         ]
       ]
 

--- a/packages/raxol_agent/test/raxol/agent/journal/writer_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/journal/writer_hardening_test.exs
@@ -158,6 +158,7 @@ defmodule Raxol.Agent.Journal.WriterHardeningTest do
       File.mkdir_p!(blocker)
 
       assert {:error, _reason} = Writer.start_link(dir: dir, session_id: s)
+
       refute File.exists?(Path.join(dir, "writer.lock")),
              "the lock must be released when init fails after acquiring it"
 

--- a/packages/raxol_agent/test/raxol/agent/keystone_close_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/keystone_close_test.exs
@@ -42,13 +42,9 @@ defmodule Raxol.Agent.KeystoneCloseTest do
     # named singleton that a later start_supervised!-based test would collide on.
     ensure_registry(:duplicate, EmitBus.registry_name())
 
-    ensure_running(
-      {Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences}
-    )
+    ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
 
-    ensure_running(
-      {DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one}
-    )
+    ensure_running({DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one})
 
     # Per-test singletons owned by ExUnit (auto-stopped at test end): the agent
     # Registry (matches session_test/team_test) and the named SessionStreamer the
@@ -138,8 +134,7 @@ defmodule Raxol.Agent.KeystoneCloseTest do
 
       # Wait until the sink has emitted turn_completed — guarantees all four were
       # processed (durable ones appended before publish).
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :turn_completed}},
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_completed}},
                      1_000
 
       # Simulate the BEAM going away: stop the sink, which flushes + closes the
@@ -180,16 +175,13 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       :ok = SessionStreamer.subscribe(session_id)
       :ok = Session.send_message(agent_id(sess), {:say, "hi"})
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :turn_started} = started},
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started},
                      1_000
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :item_completed} = item},
+      assert_receive {:session_event, ^session_id, %Event{type: :item_completed} = item},
                      1_000
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :turn_completed} = completed},
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_completed} = completed},
                      1_000
 
       # session_id is non-nil (acceptance #4) and the turn_id is one stable value
@@ -215,12 +207,10 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       :ok = SessionStreamer.subscribe(session_id)
       :ok = Session.send_message(agent_id(sess), :boom)
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :turn_started} = started},
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started},
                      1_000
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :error} = error},
+      assert_receive {:session_event, ^session_id, %Event{type: :error} = error},
                      1_000
 
       assert error.tier == :durable
@@ -247,8 +237,7 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       # A successful durable append: offset 1.
       publish(session_id, :turn_started, :durable, %{prompt: "p"}, "t1")
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :turn_started, id: 1}},
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_started, id: 1}},
                      1_000
 
       # Kill the journal writer underneath the bridge (stands in for disk-full /
@@ -261,8 +250,7 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       # The durable event was NOT published with a fabricated id. Instead a
       # loud ephemeral :error signal came out, pinned to the unchanged last
       # durable offset.
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :error} = failure},
+      assert_receive {:session_event, ^session_id, %Event{type: :error} = failure},
                      1_000
 
       assert failure.tier == :ephemeral
@@ -277,8 +265,7 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       # on-disk offset, and takes a fresh non-colliding id (2).
       publish(session_id, :turn_completed, :durable, %{}, "t1")
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :turn_completed, id: 2}},
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_completed, id: 2}},
                      1_000
 
       GenServer.stop(bridge)
@@ -314,16 +301,13 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       :ok = SessionStreamer.subscribe(session_id)
       :ok = Session.send_message(agent_id(sess), {:say, "hi"})
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :turn_started} = started},
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_started} = started},
                      1_000
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :item_completed} = turn_item},
+      assert_receive {:session_event, ^session_id, %Event{type: :item_completed} = turn_item},
                      1_000
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :turn_completed}},
+      assert_receive {:session_event, ^session_id, %Event{type: :turn_completed}},
                      1_000
 
       assert turn_item.turn_id == started.turn_id
@@ -333,8 +317,7 @@ defmodule Raxol.Agent.KeystoneCloseTest do
       # finished turn's id.
       send(dispatcher(sess), {:subscription, :tick})
 
-      assert_receive {:session_event, ^session_id,
-                      %Event{type: :item_completed} = item},
+      assert_receive {:session_event, ^session_id, %Event{type: :item_completed} = item},
                      1_000
 
       assert is_nil(item.turn_id)
@@ -468,9 +451,7 @@ defmodule Raxol.Agent.KeystoneCloseTest do
   end
 
   defp publish(session_id, type, tier, payload, turn_id) do
-    EmitBus.publish(
-      EmitBus.build(session_id, type, tier, payload, turn_id: turn_id)
-    )
+    EmitBus.publish(EmitBus.build(session_id, type, tier, payload, turn_id: turn_id))
   end
 
   defp agent_id(sess) do

--- a/packages/raxol_agent/test/raxol/agent/policy/cache_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/policy/cache_test.exs
@@ -56,8 +56,8 @@ defmodule Raxol.Agent.Policy.CacheTest do
           table: "agent_cache"
         )
 
-      assert {Raxol.Agent.Cache.Postgrex,
-              %{conn: MyApp.Postgrex, table: "agent_cache"}} = policy.storage
+      assert {Raxol.Agent.Cache.Postgrex, %{conn: MyApp.Postgrex, table: "agent_cache"}} =
+               policy.storage
     end
 
     test "raises without :conn" do

--- a/packages/raxol_agent/test/raxol/agent/policy_applier_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/policy_applier_test.exs
@@ -247,13 +247,11 @@ defmodule Raxol.Agent.PolicyApplierTest do
     test "applied fires once per apply/3 call with the outcome tag" do
       PolicyApplier.apply([], fn _ -> {:ok, :ok_thing} end, nil)
 
-      assert_receive {:tel, [:raxol, :agent, :policy, :applied], _,
-                      %{outcome: :ok}}
+      assert_receive {:tel, [:raxol, :agent, :policy, :applied], _, %{outcome: :ok}}
 
       PolicyApplier.apply([], fn _ -> {:error, :bad} end, nil)
 
-      assert_receive {:tel, [:raxol, :agent, :policy, :applied], _,
-                      %{outcome: :error}}
+      assert_receive {:tel, [:raxol, :agent, :policy, :applied], _, %{outcome: :error}}
     end
 
     test "retry_attempt fires with attempt + reason + backoff_ms" do
@@ -282,11 +280,9 @@ defmodule Raxol.Agent.PolicyApplierTest do
       PolicyApplier.apply([policy], fn _ -> {:ok, :v} end, nil)
       PolicyApplier.apply([policy], fn _ -> {:ok, :v} end, nil)
 
-      assert_receive {:tel, [:raxol, :agent, :policy, :cache_miss], _,
-                      %{key: :only_key}}
+      assert_receive {:tel, [:raxol, :agent, :policy, :cache_miss], _, %{key: :only_key}}
 
-      assert_receive {:tel, [:raxol, :agent, :policy, :cache_hit], _,
-                      %{key: :only_key}}
+      assert_receive {:tel, [:raxol, :agent, :policy, :cache_hit], _, %{key: :only_key}}
     end
 
     test "timeout fires when fun overruns" do
@@ -301,8 +297,7 @@ defmodule Raxol.Agent.PolicyApplierTest do
         nil
       )
 
-      assert_receive {:tel, [:raxol, :agent, :policy, :timeout], _,
-                      %{wall_ms: 20}}
+      assert_receive {:tel, [:raxol, :agent, :policy, :timeout], _, %{wall_ms: 20}}
     end
   end
 end

--- a/packages/raxol_agent/test/raxol/agent/red/support/meta_journal_gen.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/meta_journal_gen.ex
@@ -111,9 +111,7 @@ defmodule Raxol.Agent.Red.MetaJournalGen do
       })
 
     trusted_meta =
-      rec(depth + 2, :meta, :extract, meta_payload(:extract, [depth + 1]),
-        trust: "trusted"
-      )
+      rec(depth + 2, :meta, :extract, meta_payload(:extract, [depth + 1]), trust: "trusted")
 
     records = [entry | chain] ++ [trusted_loop, trusted_meta]
 
@@ -156,7 +154,9 @@ defmodule Raxol.Agent.Red.MetaJournalGen do
           id,
           :loop,
           :tool_result,
-          %{name: "fetch", result: "r#{id}", refs: []}, trust: trust)
+          %{name: "fetch", result: "r#{id}", refs: []},
+          trust: trust
+        )
       end
 
     metas =
@@ -165,7 +165,9 @@ defmodule Raxol.Agent.Red.MetaJournalGen do
           id,
           :meta,
           :speculation,
-          meta_payload(:speculation, [id - 1, id - 2]), trust: trust)
+          meta_payload(:speculation, [id - 1, id - 2]),
+          trust: trust
+        )
       end
 
     %{
@@ -276,9 +278,7 @@ defmodule Raxol.Agent.Red.MetaJournalGen do
           List.replace_at(
             rs,
             -1,
-            rec(length(rs), :meta, :research, meta_payload(:research, [1]),
-              source: "probe_c5"
-            )
+            rec(length(rs), :meta, :research, meta_payload(:research, [1]), source: "probe_c5")
           )
     end)
   end
@@ -298,10 +298,8 @@ defmodule Raxol.Agent.Red.MetaJournalGen do
     _ = seed
 
     gens = [
-      {[1, 2], %{"kind" => "human", "id" => "u-42"},
-       %{kind: :human, id: "u-42"}},
-      {[3, 4], %{"kind" => "agent", "id" => "agent-7"},
-       %{kind: :agent, id: "agent-7"}},
+      {[1, 2], %{"kind" => "human", "id" => "u-42"}, %{kind: :human, id: "u-42"}},
+      {[3, 4], %{"kind" => "agent", "id" => "agent-7"}, %{kind: :agent, id: "agent-7"}},
       # Absent actor generation — stamped nil, expected system by rule.
       {[5, 6], nil, %{kind: :system}}
     ]

--- a/packages/raxol_agent/test/raxol/agent/red/support/meta_oracle.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/meta_oracle.ex
@@ -135,9 +135,7 @@ defmodule Raxol.Agent.Red.MetaOracle do
   def validate_no_scope_check(_), do: :ok
 
   @doc "N-U11.10 dead injector — speculation `:begin` refs hardcoded to length 1."
-  def validate_singular_refs(
-        %{family: :meta, type: :speculation, payload: payload} = event
-      ) do
+  def validate_singular_refs(%{family: :meta, type: :speculation, payload: payload} = event) do
     with :ok <- validate_correct(event) do
       case payload do
         %{phase: :begin, refs: refs} when length(refs) == 1 ->

--- a/packages/raxol_agent/test/raxol/agent/red/support/u10_compaction.ex
+++ b/packages/raxol_agent/test/raxol/agent/red/support/u10_compaction.ex
@@ -324,8 +324,7 @@ defmodule Raxol.Agent.Red.Support.U10Compaction do
 
       if count == 0 do
         raise ExUnit.AssertionError,
-          message:
-            "dead injector never fired: #{inspect(site)} (armed but silent = green lies)"
+          message: "dead injector never fired: #{inspect(site)} (armed but silent = green lies)"
       end
 
       :ok
@@ -411,8 +410,7 @@ defmodule Raxol.Agent.Red.Support.U10Compaction do
     defp select_latest_healthy(dir, records, [cp | rest], skipped) do
       case restore_from(dir, records, cp) do
         {:ok, model, _info} ->
-          {:ok, model,
-           %{selected_offset: cp["id"], skipped: Enum.reverse(skipped)}}
+          {:ok, model, %{selected_offset: cp["id"], skipped: Enum.reverse(skipped)}}
 
         {:error, reason} ->
           select_latest_healthy(dir, records, rest, [

--- a/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_hardening_test.exs
@@ -29,9 +29,7 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
   describe "taint fails CLOSED on unknown trust (§2.1 pt.1)" do
     test "(a) a record with provenance.trust \"poisoned\" decodes to :tainted, never :trusted" do
       poisoned =
-        Gen.rec(1, :meta, :extract, Gen.meta_payload(:extract, []),
-          trust: "poisoned"
-        )
+        Gen.rec(1, :meta, :extract, Gen.meta_payload(:extract, []), trust: "poisoned")
 
       assert {:ok, %Event{provenance: %{trust: :tainted}}} =
                Meta.decode(poisoned),
@@ -48,9 +46,7 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
         )
 
       dependent =
-        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]),
-          trust: "trusted"
-        )
+        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]), trust: "trusted")
 
       derived = Meta.derive_taint([entry, dependent])
 
@@ -71,9 +67,7 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
              "absent provenance must default to the frozen grandfather value"
 
       dependent =
-        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]),
-          trust: "trusted"
-        )
+        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]), trust: "trusted")
 
       # A meta event whose only ref is a grandfathered (absent-provenance) leaf
       # stays trusted — the grandfather path is NOT the same as fail-closed.
@@ -95,14 +89,10 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
         |> Map.put("provenance", "garbage")
 
       dep_a =
-        Gen.rec(3, :meta, :extract, Gen.meta_payload(:extract, [1]),
-          trust: "trusted"
-        )
+        Gen.rec(3, :meta, :extract, Gen.meta_payload(:extract, [1]), trust: "trusted")
 
       dep_b =
-        Gen.rec(4, :meta, :extract, Gen.meta_payload(:extract, [2]),
-          trust: "trusted"
-        )
+        Gen.rec(4, :meta, :extract, Gen.meta_payload(:extract, [2]), trust: "trusted")
 
       derived = Meta.derive_taint([leaf_trustless, leaf_nonmap, dep_a, dep_b])
 
@@ -131,9 +121,7 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
       }
 
       dep_c =
-        Gen.rec(6, :meta, :extract, Gen.meta_payload(:extract, [5]),
-          trust: "trusted"
-        )
+        Gen.rec(6, :meta, :extract, Gen.meta_payload(:extract, [5]), trust: "trusted")
 
       assert {:ok, %Event{provenance: %{source: :primary, trust: :trusted}}} =
                Meta.decode(absent)
@@ -390,19 +378,13 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
       # predicted a naive node-keyed memo would introduce. Computed fresh,
       # X -> A -> T is found and X is `:tainted`.
       t =
-        Gen.rec(1, :loop, :tool_result, %{name: "f", result: "r", refs: []},
-          trust: "tainted"
-        )
+        Gen.rec(1, :loop, :tool_result, %{name: "f", result: "r", refs: []}, trust: "tainted")
 
       a =
-        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [3, 1]),
-          trust: "tainted"
-        )
+        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [3, 1]), trust: "tainted")
 
       x =
-        Gen.rec(3, :meta, :extract, Gen.meta_payload(:extract, [2]),
-          trust: "tainted"
-        )
+        Gen.rec(3, :meta, :extract, Gen.meta_payload(:extract, [2]), trust: "tainted")
 
       derived = Meta.derive_taint([t, a, x])
 
@@ -418,14 +400,10 @@ defmodule Raxol.Agent.Red.U11HardeningTest do
       # reachable tainted leaf is reached via a simple path — pinned here so a
       # future change to the cycle arm is a deliberate decision, not drift.
       a =
-        Gen.rec(1, :meta, :extract, Gen.meta_payload(:extract, [2]),
-          trust: "trusted"
-        )
+        Gen.rec(1, :meta, :extract, Gen.meta_payload(:extract, [2]), trust: "trusted")
 
       b =
-        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]),
-          trust: "trusted"
-        )
+        Gen.rec(2, :meta, :extract, Gen.meta_payload(:extract, [1]), trust: "trusted")
 
       derived = Meta.derive_taint([a, b])
       assert derived[1] == :trusted

--- a/packages/raxol_agent/test/raxol/agent/red/u11_meta_controls_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_meta_controls_test.exs
@@ -87,9 +87,7 @@ defmodule Raxol.Agent.Red.U11MetaControlsTest do
          if disagreements == tainted and
               Enum.all?(tainted, &(correct[&1] == :tainted)),
             do: :caught,
-            else:
-              {:missed,
-               %{seed: seed, disagreements: disagreements, tainted: tainted}}
+            else: {:missed, %{seed: seed, disagreements: disagreements, tainted: tainted}}
        end},
       {:n_u11_4_scope_check_deleted,
        fn seed ->
@@ -128,16 +126,12 @@ defmodule Raxol.Agent.Red.U11MetaControlsTest do
 
          if promote_offsets != [] and laundered == promote_offsets,
            do: :caught,
-           else:
-             {:missed,
-              %{seed: seed, promotes: promote_offsets, laundered: laundered}}
+           else: {:missed, %{seed: seed, promotes: promote_offsets, laundered: laundered}}
        end},
       {:n_u11_6_strict_reader_seam,
        fn seed ->
          unknown =
-           Gen.rec(1, :meta, :from_the_future_v9, %{refs: []},
-             source: "probe_x"
-           )
+           Gen.rec(1, :meta, :from_the_future_v9, %{refs: []}, source: "probe_x")
 
          correct = Oracle.decode_correct(unknown)
          broken = Oracle.decode_strict(unknown)
@@ -183,9 +177,7 @@ defmodule Raxol.Agent.Red.U11MetaControlsTest do
 
          if reader_caught? and producer_caught?,
            do: :caught,
-           else:
-             {:missed,
-              %{seed: seed, reader: reader_caught?, producer: producer_caught?}}
+           else: {:missed, %{seed: seed, reader: reader_caught?, producer: producer_caught?}}
        end},
       {:n_u11_9_head_wins_precedence,
        fn seed ->

--- a/packages/raxol_agent/test/raxol/agent/red/u11_meta_family_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u11_meta_family_red_test.exs
@@ -162,9 +162,7 @@ defmodule Raxol.Agent.Red.U11MetaFamilyRedTest do
            seed: seed
          } do
       unknown =
-        Gen.rec(1, :meta, :from_the_future_v9, %{refs: [], note: "later"},
-          source: "probe_x"
-        )
+        Gen.rec(1, :meta, :from_the_future_v9, %{refs: [], note: "later"}, source: "probe_x")
 
       {[readback], _session} = seed_journal!(base, [unknown])
 

--- a/packages/raxol_agent/test/raxol/agent/red/u12_probe_runner_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u12_probe_runner_red_test.exs
@@ -90,8 +90,7 @@ defmodule Raxol.Agent.Red.U12ProbeRunnerRedTest do
     %{
       session_id: Keyword.get(opts, :session_id, "u12-red"),
       tip_offset: Keyword.get(opts, :tip_offset, 41),
-      prefix_ref:
-        Keyword.get(opts, :prefix_ref, {:captured, L.primary_prefix()}),
+      prefix_ref: Keyword.get(opts, :prefix_ref, {:captured, L.primary_prefix()}),
       taint: Keyword.get(opts, :taint, :trusted),
       budget_scope: Keyword.get(opts, :budget_scope, :session_then_run),
       read_set: Keyword.get(opts, :read_set, [])

--- a/packages/raxol_agent/test/raxol/agent/red/u21_evidence_done_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u21_evidence_done_red_test.exs
@@ -355,11 +355,7 @@ defmodule Raxol.Agent.Red.U21.Injector do
 
     @impl true
     def gate(_journal, turn_id, refs),
-      do:
-        {:ok,
-         Build.ev(9_999, :turn_completed, %{final: true, refs: refs},
-           turn_id: turn_id
-         )}
+      do: {:ok, Build.ev(9_999, :turn_completed, %{final: true, refs: refs}, turn_id: turn_id)}
   end
 
   # (b) checks existence + evidence-class but NOT ordering — must FAIL the stale-evidence red.
@@ -374,10 +370,7 @@ defmodule Raxol.Agent.Red.U21.Injector do
     def gate(journal, turn_id, refs) do
       Enum.reduce_while(
         refs,
-        {:ok,
-         Build.ev(9_999, :turn_completed, %{final: true, refs: refs},
-           turn_id: turn_id
-         )},
+        {:ok, Build.ev(9_999, :turn_completed, %{final: true, refs: refs}, turn_id: turn_id)},
         fn ref, acc ->
           case Build.resolve(journal, ref) do
             nil ->
@@ -407,10 +400,7 @@ defmodule Raxol.Agent.Red.U21.Injector do
 
       Enum.reduce_while(
         refs,
-        {:ok,
-         Build.ev(9_999, :turn_completed, %{final: true, refs: refs},
-           turn_id: turn_id
-         )},
+        {:ok, Build.ev(9_999, :turn_completed, %{final: true, refs: refs}, turn_id: turn_id)},
         fn ref, acc ->
           case Build.resolve(journal, ref) do
             nil ->
@@ -458,10 +448,7 @@ defmodule Raxol.Agent.Red.U21.Injector do
 
       Enum.reduce_while(
         refs,
-        {:ok,
-         Build.ev(9_999, :turn_completed, %{final: true, refs: refs},
-           turn_id: turn_id
-         )},
+        {:ok, Build.ev(9_999, :turn_completed, %{final: true, refs: refs}, turn_id: turn_id)},
         fn ref, acc ->
           case Build.resolve(journal, ref) do
             nil ->
@@ -501,26 +488,23 @@ defmodule Raxol.Agent.Red.U21.Contours do
 
     [
       # done with valid postdating evidence -> accepted
-      {:valid, [Build.turn_started(1), Build.mutation(2), Build.evidence(3)], t,
-       [3], :accept},
+      {:valid, [Build.turn_started(1), Build.mutation(2), Build.evidence(3)], t, [3], :accept},
       # done with NO refs -> evidence_required, no done event
-      {:evidence_required,
-       [Build.turn_started(1), Build.mutation(2), Build.evidence(3)], t, [],
+      {:evidence_required, [Build.turn_started(1), Build.mutation(2), Build.evidence(3)], t, [],
        {:reject, :evidence_required}},
       # evidence PREDATES a later mutation -> stale
-      {:stale, [Build.turn_started(1), Build.evidence(2), Build.mutation(3)], t,
-       [2], {:reject, {:stale_evidence, 2}}},
+      {:stale, [Build.turn_started(1), Build.evidence(2), Build.mutation(3)], t, [2],
+       {:reject, {:stale_evidence, 2}}},
       # ref points at an internal state_change -> not evidence-class
       {:not_evidence_state_change,
-       [Build.turn_started(1), Build.mutation(2), Build.state_change(3)], t,
-       [3], {:reject, {:not_evidence, 3}}},
+       [Build.turn_started(1), Build.mutation(2), Build.state_change(3)], t, [3],
+       {:reject, {:not_evidence, 3}}},
       # ref points at the agent's own message text -> not evidence-class
       {:not_evidence_self_report,
        [Build.turn_started(1), Build.mutation(2), Build.self_report(3)], t, [3],
        {:reject, {:not_evidence, 3}}},
       # ref names an offset that does not exist
-      {:missing_ref,
-       [Build.turn_started(1), Build.mutation(2), Build.evidence(3)], t, [99],
+      {:missing_ref, [Build.turn_started(1), Build.mutation(2), Build.evidence(3)], t, [99],
        {:reject, {:missing_ref, 99}}},
       # H2 — cross-turn evidence spoof: turn "t"'s last mutation is at offset
       # 2; a DIFFERENT turn ("other") starts afterward and journals its own
@@ -645,16 +629,12 @@ defmodule Raxol.Agent.Red.U21.Gen do
       # if it checks ordering/class but not ownership.
       own_evidence_offsets =
         journal
-        |> Enum.filter(
-          &(&1.payload[:item_type] == :tool_result and &1.turn_id == "t")
-        )
+        |> Enum.filter(&(&1.payload[:item_type] == :tool_result and &1.turn_id == "t"))
         |> Enum.map(& &1.id)
 
       foreign_evidence_offsets =
         journal
-        |> Enum.filter(
-          &(&1.payload[:item_type] == :tool_result and &1.turn_id != "t")
-        )
+        |> Enum.filter(&(&1.payload[:item_type] == :tool_result and &1.turn_id != "t"))
         |> Enum.map(& &1.id)
 
       refs_gen =
@@ -1194,10 +1174,8 @@ defmodule Raxol.Agent.Red.U21RealProducerRegressionTest do
 
     stream = [
       {:tool_use, %{name: "run_tests", id: "call-1", arguments: %{}}},
-      {:tool_result,
-       %{name: "run_tests", result: "tests: 12 passed, 0 failed"}},
-      {:tool_use,
-       %{name: "fs_write", id: "call-2", arguments: %{path: "lib/a.ex"}}},
+      {:tool_result, %{name: "run_tests", result: "tests: 12 passed, 0 failed"}},
+      {:tool_use, %{name: "fs_write", id: "call-2", arguments: %{path: "lib/a.ex"}}},
       {:tool_result, %{name: "fs_write", result: "wrote 42 bytes"}},
       {:done, %{content: "All fixed.", usage: %{}}}
     ]

--- a/packages/raxol_agent/test/raxol/agent/red/u7_spend_gate_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u7_spend_gate_red_test.exs
@@ -256,7 +256,13 @@ defmodule Raxol.Agent.Red.U7SpendGateControlsTest do
     probe = P.new_probe() |> P.arm(:call_on_refused)
     # Cap 0 ⇒ every reserve is refused.
     budget = P.new_budget(0)
-    ctx = %{emit: P.emit_fun(j), probe: probe, budget: budget, try_reserve: P.try_reserve_fun(budget)}
+
+    ctx = %{
+      emit: P.emit_fun(j),
+      probe: probe,
+      budget: budget,
+      try_reserve: P.try_reserve_fun(budget)
+    }
 
     assert {:error, {:reserve_refused, _}} =
              CallOnRefusedInjector.around(ctx, "c1", 100, P.call_fun(p, "c1", 100))
@@ -308,7 +314,13 @@ defmodule Raxol.Agent.Red.U7SpendGateControlsTest do
     p = P.new_provider()
     probe = P.new_probe() |> P.arm(:duplicate_reserve)
     budget = P.new_budget(1000)
-    ctx = %{emit: P.emit_fun(j), probe: probe, budget: budget, try_reserve: P.try_reserve_fun(budget)}
+
+    ctx = %{
+      emit: P.emit_fun(j),
+      probe: probe,
+      budget: budget,
+      try_reserve: P.try_reserve_fun(budget)
+    }
 
     assert {:ok, _} = DuplicateReserveInjector.around(ctx, "c1", 100, P.call_fun(p, "c1", 80))
 
@@ -326,7 +338,13 @@ defmodule Raxol.Agent.Red.U7SpendGateControlsTest do
     p = P.new_provider()
     probe = P.new_probe() |> P.arm(:double_settle)
     budget = P.new_budget(1000)
-    ctx = %{emit: P.emit_fun(j), probe: probe, budget: budget, try_reserve: P.try_reserve_fun(budget)}
+
+    ctx = %{
+      emit: P.emit_fun(j),
+      probe: probe,
+      budget: budget,
+      try_reserve: P.try_reserve_fun(budget)
+    }
 
     assert {:ok, _} = DoubleSettleInjector.around(ctx, "c1", 100, P.call_fun(p, "c1", 70))
 
@@ -389,7 +407,9 @@ defmodule Raxol.Agent.Red.U7SpendGateControlsTest do
     # Pin that the PEAK fix (not a raised cap) is what makes this pass: the
     # naive cumulative sum of every :reserve estimate WOULD have wrongly
     # rejected this well-formed, budget-respecting trace.
-    cumulative = recs |> Enum.filter(&(&1.kind == :reserve)) |> Enum.map(& &1.estimate) |> Enum.sum()
+    cumulative =
+      recs |> Enum.filter(&(&1.kind == :reserve)) |> Enum.map(& &1.estimate) |> Enum.sum()
+
     assert cumulative > cap
   end
 

--- a/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u8_blast_radius_red_test.exs
@@ -243,17 +243,13 @@ defmodule Raxol.Agent.Red.U8BlastRadiusControlsTest do
 
   # {site, injector, contour id, signature-predicate function name}
   @injector_table [
-    {:executes_while_pending, ExecutesWhilePending, :c1,
-     :sig_executed_while_locked},
+    {:executes_while_pending, ExecutesWhilePending, :c1, :sig_executed_while_locked},
     {:emits_meta_family, EmitsMetaFamily, :c2, :sig_not_loop_family},
     {:forgets_deny, ForgetsDeny, :c4, :sig_proceeded_after_deny},
-    {:accepts_forged_decision, AcceptsForgedDecision, :c7,
-     :sig_forged_accepted},
+    {:accepts_forged_decision, AcceptsForgedDecision, :c7, :sig_forged_accepted},
     {:in_memory_only, InMemoryOnly, :c6, :sig_rebuild_diverged},
-    {:reads_destructive_hint_c8, ReadsDestructiveHint, :c8,
-     :sig_predicate_wrong},
-    {:reads_destructive_hint_c9, ReadsDestructiveHint, :c9,
-     :sig_trusted_self_report},
+    {:reads_destructive_hint_c8, ReadsDestructiveHint, :c8, :sig_predicate_wrong},
+    {:reads_destructive_hint_c9, ReadsDestructiveHint, :c9, :sig_trusted_self_report},
     {:ignores_taint, IgnoresTaint, :c10, :sig_tainted_auto_proceeded},
     {:reads_stamped_trust, ReadsStampedTrust, :c10, :sig_mis_stamped_proceeded}
   ]

--- a/packages/raxol_agent/test/raxol/agent/red/u9_checkpoint_red_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/red/u9_checkpoint_red_test.exs
@@ -185,9 +185,7 @@ defmodule Raxol.Agent.Red.U9CheckpointRedTest do
 
       # Checkpoint captures the model as of the tip.
       assert {:ok, _cp_off} =
-               Checkpoint.write(j, CR.fold(CR.raw_records(dir)),
-                 reason: "manual"
-               )
+               Checkpoint.write(j, CR.fold(CR.raw_records(dir)), reason: "manual")
 
       # Mutate the conversation forward past the checkpoint.
       CR.append_all!(j, [

--- a/packages/raxol_agent/test/raxol/agent/schedule_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/schedule_test.exs
@@ -108,7 +108,8 @@ defmodule Raxol.Agent.ScheduleTest do
     test "a rare-but-valid date (Feb 29) lands on the next leap year" do
       {:ok, schedule} = Schedule.parse("0 0 29 2 *")
       # 2027 is not a leap year; the next Feb 29 is in 2028.
-      assert {:ok, ~U[2028-02-29 00:00:00Z]} = Schedule.next_fire(schedule, ~U[2026-03-01 00:00:00Z])
+      assert {:ok, ~U[2028-02-29 00:00:00Z]} =
+               Schedule.next_fire(schedule, ~U[2026-03-01 00:00:00Z])
     end
 
     test "rejects an out-of-range field" do

--- a/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/session_supervisor_test.exs
@@ -43,23 +43,17 @@ defmodule Raxol.Agent.Session.SupervisorTest do
     # App-level singletons: tolerate an already-running instance.
     ensure_registry(:duplicate, EmitBus.registry_name())
 
-    ensure_running(
-      {Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences}
-    )
+    ensure_running({Raxol.Core.UserPreferences, name: Raxol.Core.UserPreferences})
 
     # The lifecycle's own DynamicSupervisor (used by Lifecycle.start_link).
-    ensure_running(
-      {DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one}
-    )
+    ensure_running({DynamicSupervisor, name: Raxol.DynamicSupervisor, strategy: :one_for_one})
 
     # Per-test singletons owned by ExUnit (auto-stopped at test end): the agent
     # Registry, the DynSup the session trees run under, and the named
     # SessionStreamer the sink emits into.
     start_supervised!({Registry, keys: :unique, name: Raxol.Agent.Registry})
 
-    start_supervised!(
-      {DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one}
-    )
+    start_supervised!({DynamicSupervisor, name: Raxol.Agent.DynSup, strategy: :one_for_one})
 
     start_supervised!(Raxol.Agent.SessionStreamer)
 

--- a/packages/raxol_agent/test/raxol/agent/snapshot_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/snapshot_test.exs
@@ -373,8 +373,8 @@ defmodule Raxol.Agent.SnapshotTest do
       assert log =~ "persist:"
 
       assert_received {:telemetry_event,
-                        [:raxol, :agent, :snapshot, :persist_redacted_by_heuristic], %{count: 1},
-                        %{path: ["client_secret_version"]}}
+                       [:raxol, :agent, :snapshot, :persist_redacted_by_heuristic], %{count: 1},
+                       %{path: ["client_secret_version"]}}
     end
 
     # explicit redact still beats explicit persist — already proven by the

--- a/packages/raxol_agent/test/raxol/agent/stream/event_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/stream/event_test.exs
@@ -32,9 +32,7 @@ defmodule Raxol.Agent.Stream.EventTest do
 
     test "lifts tool_result" do
       assert %Event.ToolResult{name: "x", result: %{ok: true}} =
-               Event.from_tuple(
-                 {:tool_result, %{name: "x", result: %{ok: true}}}
-               )
+               Event.from_tuple({:tool_result, %{name: "x", result: %{ok: true}}})
     end
 
     test "lifts turn_complete with defaults" do

--- a/packages/raxol_agent/test/raxol/agent/thread_log/ets_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/thread_log/ets_test.exs
@@ -24,8 +24,7 @@ defmodule Raxol.Agent.ThreadLog.EtsTest do
       assert {:ok, %ThreadEvent{sequence: 0}} =
                Ets.append(config, "thr-1", :directive, %{step: 1})
 
-      assert {:ok,
-              %ThreadEvent{sequence: 0, kind: :directive, payload: %{step: 1}}} =
+      assert {:ok, %ThreadEvent{sequence: 0, kind: :directive, payload: %{step: 1}}} =
                Ets.latest(config, "thr-1")
     end
 

--- a/packages/raxol_agent/test/raxol/agent/thread_log_router_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/thread_log_router_test.exs
@@ -75,9 +75,7 @@ defmodule Raxol.Agent.ThreadLogRouterTest do
 
       attempts =
         retry_events
-        |> Enum.filter(
-          &(&1.payload.policy == :retry and &1.payload.decision == :attempt)
-        )
+        |> Enum.filter(&(&1.payload.policy == :retry and &1.payload.decision == :attempt))
         |> Enum.map(& &1.payload.attempt)
 
       assert 1 in attempts
@@ -110,8 +108,7 @@ defmodule Raxol.Agent.ThreadLogRouterTest do
       kinds =
         Enum.map(
           events,
-          &{&1.kind, get_in(&1.payload, [:policy]),
-           get_in(&1.payload, [:decision])}
+          &{&1.kind, get_in(&1.payload, [:policy]), get_in(&1.payload, [:decision])}
         )
 
       assert {:policy_result, :cache, :miss} in kinds

--- a/packages/raxol_agent/test/support/kill_lab.ex
+++ b/packages/raxol_agent/test/support/kill_lab.ex
@@ -102,9 +102,7 @@ defmodule Raxol.Agent.KillLab do
   @doc "True iff `ps` reports `pid` in a zombie (`Z*`) state."
   @spec zombie?(non_neg_integer()) :: boolean()
   def zombie?(pid) when is_integer(pid) do
-    case System.cmd("ps", ["-o", "stat=", "-p", Integer.to_string(pid)],
-           stderr_to_stdout: true
-         ) do
+    case System.cmd("ps", ["-o", "stat=", "-p", Integer.to_string(pid)], stderr_to_stdout: true) do
       {out, 0} -> out |> String.trim() |> String.starts_with?("Z")
       _ -> false
     end
@@ -258,9 +256,7 @@ defmodule Raxol.Agent.KillLab do
   end
 
   defp pgid_of(pid) do
-    case System.cmd("ps", ["-o", "pgid=", "-p", Integer.to_string(pid)],
-           stderr_to_stdout: true
-         ) do
+    case System.cmd("ps", ["-o", "pgid=", "-p", Integer.to_string(pid)], stderr_to_stdout: true) do
       {out, 0} -> out |> String.trim() |> parse_int()
       _ -> nil
     end

--- a/packages/raxol_agent/test/support/red_probe_runner_lab.ex
+++ b/packages/raxol_agent/test/support/red_probe_runner_lab.ex
@@ -236,9 +236,7 @@ defmodule Raxol.Agent.Red.ProbeRunnerLab do
 
         cond do
           openings != 1 or terminals != 1 ->
-            {:halt,
-             {:error,
-              {:lifecycle, run_id, %{openings: openings, terminals: terminals}}}}
+            {:halt, {:error, {:lifecycle, run_id, %{openings: openings, terminals: terminals}}}}
 
           post_terminal?(events, run_id) ->
             {:halt, {:error, {:post_terminal, run_id}}}
@@ -275,9 +273,7 @@ defmodule Raxol.Agent.Red.ProbeRunnerLab do
 
   defp terminal_seq(events, run_id) do
     events
-    |> Enum.filter(
-      &(&1.kind == :probe_run and &1.run_id == run_id and &1.status in @terminal)
-    )
+    |> Enum.filter(&(&1.kind == :probe_run and &1.run_id == run_id and &1.status in @terminal))
     |> Enum.map(& &1.seq)
     |> case do
       [] -> nil
@@ -330,15 +326,11 @@ defmodule Raxol.Agent.Red.ProbeRunnerLab do
   the primary's. On divergence, names the first divergent byte offset.
   """
   def prefix_identity(captures, primary) do
-    Enum.reduce_while(captures, :ok, fn %{run_id: run_id, prefix: prefix},
-                                        :ok ->
+    Enum.reduce_while(captures, :ok, fn %{run_id: run_id, prefix: prefix}, :ok ->
       if prefix == primary,
         do: {:cont, :ok},
         else:
-          {:halt,
-           {:error,
-            {:prefix_divergence, first_divergent_offset(primary, prefix),
-             run_id}}}
+          {:halt, {:error, {:prefix_divergence, first_divergent_offset(primary, prefix), run_id}}}
     end)
   end
 
@@ -380,8 +372,7 @@ defmodule Raxol.Agent.Red.ProbeRunnerLab do
           {:halt, {:error, {:bad_source, m.run_id, m.source}}}
 
         m.trust != expected_trust ->
-          {:halt,
-           {:error, {:trust_not_absorbed, m.run_id, m.trust, expected_trust}}}
+          {:halt, {:error, {:trust_not_absorbed, m.run_id, m.trust, expected_trust}}}
 
         true ->
           {:cont, :ok}
@@ -805,9 +796,7 @@ defmodule Raxol.Agent.Red.ProbeRunnerLab do
 
     @impl true
     def interpret(_response, context),
-      do:
-        {:ok,
-         [%{type: :extract, op: :add, item: "rule", refs: [context.tip_offset]}]}
+      do: {:ok, [%{type: :extract, op: :add, item: "rule", refs: [context.tip_offset]}]}
   end
 
   defmodule SlowMultiCallProbe do
@@ -851,9 +840,7 @@ defmodule Raxol.Agent.Red.ProbeRunnerLab do
 
     @impl true
     def interpret(_response, context),
-      do:
-        {:ok,
-         [%{type: :extract, op: :add, item: "rule", refs: [context.tip_offset]}]}
+      do: {:ok, [%{type: :extract, op: :add, item: "rule", refs: [context.tip_offset]}]}
   end
 
   defmodule LoopDraftProbe do
@@ -917,9 +904,7 @@ defmodule Raxol.Agent.Red.ProbeRunnerLab do
 
     @impl true
     def interpret(_response, context),
-      do:
-        {:ok,
-         [%{type: :gate_decision, trust: :trusted, refs: [context.tip_offset]}]}
+      do: {:ok, [%{type: :gate_decision, trust: :trusted, refs: [context.tip_offset]}]}
   end
 
   # ===========================================================================

--- a/packages/raxol_agent/test/support/red_spend_gate_probe.ex
+++ b/packages/raxol_agent/test/support/red_spend_gate_probe.ex
@@ -214,7 +214,9 @@ defmodule Raxol.Agent.Red.SpendGateProbe do
     {peak, _running} =
       records
       |> Enum.sort_by(& &1.seq)
-      |> Enum.reduce({0, 0}, fn record, {peak, running} -> fold_reserved(record, estimate_by_ref, peak, running) end)
+      |> Enum.reduce({0, 0}, fn record, {peak, running} ->
+        fold_reserved(record, estimate_by_ref, peak, running)
+      end)
 
     if peak <= cap, do: :ok, else: {:error, {:over_reserve, peak, cap}}
   end
@@ -224,7 +226,12 @@ defmodule Raxol.Agent.Red.SpendGateProbe do
     {max(peak, new_running), new_running}
   end
 
-  defp fold_reserved(%{kind: :settle, cost_ref: cost_ref, actual: actual}, estimate_by_ref, peak, running) do
+  defp fold_reserved(
+         %{kind: :settle, cost_ref: cost_ref, actual: actual},
+         estimate_by_ref,
+         peak,
+         running
+       ) do
     refund = Map.get(estimate_by_ref, cost_ref, actual) - actual
     new_running = running - refund
     {max(peak, new_running), new_running}

--- a/packages/raxol_core/lib/raxol/core/events/manager/event_manager_server.ex
+++ b/packages/raxol_core/lib/raxol/core/events/manager/event_manager_server.ex
@@ -99,8 +99,7 @@ defmodule Raxol.Core.Events.EventManager.EventManagerServer do
 
     GenServer.call(
       server,
-      {:register_handler_struct, event_type, handler_id, handler_struct,
-       priority}
+      {:register_handler_struct, event_type, handler_id, handler_struct, priority}
     )
   end
 
@@ -279,8 +278,7 @@ defmodule Raxol.Core.Events.EventManager.EventManagerServer do
 
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_call(
-        {:register_handler_struct, event_type, handler_id, handler_struct,
-         priority},
+        {:register_handler_struct, event_type, handler_id, handler_struct, priority},
         _from,
         state
       ) do
@@ -513,9 +511,7 @@ defmodule Raxol.Core.Events.EventManager.EventManagerServer do
       case handler do
         # Traditional module/function handler
         {module, function, _priority} when is_atom(module) and is_atom(function) ->
-          Log.debug(
-            "EventManager calling #{module}.#{function} with event: #{inspect(event)}"
-          )
+          Log.debug("EventManager calling #{module}.#{function} with event: #{inspect(event)}")
 
           execute_module_function_handler(event, module, function)
 
@@ -600,9 +596,7 @@ defmodule Raxol.Core.Events.EventManager.EventManagerServer do
         )
 
       {:error, reason} ->
-        Log.error(
-          "Event handler #{module}.#{function} failed: #{inspect(reason)}"
-        )
+        Log.error("Event handler #{module}.#{function} failed: #{inspect(reason)}")
     end
   end
 

--- a/packages/raxol_core/lib/raxol/core/keyboard_navigator/navigator_server.ex
+++ b/packages/raxol_core/lib/raxol/core/keyboard_navigator/navigator_server.ex
@@ -40,7 +40,6 @@ defmodule Raxol.Core.KeyboardNavigator.NavigatorServer do
 
   use Raxol.Core.Behaviours.BaseManager
 
-
   alias Raxol.Core.Events.EventManager, as: EventManager
   alias Raxol.Core.FocusManager
   alias Raxol.Core.NavigationUtils

--- a/packages/raxol_core/lib/raxol/core/preferences/persistence.ex
+++ b/packages/raxol_core/lib/raxol/core/preferences/persistence.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Core.Preferences.Persistence do
   Handles persistence (loading/saving) of user preferences to a file.
   """
 
-
   @default_filename "user_preferences.bin"
 
   @doc """

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/command_helper.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/command_helper.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Core.Runtime.Plugins.CommandHelper do
   Handles plugin command registration and dispatch for the Plugin Manager.
   """
 
-
   alias Raxol.Core.Runtime.Plugins.CommandRegistry
 
   @doc """

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/command_registry.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/command_registry.ex
@@ -6,7 +6,6 @@ defmodule Raxol.Core.Runtime.Plugins.CommandRegistry do
   `{name, {module, function, arity}, metadata}` tuples as values.
   """
 
-
   @type command_name :: String.t()
   @type command_handler :: (list(), map() -> term())
   @type command_metadata :: %{

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/discovery.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/discovery.ex
@@ -8,7 +8,6 @@ defmodule Raxol.Core.Runtime.Plugins.Discovery do
   - Handling plugin dependencies
   """
 
-
   alias Raxol.Core.Runtime.Plugins.{FileWatcher, Loader, StateManager}
 
   @doc """

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/event_filter.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/event_filter.ex
@@ -7,7 +7,6 @@ defmodule Raxol.Core.Runtime.Plugins.EventFilter do
   - Handling event halting
   """
 
-
   @doc """
   Filters an event through registered plugin filters.
   Returns the filtered event or :halt if the event should be stopped.

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/file_watcher.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/file_watcher.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Core.Runtime.Plugins.FileWatcher do
   Handles file watching and plugin reloading functionality.
   """
 
-
   @doc """
   Sets up file watching for plugin hot-reloading.
   """

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/lifecycle_helper.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/lifecycle_helper.ex
@@ -17,7 +17,6 @@ defmodule Raxol.Core.Runtime.Plugins.LifecycleHelper do
     PluginValidator
   }
 
-
   def init(opts) do
     {:ok, opts}
   end

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/lifecycle_manager.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/lifecycle_manager.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Core.Runtime.Plugins.LifecycleManager do
   Handles plugin lifecycle operations including loading, unloading, enabling, and disabling plugins.
   """
 
-
   @doc """
   Loads a plugin with the given configuration.
   """

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/loader.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/loader.ex
@@ -7,7 +7,6 @@ defmodule Raxol.Core.Runtime.Plugins.Loader do
 
   @behaviour Raxol.Core.Runtime.Plugins.LoaderBehaviour
 
-
   defstruct [
     :loaded_plugins,
     :plugin_configs,

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_error_handler.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_error_handler.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Core.Runtime.Plugins.PluginErrorHandler do
   Handles plugin error handling and logging.
   """
 
-
   @doc """
   Handles load errors for plugins.
   """

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_event_processor.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_event_processor.ex
@@ -36,7 +36,6 @@ defmodule Raxol.Core.Runtime.Plugins.PluginEventProcessor do
   A crashed plugin is skipped, and the event continues to the next plugin.
   """
 
-
   alias Raxol.Core.Runtime.Plugins.PluginSupervisor
 
   @doc """

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_reloader.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_reloader.ex
@@ -3,7 +3,6 @@ defmodule Raxol.Core.Runtime.Plugins.PluginReloader do
   Handles plugin reloading operations including reloading by ID and from disk.
   """
 
-
   @doc """
   Reloads a plugin by ID.
   """

--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/timer_manager.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/timer_manager.ex
@@ -6,7 +6,6 @@ defmodule Raxol.Core.Runtime.Plugins.TimerManager do
   timer handling across the plugin system.
   """
 
-
   alias Raxol.Core.Utils.TimerManager
 
   @doc """

--- a/packages/raxol_core/lib/raxol/core/user_preferences.ex
+++ b/packages/raxol_core/lib/raxol/core/user_preferences.ex
@@ -14,7 +14,6 @@ defmodule Raxol.Core.UserPreferences do
   # Terminal.Config.Defaults lives in main raxol; guarded with Code.ensure_loaded?
   @compile {:no_warn_undefined, Raxol.Terminal.Config.Defaults}
 
-
   alias Raxol.Core.Preferences.Persistence
   alias Raxol.Core.Utils.Debounce
 

--- a/packages/raxol_core/lib/raxol/core/utils/timer_utils.ex
+++ b/packages/raxol_core/lib/raxol/core/utils/timer_utils.ex
@@ -11,7 +11,6 @@ defmodule Raxol.Core.Utils.TimerUtils do
   This consolidates the 84+ timer patterns found across the codebase.
   """
 
-
   @type timer_ref :: reference() | nil
   @type timer_type :: :periodic | :delayed | :debounced
   @type timer_opts :: [

--- a/packages/raxol_core/test/raxol/core/animation/hint_test.exs
+++ b/packages/raxol_core/test/raxol/core/animation/hint_test.exs
@@ -50,12 +50,24 @@ defmodule Raxol.Core.Animation.HintTest do
 
     test "all easing families return cubic-bezier" do
       families = [
-        :ease_in_quart, :ease_out_quart, :ease_in_out_quart,
-        :ease_in_quint, :ease_out_quint, :ease_in_out_quint,
-        :ease_in_sine, :ease_out_sine, :ease_in_out_sine,
-        :ease_in_expo, :ease_out_expo, :ease_in_out_expo,
-        :ease_in_circ, :ease_out_circ, :ease_in_out_circ,
-        :ease_in_back, :ease_out_back, :ease_in_out_back
+        :ease_in_quart,
+        :ease_out_quart,
+        :ease_in_out_quart,
+        :ease_in_quint,
+        :ease_out_quint,
+        :ease_in_out_quint,
+        :ease_in_sine,
+        :ease_out_sine,
+        :ease_in_out_sine,
+        :ease_in_expo,
+        :ease_out_expo,
+        :ease_in_out_expo,
+        :ease_in_circ,
+        :ease_out_circ,
+        :ease_in_out_circ,
+        :ease_in_back,
+        :ease_out_back,
+        :ease_in_out_back
       ]
 
       for easing <- families do


### PR DESCRIPTION
`raxol_core` and `raxol_agent` were absent from the `package-tests` matrix in
`.github/workflows/ci-unified.yml`. Nothing in per-PR CI compiled them, ran
their suites, or format-checked them.

That is the wrong pair to leave ungated. `Raxol.Core.Boundary.Path` is the
centralized path-traversal confinement behind the agent's fs tools. Its 18
accept/reject conformance vectors live in
`packages/raxol_core/test/support/boundary_vectors/` and are copied verbatim
into `raxol_agent_client_protocol`, and the module's own moduledoc argues that
this is what makes drift "a red test, not a silent fork". It only worked
one-sidedly: the ACP copy is gated, the raxol_core copy was not. A one-sided
corpus is a fork with extra steps.

The same hole covers the process-group kill work now landing in raxol_core
(killing an escaped port's whole process group by negative pgid), where a wrong
target takes the VM or the host down and the tests would have shipped unrun.
`raxol_agent` is the package that consumes both, so both join together.

`docs/adr/0032-agent-filesystem-namespace.md` states this as a prerequisite
rather than a follow-up.

## What was red before

Nothing, in the sense that nothing ran. Establishing ground truth first:

| package | tests | result |
| --- | --- | --- |
| `raxol_core` | 896 | 896 passed |
| `raxol_agent` | 2426 (2407 tests + 19 properties), 35 excluded | 2425 passed, 1 failure |

`mix compile --warnings-as-errors` is clean in both.

The one `raxol_agent` failure was a wall-clock flake, not a defect: it passed
3/3 when re-run in isolation. Format was the real drift -- 70 files (18 in
raxol_core, 52 in raxol_agent) had never been checked by anything and did not
match the package formatter.

## What is red now

Nothing. Both suites pass; the 70-file reflow is a separate commit and is
whitespace/line-wrapping only.

### Honest caveat on the raxol_agent numbers

The dev box these runs happened on was carrying other agents' test suites at a
load average of 45-70 on 8 cores. At that load the full `raxol_agent` run
produces 5-13 failures, every one of them an `assert_receive ... 2000ms`
timeout, concentrated in `TurnRunnerTest` / `TurnRunnerJournalTest`. Both of
those files pass 4/4 when run alone at the *same* load, and the different
failing sets across runs confirm scheduling starvation rather than a defect.
`raxol_core` shows the same pattern at a smaller scale (0-2 sporadic timing
failures, a different test each run, all green in isolation).

So: I could not obtain a clean full-suite `raxol_agent` run on a quiet machine,
and the best evidence I have is 2425/2426 at moderate load with the single
failure reproducing green 3/3 isolated. Those 2000 ms budgets may prove tight
on a two-core GitHub runner. This PR is the first real data point; if
`raxol_agent` turns out flaky in CI the fix belongs in those timeouts, not in
reverting the gate.

## Changes beyond the matrix line

The matrix line stays on ONE line -- `test/raxol/formatter_delegation_test.exs`
parses it with `^\s*package: \[...\]` and a YAML block sequence parses as
absent.

- `.formatter.exs`: both packages added to `subdirectories`. The delegation
  test asserts every gated package is delegated, and delegation is what keeps a
  root-cwd `mix format` from rewrapping them at 80 columns.
- `timeout-minutes: 20 -> 35`. `raxol_agent`'s suite takes ~6 minutes on an
  8-core box on top of compiling main raxol and the termbox2 NIF; 20 left no
  headroom on a two-core runner.
- `--exclude skip_on_ci` added to the shared test step. That tag is the
  repo-wide "needs a real workstation" marker and the root suite already honours
  it whenever `SKIP_TERMBOX2_TESTS` is set (workflow-global here).
  `raxol_agent`'s `test_helper.exs` never wired it up, so its one tagged test (a
  `chmod 0500` write-failure fault in the journal Writer) was inert. Excluding
  it applies the existing convention rather than inventing a package-local one.
  No other gated package uses the tag. It drops exactly 1 test.
- The stale comment on the format job's journal-goldens step ("raxol_agent is a
  local gate, not a per-PR CI package") is corrected; the check stays because it
  is dependency-free and answers in seconds.

No apt step is needed for either package: `raxol_cli` already builds the same
raxol + raxol_agent + termbox2 NIF chain in this matrix without one. Neither
package has a `file_system` watcher, so nothing analogous to raxol_symphony's
`inotify-tools` applies.

## Interaction with #906

Open PR #906 replaces the explicit `.formatter.exs` `subdirectories` list with
the glob `packages/*`. If #906 lands first, the `.formatter.exs` hunk here
becomes redundant and will conflict -- drop this PR's hunk and keep #906's
glob. The workflow hunk is unaffected either way. Note the format sweep in
commit 1 is still required regardless: under `packages/*` the root format check
would go red on the same 70 files.

## Manual testing

- [x] `cd packages/raxol_core && MIX_ENV=test mix test` -- 896 passed
- [x] `cd packages/raxol_agent && MIX_ENV=test mix test` -- 2425/2426, the one
      failure green 3/3 in isolation
- [x] `mix compile --warnings-as-errors` clean in both packages
- [x] Exact CI test command (full `--exclude` list incl. `skip_on_ci`) run in
      both packages; `Excluding tags:` line confirms `skip_on_ci` drops 1 test
- [x] `mix format --check-formatted` clean from inside both packages
- [x] `mix format --check-formatted` clean at the repo root with both packages
      newly delegated
- [x] `MIX_ENV=test mix test test/raxol/formatter_delegation_test.exs` -- 3
      passed, so the matrix line parses and both packages are delegated
- [x] Workflow YAML parsed with `yaml_elixir`: matrix resolves to 10 packages,
      `timeout-minutes` to 35
- [x] `.githooks/pre-commit` run manually, exit 0
- [ ] The matrix cells actually go green on a two-core GitHub runner (this PR's
      own CI run is the check)
