### PR TITLE
Stop asserting that test teardown failed

### DIFF
--- a/packages/raxol_agent_client_protocol/test/agent_test.exs
+++ b/packages/raxol_agent_client_protocol/test/agent_test.exs
@@ -20,6 +20,7 @@ defmodule Raxol.AgentClientProtocol.AgentTest do
   alias Raxol.AgentClientProtocol.Error
   alias Raxol.AgentClientProtocol.Handler.Codegen
   alias Raxol.AgentClientProtocol.MethodTable
+  alias Raxol.AgentClientProtocol.Test.Teardown
   alias Raxol.AgentClientProtocol.Transport
 
   # -- fixtures -----------------------------------------------------------
@@ -262,10 +263,7 @@ defmodule Raxol.AgentClientProtocol.AgentTest do
           handler_arg: self()
         )
 
-      on_exit(fn ->
-        catch_exit(Supervisor.stop(agent_sup, :normal, 500))
-        catch_exit(Supervisor.stop(client_sup, :normal, 500))
-      end)
+      on_exit(fn -> Teardown.stop_all([agent_sup, client_sup]) end)
 
       client_conn = connection_pid(client_sup)
 

--- a/packages/raxol_agent_client_protocol/test/capabilities_test.exs
+++ b/packages/raxol_agent_client_protocol/test/capabilities_test.exs
@@ -17,6 +17,7 @@ defmodule Raxol.AgentClientProtocol.CapabilitiesTest do
 
   alias Raxol.AgentClientProtocol.Capabilities
   alias Raxol.AgentClientProtocol.MethodTable
+  alias Raxol.AgentClientProtocol.Test.Teardown
 
   alias Raxol.AgentClientProtocol.Schema.AgentTypes.AgentAuthCapabilities
   alias Raxol.AgentClientProtocol.Schema.AgentTypes.AgentCapabilities
@@ -371,10 +372,7 @@ defmodule Raxol.AgentClientProtocol.CapabilitiesTest do
       {:ok, client_sup} =
         Client.start_link(GateClient, transport: {Transport.Paired, client_handle})
 
-      on_exit(fn ->
-        catch_exit(Supervisor.stop(agent_sup, :normal, 500))
-        catch_exit(Supervisor.stop(client_sup, :normal, 500))
-      end)
+      on_exit(fn -> Teardown.stop_all([agent_sup, client_sup]) end)
 
       {:ok, agent_conn: connection_pid(agent_sup), client_conn: connection_pid(client_sup)}
     end

--- a/packages/raxol_agent_client_protocol/test/client_test.exs
+++ b/packages/raxol_agent_client_protocol/test/client_test.exs
@@ -10,6 +10,7 @@ defmodule Raxol.AgentClientProtocol.ClientTest do
   alias Raxol.AgentClientProtocol.Error
   alias Raxol.AgentClientProtocol.Handler.Codegen
   alias Raxol.AgentClientProtocol.MethodTable
+  alias Raxol.AgentClientProtocol.Test.Teardown
   alias Raxol.AgentClientProtocol.Transport
 
   # -- fixtures -----------------------------------------------------------
@@ -271,10 +272,7 @@ defmodule Raxol.AgentClientProtocol.ClientTest do
           handler_arg: self()
         )
 
-      on_exit(fn ->
-        catch_exit(Supervisor.stop(agent_sup, :normal, 500))
-        catch_exit(Supervisor.stop(client_sup, :normal, 500))
-      end)
+      on_exit(fn -> Teardown.stop_all([agent_sup, client_sup]) end)
 
       client_conn = connection_pid(client_sup)
 

--- a/packages/raxol_agent_client_protocol/test/support/teardown.ex
+++ b/packages/raxol_agent_client_protocol/test/support/teardown.ex
@@ -36,7 +36,9 @@ defmodule Raxol.AgentClientProtocol.Test.Teardown do
 
   # Long enough for an orderly shutdown of the two-process pairs in this
   # package, short enough that a wedged supervisor cannot hold the whole suite.
-  # Spent at most twice: once waiting on `Supervisor.stop`, once on the `:DOWN`.
+  # Spent at most twice PER supervisor: once waiting on `Supervisor.stop`, once
+  # on the `:DOWN`. `stop_all/1` therefore has a worst-case budget of
+  # `2 * @stop_timeout_ms * length(supervisors)`.
   @stop_timeout_ms 500
 
   @doc """
@@ -47,7 +49,7 @@ defmodule Raxol.AgentClientProtocol.Test.Teardown do
   leak shows up as an unrelated later test inheriting a process it never
   started.
   """
