### PR TITLE
Stop rejection-sampling a 15-key space for 8 keys

### DIFF
--- a/packages/raxol_earn/test/raxol/earn/xochi/solver_agent_property_test.exs
+++ b/packages/raxol_earn/test/raxol/earn/xochi/solver_agent_property_test.exs
@@ -118,7 +118,31 @@ defmodule Raxol.Earn.Xochi.SolverAgentPropertyTest do
     end
   end
 
+  # Built by collapsing a plain list into a map, NOT by `map_of/3`.
+  #
+  # `map_of/3` gets its distinct keys from `uniq_list_of`, which is rejection
+  # sampling: it draws, discards duplicates, and raises
+  # `StreamData.TooManyDuplicatesError` after 10 consecutive collisions. That
+  # cannot work against this key space. `job_key_gen/0` spans `1..3` chains and
+  # `1..5` jobs, which is FIFTEEN keys total, and `max_length: 8` asks for up to
+  # eight of them -- so once seven are drawn, better than half of every
+  # subsequent draw is a duplicate and ten in a row is routine. It failed in CI
+  # with exactly that shape: seven keys generated, one left to find.
+  #
+  # Widening the key space would fix the sampling and gut the property. The
+  # space is small ON PURPOSE: `key` is drawn independently, and the invariant
+  # under test (a funded key settles its own session and no other) is only
+  # exercised when `key` actually collides with something in `sessions`. Make
+  # keys unlikely to collide and the property still passes, having tested
+  # nothing.
+  #
+  # So the collisions stay and the rejection goes. `Map.new/1` keeps the last
+  # value for a repeated key, which is the same distinct-key map `map_of/3` was
+  # after, reached by construction instead of by retrying. The map may hold
+  # fewer than eight entries; it always used to as well.
   defp sessions_gen do
-    map_of(job_key_gen(), session_gen(), max_length: 8)
+    gen all(pairs <- list_of({job_key_gen(), session_gen()}, max_length: 8)) do
+      Map.new(pairs)
+    end
   end
 end


### PR DESCRIPTION
`Package Tests (raxol_earn)` failed on #905 -- a PR that touches only
`raxol_agent` -- with:

```
1) property the target for a key ignores every other session in flight
   (Raxol.Earn.Xochi.SolverAgentPropertyTest)
   ** (StreamData.TooManyDuplicatesError) too many (10) non-unique elements were
   generated consecutively. There were still 1 elements left to generate, while
   the generated elements were:
   MapSet.new([{1, "1"}, {1, "2"}, {1, "3"}, {2, "4"}, {3, "2"}, {3, "3"}, {3, "4"}])
```

## The arithmetic

`sessions_gen/0` was `map_of(job_key_gen(), session_gen(), max_length: 8)`.
`map_of/3` gets distinct keys from `uniq_list_of`, which is rejection sampling:
draw, discard duplicates, raise after 10 consecutive collisions.

`job_key_gen/0` spans `integer(1..3)` chains and `integer(1..5)` jobs. That is
**15 keys**, and `max_length: 8` asks for up to eight of them. Once seven are
drawn, 7/15 of every subsequent draw is a duplicate, so ten in a row is ordinary
-- and the failing message shows exactly that: seven keys generated, one left to
find.

Two `sessions_gen()` draws in the failing property and 100 iterations each make
this a small per-run probability that lands on whichever PR happens to draw it.

## Why not just widen the key space

It would fix the sampling and gut the property.

The space is small **on purpose**. `key` is drawn independently of `sessions`,
and the invariant under test -- a funded key settles its own session and never
another -- is only exercised when `key` actually collides with something in
`sessions`. Widen the keys and collisions get rare, the `{:ok, ...}` branch stops
being reached, and the property passes having tested nothing. That is a worse
outcome than the flake.

## What this does

Keeps the collisions, removes the rejection. A plain `list_of` collapsed through
`Map.new/1` produces the same distinct-key map by construction instead of by
retrying:

```elixir
gen all(pairs <- list_of({job_key_gen(), session_gen()}, max_length: 8)) do
  Map.new(pairs)
end
```

`Map.new/1` keeps the last value for a repeated key, which is what `map_of/3`
was after. The failure mode is now unreachable rather than rare. Maps with fewer
than eight entries were always possible and still are.

## Testing

- `packages/raxol_earn`: 952 passed (9 properties, 943 tests), 31 excluded
- the property file across seeds 1-6: 5 passed each

Seed sweeps are not the argument here -- the old generator also passed those six,
which is what makes it a flake. The argument is that `uniq_list_of` is no longer
in the path.
