### PR TITLE
Harden REPL evaluation limits

### DIFF
--- a/lib/raxol/repl/evaluator.ex
+++ b/lib/raxol/repl/evaluator.ex
@@ -13,6 +13,8 @@ defmodule Raxol.REPL.Evaluator do
 
   @default_timeout Raxol.Core.Defaults.timeout_ms()
   @default_max_history Raxol.Core.Defaults.history_limit()
+  @default_max_heap_bytes 64 * 1024 * 1024
+  @default_max_result_bytes 1024 * 1024
 
   @type t :: %__MODULE__{
           bindings: keyword(),
@@ -70,19 +72,52 @@ defmodule Raxol.REPL.Evaluator do
           {:ok, result(), t()} | {:error, String.t(), t()}
   def eval(evaluator, code, opts \\ []) do
     timeout = Keyword.get(opts, :timeout, @default_timeout)
+    max_heap_bytes = Keyword.get(opts, :max_heap_bytes, @default_max_heap_bytes)
+
+    max_result_bytes =
+      Keyword.get(opts, :max_result_bytes, @default_max_result_bytes)
+
     parent = self()
     full_code = apply_prelude(evaluator.prelude, code)
+    word_size = :erlang.system_info(:wordsize)
+    heap_words = div(max_heap_bytes + word_size - 1, word_size)
 
     {pid, ref} =
-      spawn_monitor(fn ->
-        result = eval_with_capture(full_code, evaluator.bindings, evaluator.env)
-        send(parent, {:eval_result, result})
-      end)
+      :erlang.spawn_opt(
+        fn ->
+          result =
+            eval_with_capture(full_code, evaluator.bindings, evaluator.env)
 
-    handle_eval_response(evaluator, code, pid, ref, timeout)
+          send(parent, {:eval_result, bound_result(result, max_result_bytes)})
+        end,
+        [
+          :monitor,
+          {:max_heap_size, %{size: heap_words, kill: true, error_logger: false}}
+        ]
+      )
+
+    handle_eval_response(evaluator, code, pid, ref, timeout, max_heap_bytes)
   end
 
-  defp handle_eval_response(evaluator, code, pid, ref, timeout) do
+  defp bound_result(
+         {:ok, value, new_bindings, output} = result,
+         max_result_bytes
+       ) do
+    result_bytes =
+      :erlang.external_size(value) + :erlang.external_size(new_bindings) +
+        byte_size(output)
+
+    if result_bytes <= max_result_bytes do
+      result
+    else
+      {:error,
+       "Evaluation result exceeded the #{max_result_bytes}-byte result limit"}
+    end
+  end
+
+  defp bound_result(result, _max_result_bytes), do: result
+
+  defp handle_eval_response(evaluator, code, pid, ref, timeout, max_heap_bytes) do
     receive do
       {:eval_result, {:ok, value, new_bindings, output}} ->
         Process.demonitor(ref, [:flush])
@@ -91,6 +126,10 @@ defmodule Raxol.REPL.Evaluator do
       {:eval_result, {:error, message}} ->
         Process.demonitor(ref, [:flush])
         {:error, message, evaluator}
+
+      {:DOWN, ^ref, :process, ^pid, :killed} ->
+        {:error, "Evaluation exceeded the #{max_heap_bytes}-byte memory limit",
+         evaluator}
 
       {:DOWN, ^ref, :process, ^pid, reason} ->
         {:error, "Process crashed: #{Exception.format_exit(reason)}", evaluator}

--- a/lib/raxol/repl/sandbox.ex
+++ b/lib/raxol/repl/sandbox.ex
@@ -62,6 +62,8 @@ defmodule Raxol.REPL.Sandbox do
     {Kernel, :spawn_link, "process spawning"},
     {Kernel, :spawn_monitor, "process spawning"},
     {Kernel, :exit, "process termination"},
+    {String, :to_atom, "dynamic atom creation"},
+    {List, :to_atom, "dynamic atom creation"},
     {Process, :send, "message sending"},
     {Process, :send_after, "delayed message sending"},
     {Process, :whereis, "process lookup"},

--- a/test/raxol/repl/evaluator_test.exs
+++ b/test/raxol/repl/evaluator_test.exs
@@ -46,8 +46,33 @@ defmodule Raxol.REPL.EvaluatorTest do
 
     test "times out on long-running code" do
       eval = Evaluator.new()
-      {:error, reason, _eval} = Evaluator.eval(eval, ":timer.sleep(10_000)", timeout: 100)
+
+      {:error, reason, _eval} =
+        Evaluator.eval(eval, ":timer.sleep(10_000)", timeout: 100)
+
       assert reason =~ "timed out"
+    end
+
+    test "kills evaluation that exceeds its heap budget" do
+      eval = Evaluator.new()
+
+      assert {:error, reason, ^eval} =
+               Evaluator.eval(eval, "List.duplicate(0, 1_000_000)",
+                 max_heap_bytes: 128_000
+               )
+
+      assert reason =~ "memory limit"
+    end
+
+    test "rejects oversized results before copying them to the owner" do
+      eval = Evaluator.new()
+
+      assert {:error, reason, ^eval} =
+               Evaluator.eval(eval, "String.duplicate(\"x\", 10_000)",
+                 max_result_bytes: 1_000
+               )
+
+      assert reason =~ "result limit"
     end
 
     test "preserves evaluator on error" do
@@ -75,7 +100,10 @@ defmodule Raxol.REPL.EvaluatorTest do
 
     test "evaluates pipe chains" do
       eval = Evaluator.new()
-      {:ok, result, _eval} = Evaluator.eval(eval, "[1,2,3] |> Enum.map(& &1 * 2) |> Enum.sum()")
+
+      {:ok, result, _eval} =
+        Evaluator.eval(eval, "[1,2,3] |> Enum.map(& &1 * 2) |> Enum.sum()")
+
       assert result.value == 12
     end
 

--- a/test/raxol/repl/sandbox_test.exs
+++ b/test/raxol/repl/sandbox_test.exs
@@ -110,6 +110,21 @@ defmodule Raxol.REPL.SandboxTest do
       {:error, violations} = Sandbox.check("Process.list()", :strict)
       assert Enum.any?(violations, &String.contains?(&1, "not in whitelist"))
     end
+
+    test "denies irreversible dynamic atom creation" do
+      for code <- [
+            ~S[String.to_atom("attacker-controlled")],
+            ~S[List.to_atom(~c"attacker-controlled")],
+            ~S[Atom.to_string(:ok) |> String.to_atom()]
+          ] do
+        assert {:error, violations} = Sandbox.check(code, :strict)
+
+        assert Enum.any?(
+                 violations,
+                 &String.contains?(&1, "dynamic atom creation")
+               )
+      end
+    end
   end
 
   # The strict level guards an SSH/web-exposed REPL that may share a node with


### PR DESCRIPTION
## Summary
- reject dynamic atom creation in strict REPL sandbox mode
- enforce evaluator heap limits with process termination
- enforce evaluator result-size limits
- add regression coverage for each guard

## Verification
- `mix test test/raxol/repl/sandbox_test.exs test/raxol/repl/evaluator_test.exs` — 44 passed
- `mix test test/raxol/repl test/raxol/playground/demos/repl_demo_test.exs` — 77 passed