-  @spec stop_all([GenServer.server()]) :: :ok
+  @spec stop_all([pid() | atom()]) :: :ok
   def stop_all(supervisors) when is_list(supervisors) do
     Enum.each(supervisors, &stop_quietly/1)
   end
@@ -62,7 +64,7 @@ defmodule Raxol.AgentClientProtocol.Test.Teardown do
   A supervisor that does not go down inside the budget is killed, so this
   cannot hang a suite on a wedged `terminate/2`.
   """
-  @spec stop_quietly(GenServer.server()) :: :ok
+  @spec stop_quietly(pid() | atom()) :: :ok
   def stop_quietly(supervisor) do
     case GenServer.whereis(supervisor) do
       nil -> :ok

--- a/packages/raxol_agent_client_protocol/test/support/teardown.ex
+++ b/packages/raxol_agent_client_protocol/test/support/teardown.ex
@@ -49,7 +49,7 @@ defmodule Raxol.AgentClientProtocol.Test.Teardown do
   leak shows up as an unrelated later test inheriting a process it never
   started.
   """
-  @spec stop_all([pid() | atom()]) :: :ok
+  @spec stop_all([pid()]) :: :ok
   def stop_all(supervisors) when is_list(supervisors) do
     Enum.each(supervisors, &stop_quietly/1)
   end
@@ -57,27 +57,25 @@ defmodule Raxol.AgentClientProtocol.Test.Teardown do
   @doc """
   Stop one supervisor and wait for it to actually be gone.
 
-  Returns `:ok` whether it was alive, already dead, or never registered.
-  Nothing here asserts: a teardown helper has no verdict to give, and the one
-  it used to give was inverted.
+  Returns `:ok` whether the captured supervisor PID was alive or already dead.
+  It exits only if a process survives the final untrappable kill; returning
+  success without the promised postcondition would hide a cross-test leak.
 
   A supervisor that does not go down inside the budget is killed, so this
   cannot hang a suite on a wedged `terminate/2`.
   """
-  @spec stop_quietly(pid() | atom()) :: :ok
-  def stop_quietly(supervisor) do
-    case GenServer.whereis(supervisor) do
-      nil -> :ok
-      pid -> stop_and_await(pid)
-    end
-  end
+  @spec stop_quietly(pid()) :: :ok
+  def stop_quietly(supervisor) when is_pid(supervisor), do: stop_and_await(supervisor)
 
   defp stop_and_await(pid) do
-    # Monitored BEFORE the stop, so a supervisor that dies during the call is
-    # still reported rather than leaving nothing to wait on. Monitoring a pid
-    # that is already dead delivers `:DOWN` with `:noproc` immediately, which
-    # is the same answer by a shorter route.
-    ref = Process.monitor(pid)
+    # Snapshot and monitor the tree BEFORE the stop. Killing only a wedged
+    # supervisor is insufficient: its `:killed` exit reaches a trapping child
+    # as an ordinary, trappable signal, so that child can survive the parent.
+    monitors =
+      pid
+      |> supervision_tree()
+      |> Enum.uniq()
+      |> Map.new(&{&1, Process.monitor(&1)})
 
     try do
       Supervisor.stop(pid, :normal, @stop_timeout_ms)
@@ -87,7 +85,14 @@ defmodule Raxol.AgentClientProtocol.Test.Teardown do
       :exit, _reason -> :ok
     end
 
-    await_down(pid, ref)
+    monitors
+    |> Map.keys()
+    |> Enum.reverse()
+    |> Enum.each(&kill_if_alive/1)
+
+    Enum.each(monitors, fn {monitored_pid, ref} ->
+      await_down(monitored_pid, ref)
+    end)
   end
 
   defp await_down(pid, ref) do
@@ -96,10 +101,29 @@ defmodule Raxol.AgentClientProtocol.Test.Teardown do
     after
       @stop_timeout_ms ->
         Process.demonitor(ref, [:flush])
-        # `:kill` rather than a trappable reason: the only way to be here is a
-        # supervisor that already declined an orderly stop.
-        Process.exit(pid, :kill)
-        :ok
+        exit({:teardown_process_survived_kill, pid})
     end
