### PR TITLE
Close package formatter gate gaps

### DIFF
--- a/scripts/check_formatter_loaders.exs
+++ b/scripts/check_formatter_loaders.exs
@@ -1,0 +1,40 @@
+[path] = System.argv()
+
+try do
+  {opts, _bindings} = Code.eval_file(path)
+  import_deps = Keyword.get(opts, :import_deps, [])
+  plugins = Keyword.get(opts, :plugins, [])
+
+  cond do
+    import_deps != [] ->
+      IO.puts(
+        :stderr,
+        "sets import_deps: #{inspect(import_deps)}, which makes mix format load those deps. " <>
+          "This check does not fetch them. Either drop it, or move this package into the " <>
+          "package-tests matrix where deps are available."
+      )
+
+      System.halt(1)
+
+    plugins != [] ->
+      IO.puts(
+        :stderr,
+        "sets plugins: #{inspect(plugins)}, which makes mix format load compiled plugin " <>
+          "modules. This check does not fetch or compile them. Drop the plugins, or move " <>
+          "this package into the package-tests matrix where deps are available."
+      )
+
+      System.halt(1)
+
+    true ->
+      :ok
+  end
+rescue
+  error ->
+    IO.puts(
+      :stderr,
+      "has an unreadable .formatter.exs: #{Exception.message(error)}"
+    )
+
+    System.halt(1)
+end

--- a/scripts/check_package_formatting.sh
+++ b/scripts/check_package_formatting.sh
@@ -25,22 +25,12 @@ err() {
   printf '::error::%s\n' "$1" >&2
 }
 
