### PR TITLE
Harden 1Password diagnostic follow-ups

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/resolver.ex
@@ -249,7 +249,9 @@ defmodule Raxol.Agent.Backend.Resolver do
   The `op` state is read ONCE and, when it is unusable, the per-provider `op`
   probes are skipped entirely. See `provider_diag/2`.
   """
-  @spec diagnostics() :: %{op: atom(), providers: [map()]}
+  @type diagnostic_op_status :: :absent | :not_signed_in | :ok | :unresponsive
+
+  @spec diagnostics() :: %{op: diagnostic_op_status(), providers: [map()]}
   def diagnostics do
     op = Credentials.op_status()
 

--- a/packages/raxol_agent/lib/raxol/agent/setup.ex
+++ b/packages/raxol_agent/lib/raxol/agent/setup.ex
@@ -36,7 +36,10 @@ defmodule Raxol.Agent.Setup do
   A point-in-time detection snapshot: the `op` CLI state plus each provider's
   availability. Delegates to `Resolver.diagnostics/0`.
   """
-  @spec status() :: %{op: atom(), providers: [map()]}
+  @spec status() :: %{
+          op: Raxol.Agent.Backend.Resolver.diagnostic_op_status(),
+          providers: [map()]
+        }
   def status, do: Resolver.diagnostics()
 
   @doc """

--- a/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/resolver_test.exs
@@ -349,6 +349,7 @@ defmodule Raxol.Agent.Backend.ResolverTest do
         )
 
       File.mkdir_p!(dir)
+      File.chmod!(dir, 0o700)
       log = Path.join(dir, "calls")
       fake_op = Path.join(dir, "op")
 
@@ -458,7 +459,7 @@ defmodule Raxol.Agent.Backend.ResolverTest do
         System.put_env(var, "op://vault/#{var}/credential")
       end
 
-      {elapsed_us, diag} = :timer.tc(&Resolver.diagnostics/0)
+      diag = Resolver.diagnostics()
 
       # A timeout is evidence about the VAULT, so the first one demotes `op`
       # and the rest are answered from that without paying again.
@@ -473,11 +474,6 @@ defmodule Raxol.Agent.Backend.ResolverTest do
       assert length(reads) == 1,
              "expected the sweep to stop after one hung read, got #{length(reads)}: " <>
                inspect(reads)
-
-      # Four references, one budget. Asserted generously -- the point is that
-      # this is not four budgets, not where it lands inside one.
-      assert elapsed_us < 10_000_000,
-             "diagnostics took #{div(elapsed_us, 1000)}ms; a per-provider budget is back"
     end
 
     test "the stored references say the vault did not answer" do


### PR DESCRIPTION
## Summary

- narrow the diagnostic 1Password status type to the four states the resolver can return
- propagate that contract through setup status
- make the fake 1Password test directory private before placing the executable in it
- remove the wall-clock assertion while retaining the behavioral proof that a hung vault read stops the sweep after one call

## Verification represented by the branch

- resolver diagnostics still assert every provider receives the unresponsive result
- the call log asserts only one vault read occurs
- the status contract is explicit for Dialyzer and callers

## Merge order

Independent of the formatter changes, but intended to merge after PR #926 so its checks benefit from the strengthened package-format gate.