+  end
+
+  defp supervision_tree(pid) do
+    children =
+      try do
+        Supervisor.which_children(pid)
+      catch
+        :exit, _reason -> []
+      end
+
+    descendants =
+      Enum.flat_map(children, fn
+        {_id, child, :supervisor, _modules} when is_pid(child) -> supervision_tree(child)
+        {_id, child, _type, _modules} when is_pid(child) -> [child]
+        _other -> []
+      end)
+
+    [pid | descendants]
+  end
+
+  defp kill_if_alive(pid) do
+    if Process.alive?(pid), do: Process.exit(pid, :kill)
   end
 end

--- a/packages/raxol_agent_client_protocol/test/support/teardown.ex
+++ b/packages/raxol_agent_client_protocol/test/support/teardown.ex
@@ -1,0 +1,103 @@
+defmodule Raxol.AgentClientProtocol.Test.Teardown do
+  @moduledoc """
+  Stopping a supervisor from `on_exit` without asserting anything about
+  whether it was still alive.
+
+  Every end-to-end test in this package builds a `Transport.Paired` pair and
+  starts an agent and a client supervisor with `start_link/2`, which links them
+  to the TEST process. `on_exit` runs in `ExUnit.OnExitHandler`, a different
+  process, after the test process is already gone -- so the link has usually,
+  but not always, taken both supervisors down before the callback runs.
+
+  That "usually" is the whole problem. `catch_exit/1` is an ASSERTION: it fails
+  the test when the expression returns normally. Written as
+  `catch_exit(Supervisor.stop(sup, :normal, 500))` it therefore passed only in
+  the race where the supervisor was ALREADY DEAD (`Supervisor.stop` exits, and
+  the exit is caught) and failed in the race where the teardown WORKED
+  (`Supervisor.stop` returns `:ok`, and there is no exit to catch). The test
+  asserted that its own cleanup had failed.
+
+  It surfaced as an unrelated red X on other PRs, which is the expensive shape:
+  reported against the test that owns the supervisor, in a package the PR never
+  touched, at a line inside a callback rather than in the body.
+
+  ## Why a monitor rather than a list of tolerable exit reasons
+
+  There is no small set of reasons to enumerate. A supervisor caught mid-
+  shutdown answers with a NESTED exit -- `GenServer.stop` wrapping
+  `:sys.terminate` wrapping `shutdown` -- and which layer you get depends on
+  how far along the link-driven shutdown already was. Matching on that is
+  matching on a race.
+
+  So the exit is discarded and the monitor is the verdict instead. The
+  postcondition a teardown actually wants is "this process is gone", which a
+  `:DOWN` states directly and a return value only implies.
+  """
+
+  # Long enough for an orderly shutdown of the two-process pairs in this
+  # package, short enough that a wedged supervisor cannot hold the whole suite.
+  # Spent at most twice: once waiting on `Supervisor.stop`, once on the `:DOWN`.
+  @stop_timeout_ms 500
+
+  @doc """
+  Stop each supervisor in turn, treating an already-dead one as success.
+
+  Every entry is visited even if an earlier one was already gone: a helper that
+  gave up partway would leak the supervisors after the first dead one, and that
+  leak shows up as an unrelated later test inheriting a process it never
+  started.
+  """
+  @spec stop_all([GenServer.server()]) :: :ok
+  def stop_all(supervisors) when is_list(supervisors) do
+    Enum.each(supervisors, &stop_quietly/1)
+  end
+
+  @doc """
+  Stop one supervisor and wait for it to actually be gone.
+
+  Returns `:ok` whether it was alive, already dead, or never registered.
+  Nothing here asserts: a teardown helper has no verdict to give, and the one
+  it used to give was inverted.
+
+  A supervisor that does not go down inside the budget is killed, so this
+  cannot hang a suite on a wedged `terminate/2`.
+  """
+  @spec stop_quietly(GenServer.server()) :: :ok
+  def stop_quietly(supervisor) do
+    case GenServer.whereis(supervisor) do
+      nil -> :ok
+      pid -> stop_and_await(pid)
+    end
+  end
+
+  defp stop_and_await(pid) do
+    # Monitored BEFORE the stop, so a supervisor that dies during the call is
+    # still reported rather than leaving nothing to wait on. Monitoring a pid
+    # that is already dead delivers `:DOWN` with `:noproc` immediately, which
+    # is the same answer by a shorter route.
+    ref = Process.monitor(pid)
+
+    try do
+      Supervisor.stop(pid, :normal, @stop_timeout_ms)
+    catch
+      # Discarded on purpose. This is not a swallowed error: the `:DOWN` below
+      # is the check, and it is a stronger one than this return value.
+      :exit, _reason -> :ok
+    end
+
+    await_down(pid, ref)
+  end
+
+  defp await_down(pid, ref) do
+    receive do
+      {:DOWN, ^ref, :process, ^pid, _reason} -> :ok
+    after
+      @stop_timeout_ms ->
+        Process.demonitor(ref, [:flush])
+        # `:kill` rather than a trappable reason: the only way to be here is a
+        # supervisor that already declined an orderly stop.
+        Process.exit(pid, :kill)
+        :ok
+    end
+  end
+end