-# The deps a package's formatter config would make `mix format` LOAD.
-#
-# Evaluated rather than grepped. `import_deps: []` and `import_deps: [:phoenix]`
-# differ by one character and a multi-line list defeats a line-based match
-# entirely, so a regex here is a gate that reports clean for the shape it exists
-# to catch. A .formatter.exs is a literal term; evaluating it is what `mix
-# format` itself does.
-formatter_loaders() {
-  elixir -e '
-    [path] = System.argv()
-    {opts, _bindings} = Code.eval_file(path)
-    import_deps = opts |> Keyword.get(:import_deps, []) |> Enum.join(", ")
-    plugins = opts |> Keyword.get(:plugins, []) |> Enum.map_join(", ", &inspect/1)
-    IO.puts(import_deps)
-    IO.write(plugins)
-  ' "$1"
+# Evaluate the formatter config in a child process, as `mix format` does. The
+# child validates loader options itself and communicates only through its exit
+# status and stderr. Formatter files are executable Elixir and may write to
+# stdout, so stdout cannot safely carry a line-oriented result protocol.
+formatter_loader_error() {
+  elixir scripts/check_formatter_loaders.exs "$1" >/dev/null
 }
 
 shopt -s nullglob
@@ -65,21 +55,11 @@ for dir in packages/*/; do
     continue
   fi
 
-  # This script's cheapness is the reason it is not in `package-tests`, and
-  # `import_deps:` is the one option that would cost it: the formatter loads the
-  # named deps, and nothing here runs `mix deps.get` inside a package. Caught by
-  # name so the failure does not arrive as an unrelated "could not find dep".
-  loaders="$(formatter_loaders "$dir/.formatter.exs")"
-  deps="$(printf '%s\n' "$loaders" | sed -n '1p')"
-  plugins="$(printf '%s\n' "$loaders" | sed -n '2p')"
-  if [[ -n "$deps" ]]; then
-    err "$pkg sets import_deps: [$deps], which makes mix format load those deps. This check does not fetch them. Either drop it, or move this package into the package-tests matrix where deps are available."
-    failed=1
-    continue
-  fi
-
-  if [[ -n "$plugins" ]]; then
-    err "$pkg sets plugins: [$plugins], which makes mix format load compiled plugin modules. This check does not fetch or compile them. Drop the plugins, or move this package into the package-tests matrix where deps are available."
+  # This script's cheapness is the reason it is not in `package-tests`.
+  # `import_deps:` and `plugins:` both make the formatter load compiled code,
+  # while nothing here fetches or compiles package dependencies.
+  if ! loader_error="$(formatter_loader_error "$dir/.formatter.exs" 2>&1)"; then
+    err "$pkg $loader_error"
     failed=1
     continue
   fi

--- a/scripts/check_package_formatting.sh
+++ b/scripts/check_package_formatting.sh
@@ -32,13 +32,19 @@ err() {
 # entirely, so a regex here is a gate that reports clean for the shape it exists
 # to catch. A .formatter.exs is a literal term; evaluating it is what `mix
 # format` itself does.
-import_deps_of() {
+formatter_loaders() {
   elixir -e '
     [path] = System.argv()
     {opts, _bindings} = Code.eval_file(path)
-    opts |> Keyword.get(:import_deps, []) |> Enum.join(", ") |> IO.write()
+    import_deps = opts |> Keyword.get(:import_deps, []) |> Enum.join(", ")
+    plugins = opts |> Keyword.get(:plugins, []) |> Enum.map_join(", ", &inspect/1)
+    IO.puts(import_deps)
+    IO.write(plugins)
   ' "$1"
 }
+
+shopt -s nullglob
+package_count=0
 
 for dir in packages/*/; do
   pkg="$(basename "$dir")"
@@ -51,6 +57,8 @@ for dir in packages/*/; do
     continue
   fi
 
+  package_count=$((package_count + 1))
+
   if [[ ! -f "$dir/.formatter.exs" ]]; then
     err "$pkg has no .formatter.exs, so the root glob formats it at 80 columns while its own gate expects 98. Add one (copy any sibling package's)."
     failed=1
@@ -61,9 +69,17 @@ for dir in packages/*/; do
   # `import_deps:` is the one option that would cost it: the formatter loads the
   # named deps, and nothing here runs `mix deps.get` inside a package. Caught by
   # name so the failure does not arrive as an unrelated "could not find dep".
-  deps="$(import_deps_of "$dir/.formatter.exs")"
+  loaders="$(formatter_loaders "$dir/.formatter.exs")"
+  deps="$(printf '%s\n' "$loaders" | sed -n '1p')"
+  plugins="$(printf '%s\n' "$loaders" | sed -n '2p')"
   if [[ -n "$deps" ]]; then
     err "$pkg sets import_deps: [$deps], which makes mix format load those deps. This check does not fetch them. Either drop it, or move this package into the package-tests matrix where deps are available."
+    failed=1
+    continue
+  fi
+
+  if [[ -n "$plugins" ]]; then
+    err "$pkg sets plugins: [$plugins], which makes mix format load compiled plugin modules. This check does not fetch or compile them. Drop the plugins, or move this package into the package-tests matrix where deps are available."
     failed=1
     continue
   fi
@@ -73,6 +89,11 @@ for dir in packages/*/; do
     failed=1
   fi
 done
+
+if [[ "$package_count" -eq 0 ]]; then
+  err "no packages found; run this check from a checkout containing packages/*/mix.exs"
+  failed=1
+fi
 
 if [[ "$failed" -eq 0 ]]; then
   echo "All packages formatted."

--- a/test/raxol/formatter_delegation_test.exs
+++ b/test/raxol/formatter_delegation_test.exs
@@ -11,15 +11,6 @@ defmodule Raxol.FormatterDelegationTest do
 
   use ExUnit.Case, async: true
 
-  # 94 columns: legal at the package default of 98, split by the root's 80.
-  @wide_line "{:ok, ExKeccak.hash_256(<<0x19, 0x01, domain_separator::binary, message_hash::binary>>)}\n"
-
-  test "the root formatter still holds root files to 80 columns" do
-    {format, _opts} = Mix.Tasks.Format.formatter_for_file("lib/raxol.ex")
-
-    refute format.(@wide_line) == @wide_line
-  end
-
   # A package is defined by its mix.exs, NOT by having a .formatter.exs -- which
   # is the point. Enumerating by `.formatter.exs` would make a package that is
   # missing one invisible to the very test that exists to catch it, and the root
@@ -39,11 +30,15 @@ defmodule Raxol.FormatterDelegationTest do
   # files -- which is the whole property.
   test "every package resolves through its own formatter, not the root's" do
     for package <- packages() do
-      {format, _opts} = Mix.Tasks.Format.formatter_for_file(probe_path(package))
+      {_format, resolved_opts} =
+        Mix.Tasks.Format.formatter_for_file(probe_path(package))
 
-      assert format.(@wide_line) == @wide_line,
-             "#{package} resolves through the root formatter (80 columns), so a " <>
-               "root-cwd `mix format` would rewrap what its own gate blessed"
+      {package_opts, _bindings} =
+        Code.eval_file("packages/#{package}/.formatter.exs")
+
+      assert Keyword.get(resolved_opts, :line_length) ==
+               Keyword.get(package_opts, :line_length),
+             "#{package} does not resolve the line length from its own formatter"
     end
   end
 
@@ -51,7 +46,9 @@ defmodule Raxol.FormatterDelegationTest do
     "packages/*/mix.exs"
     |> Path.wildcard()
     |> Enum.map(&(&1 |> Path.dirname() |> Path.basename()))
-    |> tap(&assert &1 != [], "no packages found; is this running from the repo root?")
+    |> tap(
+      &assert &1 != [], "no packages found; is this running from the repo root?"
+    )
   end
 
   # A path that need not EXIST. `formatter_for_file/1` picks a config by walking

--- a/test/raxol/formatter_delegation_test.exs
+++ b/test/raxol/formatter_delegation_test.exs
@@ -11,6 +11,8 @@ defmodule Raxol.FormatterDelegationTest do
 
   use ExUnit.Case, async: true
 
+  @root_formatter_keys [:inputs, :exclude, :line_length, :locals_without_parens]
+
   # A package is defined by its mix.exs, NOT by having a .formatter.exs -- which
   # is the point. Enumerating by `.formatter.exs` would make a package that is
   # missing one invisible to the very test that exists to catch it, and the root
@@ -36,10 +38,25 @@ defmodule Raxol.FormatterDelegationTest do
       {package_opts, _bindings} =
         Code.eval_file("packages/#{package}/.formatter.exs")
 
-      assert Keyword.get(resolved_opts, :line_length) ==
-               Keyword.get(package_opts, :line_length),
-             "#{package} does not resolve the line length from its own formatter"
+      assert Keyword.take(resolved_opts, @root_formatter_keys) ==
+               Keyword.take(package_opts, @root_formatter_keys),
+             "#{package} does not resolve options from its own formatter"
     end
+  end
+
+  @tag :tmp_dir
+  test "loader validation ignores formatter stdout", %{tmp_dir: tmp_dir} do
+    formatter = Path.join(tmp_dir, ".formatter.exs")
+
+    File.write!(formatter, "IO.puts(\"noise\")\n[plugins: [SomePlugin]]\n")
+
+    {output, status} =
+      System.cmd("elixir", ["scripts/check_formatter_loaders.exs", formatter],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "sets plugins: [SomePlugin]"
   end
 
   defp packages do


### PR DESCRIPTION
## Summary

- gate every package formatter and fail when no packages are discovered
- reject both import_deps and formatter plugins without requiring package dependency builds
- isolate formatter stdout from the loader-option protocol
- verify formatter delegation using the package option set rather than one coincidental line length

## Review follow-ups

The loader check now validates options inside a dedicated Elixir process and communicates through exit status and stderr. Formatter-controlled stdout is discarded, so it cannot shift or spoof parsed result lines. A regression test covers a noisy formatter that also declares a plugin.

## Verification

- bash scripts/check_package_formatting.sh
- shellcheck scripts/check_package_formatting.sh
- bash -n scripts/check_package_formatting.sh
- focused ExUnit run: 3 tests, 0 failures
- git diff --check

## Merge order

Merge this before the 1Password diagnostic follow-up so that branch receives the strengthened package-format gate in its PR checks.