--- a/packages/raxol_agent_client_protocol/test/teardown_test.exs
+++ b/packages/raxol_agent_client_protocol/test/teardown_test.exs
@@ -46,10 +46,6 @@ defmodule Raxol.AgentClientProtocol.TeardownTest do
       assert Teardown.stop_quietly(sup) == :ok
     end
 
-    test "returns :ok for a name that was never registered" do
-      assert Teardown.stop_quietly(:no_such_supervisor_registered) == :ok
-    end
-
     # The reason this waits on a monitor instead of enumerating exit reasons.
     # A supervisor whose child blocks in `terminate/2` makes `Supervisor.stop`
     # exit with a NESTED reason (`GenServer.stop` around `:sys.terminate`
@@ -57,9 +53,12 @@ defmodule Raxol.AgentClientProtocol.TeardownTest do
     # shutdown had already got. The helper must be gone-or-killed either way.
     test "kills a supervisor that will not shut down inside the budget" do
       sup = start_sup([{__MODULE__.Wedged, []}])
+      [{_id, child, :worker, _modules}] = Supervisor.which_children(sup)
+      on_exit(fn -> Process.exit(child, :kill) end)
 
       assert Teardown.stop_quietly(sup) == :ok
       refute Process.alive?(sup)
+      refute Process.alive?(child)
     end
   end
 

--- a/packages/raxol_agent_client_protocol/test/teardown_test.exs
+++ b/packages/raxol_agent_client_protocol/test/teardown_test.exs
@@ -1,0 +1,102 @@
+# The teardown helper the end-to-end tests hang their `on_exit` on. It gets its
+# own tests because the thing it replaced was an inverted assertion that passed
+# only in the race where cleanup had FAILED, and the way that surfaced -- a red
+# X on an unrelated PR, reported at a line inside a callback -- is expensive
+# enough to be worth pinning both directions of.
+defmodule Raxol.AgentClientProtocol.TeardownTest do
+  use ExUnit.Case, async: true
+
+  alias Raxol.AgentClientProtocol.Test.Teardown
+
+  # Unlinked, because these supervisors are the SUBJECT. Left linked, the test
+  # process would take them down on the way out and every assertion below would
+  # pass on the link rather than on the helper. `on_exit` reaps whatever a
+  # failing test leaves behind, since nothing else now will.
+  defp start_sup(children \\ []) do
+    {:ok, sup} = Supervisor.start_link(children, strategy: :one_for_one)
+    Process.unlink(sup)
+    on_exit(fn -> Process.exit(sup, :kill) end)
+    sup
+  end
+
+  defp await_death(pid) do
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _}, 1_000
+  end
+
+  describe "stop_quietly/1" do
+    # The case the old `catch_exit(Supervisor.stop(...))` FAILED on: cleanup
+    # worked, `Supervisor.stop` returned `:ok`, there was no exit to catch, and
+    # ExUnit reported "Expected to catch exit, got nothing".
+    test "returns :ok for a supervisor that is still alive" do
+      sup = start_sup()
+
+      assert Teardown.stop_quietly(sup) == :ok
+      refute Process.alive?(sup)
+    end
+
+    # The case it passed on, and the reason the inversion went unnoticed: the
+    # supervisors are linked to the test process, so by the time `on_exit` runs
+    # they are usually already gone.
+    test "returns :ok for a supervisor that is already dead" do
+      sup = start_sup()
+      Supervisor.stop(sup, :normal, 500)
+      await_death(sup)
+
+      assert Teardown.stop_quietly(sup) == :ok
+    end
+
+    test "returns :ok for a name that was never registered" do
+      assert Teardown.stop_quietly(:no_such_supervisor_registered) == :ok
+    end
+
+    # The reason this waits on a monitor instead of enumerating exit reasons.
+    # A supervisor whose child blocks in `terminate/2` makes `Supervisor.stop`
+    # exit with a NESTED reason (`GenServer.stop` around `:sys.terminate`
+    # around `shutdown`), and which layer arrives depends on how far the
+    # shutdown had already got. The helper must be gone-or-killed either way.
+    test "kills a supervisor that will not shut down inside the budget" do
+      sup = start_sup([{__MODULE__.Wedged, []}])
+
+      assert Teardown.stop_quietly(sup) == :ok
+      refute Process.alive?(sup)
+    end
+  end
+
+  describe "stop_all/1" do
+    test "stops every supervisor and does not give up at the first dead one" do
+      alive = start_sup()
+      dead = start_sup()
+      Supervisor.stop(dead, :normal, 500)
+      await_death(dead)
+
+      # Dead one FIRST: an implementation that let the exit escape would never
+      # reach the live one, and that leak only shows up later, as an unrelated
+      # test inheriting a supervisor it never started.
+      assert Teardown.stop_all([dead, alive]) == :ok
+      refute Process.alive?(alive)
+    end
+
+    test "accepts an empty list" do
+      assert Teardown.stop_all([]) == :ok
+    end
+  end
+
+  # Traps exits and never finishes terminating, so its supervisor cannot honour
+  # an orderly stop. `:infinity` shutdown means the supervisor waits on it.
+  defmodule Wedged do
+    @moduledoc false
+    use GenServer, shutdown: :infinity
+
+    def start_link(_), do: GenServer.start_link(__MODULE__, :ok)
+
+    @impl GenServer
+    def init(:ok) do
+      Process.flag(:trap_exit, true)
+      {:ok, :ok}
+    end
+
+    @impl GenServer
+    def terminate(_reason, _state), do: Process.sleep(:infinity)
+  end
+end


### PR DESCRIPTION
`catch_exit/1` is an assertion, not a rescue: it fails the test when the
expression returns normally. Three end-to-end tests wrote their cleanup as

```elixir
on_exit(fn ->
  catch_exit(Supervisor.stop(agent_sup, :normal, 500))
  catch_exit(Supervisor.stop(client_sup, :normal, 500))
end)
```

so each one passed only in the race where the supervisor was ALREADY DEAD
(`Supervisor.stop` exits, the exit is caught) and failed in the race where the
teardown WORKED (`Supervisor.stop` returns `:ok`, nothing to catch). The test
asserted that its own cleanup had failed.

## Why it sat green

`start_link/2` links both supervisors to the TEST process, and `on_exit` runs in
`ExUnit.OnExitHandler` after that process is gone. So the link has usually
already taken them down. Usually.

It shows up as an unrelated red X on other PRs -- seen on #914, in a package
that PR never touches -- reported at a line inside a callback rather than in a
test body, which is about the most expensive place for a failure to appear.

Sites: `agent_test.exs:266`, `client_test.exs:275`, `capabilities_test.exs:375`.

## Why a monitor and not a list of tolerable exit reasons

My first attempt enumerated `:noproc | :normal | :shutdown | :timeout` and still
failed, which is the useful part. A supervisor caught MID-shutdown answers with
a nested exit:

```
exited in: GenServer.stop(#PID<0.264.0>, :normal, 500)
    ** (EXIT) exited in: :sys.terminate(#PID<0.264.0>, :normal, 500)
        ** (EXIT) shutdown
```

Which layer arrives depends on how far the link-driven shutdown had got, so
matching on the reason is matching on the same race that caused the bug.

`Test.Teardown` discards the exit and waits on a monitor instead. That is not a
swallowed error: the `:DOWN` is a stronger check than the return value, and it
states the postcondition a teardown actually wants -- this process is gone. A
supervisor that will not go down inside the budget is killed, so it cannot hang
a suite on a wedged `terminate/2`.

## Testing

`test/teardown_test.exs` pins both directions, including the case the old form
failed on (alive supervisor, clean stop) and the wedged-`terminate/2` kill path.

- the four affected files: 68 tests, 0 failures across seeds 1, 7, 42, 99, 1234
  under Elixir 1.20.2 / OTP 29 (the CI pin)
- `mix format --check-formatted` clean under 1.20.2

The full package suite is nondeterministic on this machine independent of this
change -- same seed, unmodified master, four runs of
`session_test.exs ctx_test.exs connection_test.exs` gave 97, 93, 96 and 98 of 98.
That is #909, not this. None of those files are touched here.

## Manual testing

- [ ] Re-run #914 after this lands; `Package Tests (raxol_agent_client_protocol)` goes green
