### PR TITLE
Hold the site's chrome to the content's column

### DIFF
--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -54,13 +54,6 @@
   }
   .nav-link:hover { color: #e8e4dc; }
 
-  /* Footer / dimmer links */
-  .footer-link {
-    @apply font-mono transition-colors;
-    color: var(--text-dim);
-  }
-  .footer-link:hover { color: #e8e4dc; }
-
   /* Brand link (coral that fades to pearl on hover) */
   .brand-link {
     @apply font-mono transition-colors;
@@ -317,6 +310,20 @@
      backdrop-filter, so page content shows through whatever alpha it gets. */
   --border-subtle: var(--panel-border);
   --panel-strong: var(--panel-bg-elevated);
+
+  /* --- Measure ---
+     The column every page centers its content in. The header and footer rules
+     span the viewport, but what sits inside them lines up with the hero, the
+     topic prose and the gallery below: one number, so the brand mark cannot
+     drift away from the first word it sits above.
+
+     The gutter is the breathing room outside that column, not inside it. Kept
+     separate because a page that pads within its measure starts its text a
+     gutter's width further in than one that pads outside, which is how the
+     landing and the topic pages came to disagree by 20px on where a line
+     begins. */
+  --screen-measure: 62rem;
+  --screen-gutter: 1.25rem;
 
   /* --- Atmospheric pearls (used by .pearl-bg gradient stops) --- */
   --pearl-violet: rgba(40, 51, 139, 0.4);
@@ -1854,11 +1861,51 @@ html {
   background: var(--panel-border);
 }
 
+/* Takes the slack, and gives it up before the controls do: the title is the
+   one thing in the bar that can be abbreviated, so it truncates rather than
+   pushing the buttons out of a narrow bar. */
 .hd-title {
   font-family: var(--font-mono);
   font-size: 0.74rem;
   color: var(--text-dim);
   margin-left: 0.3rem;
+  margin-right: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hd-controls {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+  flex: 0 0 auto;
+}
+
+/* 24px minimum box, per WCAG 2.2 target size -- the same floor the header
+   links sit at. The type is small enough that the text alone would be under
+   it. */
+.hd-control {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.5rem;
+  transition: color var(--duration-fast) var(--ease-out);
+}
+
+.hd-control:hover,
+.hd-control:focus-visible {
+  color: var(--pearl-cream);
+}
+
+.hd-control--next {
+  color: var(--axol-coral);
 }
 
 .hero-tabs {
@@ -1975,6 +2022,28 @@ html {
 
 .hero-frames::-webkit-scrollbar { display: none; }
 
+/* The SSH pane's decoded stream. `pre` resets the `white-space: normal` its
+   container needs, and the container's own two-axis type fit applies here the
+   same way it does to a recorded frame. */
+.hero-ansi {
+  margin: 0;
+  white-space: pre;
+}
+
+/* ANSI SGR colours. These are terminal colours, not palette tokens: they must
+   equal what `TerminalBridge` writes into the recorded frames, or the SSH tab
+   and the terminal tab would show one program in two palettes. The full eight
+   are defined because `SurfaceSource` refuses to build against a code with no
+   colour behind it, and a recording is free to use any of them. */
+.ansi-black { color: #000000; }
+.ansi-red { color: #ff0000; }
+.ansi-green { color: #00ff00; }
+.ansi-yellow { color: #ffff00; }
+.ansi-blue { color: #0000ff; }
+.ansi-magenta { color: #ff00ff; }
+.ansi-cyan { color: #00ffff; }
+.ansi-white { color: #ffffff; }
+
 .hero-live-wrap {
   padding: 1rem 1.25rem;
 }
@@ -1983,15 +2052,6 @@ html {
   border: 1px solid var(--panel-border);
   border-radius: 6px;
   padding: 0.75rem 0.9rem;
-}
-
-.hero-demo-foot {
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  gap: 1.25rem;
-  padding: 0.45rem 0.9rem;
-  border-top: 1px solid var(--panel-border);
 }
 
 .hero-live-badge {
@@ -2271,12 +2331,40 @@ input[type="range"]::-moz-range-thumb {
   gap: 0;
 }
 
+/* The rule spans the viewport; what sits on it does not. `position: relative`
+   is load-bearing: the mobile nav is absolutely positioned at `top: 100%`, and
+   without a positioned header it resolved against `.screen` -- a 100dvh grid --
+   which put the open menu a full viewport below the button that opened it. */
 .screen-header {
+  position: relative;
+  padding: 0.9rem var(--screen-gutter);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+/* The measured row inside a full-bleed bar. Inline padding lives on the bar's
+   parent, not here, so the first character lines up with the hero's left edge
+   rather than sitting a padding's width inside it. */
+.screen-bar {
   display: flex;
   align-items: center;
   gap: 1.5rem;
-  padding: 0.9rem 1.5rem;
-  border-bottom: 1px solid var(--border-subtle);
+  max-width: var(--screen-measure);
+  margin-inline: auto;
+}
+
+/* The same column for pages that are not the one-screen landing. The topic
+   pages reached for Tailwind's `max-w-5xl` (64rem), which put their header two
+   characters off from the landing's -- visible as a jump in the brand mark when
+   a reader crossed between them.
+
+   The gutter is padding here rather than a `px-*` class on each call site, and
+   the cap grows by it, so the CONTENT box is exactly `--screen-measure` and a
+   line starts on the same column as the landing's. Elements carrying this class
+   must not also carry `px-*`: that pads a second time, inside the measure. */
+.measure {
+  max-width: calc(var(--screen-measure) + 2 * var(--screen-gutter));
+  margin-inline: auto;
+  padding-inline: var(--screen-gutter);
 }
 
 .screen-mark {
@@ -2321,7 +2409,9 @@ input[type="range"]::-moz-range-thumb {
 }
 
 @media (min-width: 768px) {
-  .screen-header { padding: 1rem 2rem; }
+  /* Block padding only. The inline gutter stays at the hero's 1.25rem so the
+     brand mark and the h1 below it start on the same column. */
+  .screen-header { padding-block: 1rem; }
   .screen-nav { display: flex; }
   .screen-menu-btn, .screen-nav-mobile { display: none; }
 }
@@ -2332,8 +2422,15 @@ input[type="range"]::-moz-range-thumb {
   align-items: center;
   justify-content: center;
   gap: 1.1rem;
-  padding: 1.5rem 1.25rem;
+  padding: 1.5rem var(--screen-gutter);
   min-height: 0; /* lets the demo shrink instead of forcing the grid taller */
+  /* The same release on the other axis, and the one that was missing. As a
+     grid item this defaults to `min-width: auto`, so the track could never be
+     narrower than the hero's min-content -- a fixed 62rem. Every viewport under
+     that got a page 1032px wide and scrolled sideways, phones included. The
+     panes already stack under 767px and their `pre`s already scroll, so the
+     content has somewhere to go the moment the track is allowed to shrink. */
+  min-width: 0;
   text-align: center;
 }
 
@@ -2360,8 +2457,7 @@ input[type="range"]::-moz-range-thumb {
 .screen-main .hero-demo {
   margin: 0;
   width: 100%;
-  max-width: 62rem;
-  max-height: 30rem;
+  max-width: var(--screen-measure);
   min-height: 0;
   flex: 1 1 auto;
   display: flex;
@@ -2383,7 +2479,7 @@ input[type="range"]::-moz-range-thumb {
    silently drop the tail, and a cap nobody can see is worse than motion. */
 .screen-integrations {
   width: 100%;
-  max-width: 62rem;
+  max-width: var(--screen-measure);
   flex: 0 0 auto;
   overflow: hidden;
   font-family: var(--font-mono);
@@ -2541,15 +2637,16 @@ input[type="range"]::-moz-range-thumb {
    with room for the row, and every shorter one scrolls and can simply show it. */
 
 .screen-footer {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem 1.5rem;
-  padding: 0.8rem 1.5rem;
+  padding: 0.8rem var(--screen-gutter);
   border-top: 1px solid var(--border-subtle);
   font-family: var(--font-mono);
   font-size: 0.78rem;
+}
+
+.screen-footer .screen-bar {
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem 1.5rem;
 }
 
 .screen-topics { display: flex; flex-wrap: wrap; gap: 1.1rem; }
@@ -2587,6 +2684,14 @@ input[type="range"]::-moz-range-thumb {
   /* A size container, so the type rules below can divide by the pane's real
      height instead of guessing at it. */
   .screen-main .hero-pane { min-height: 0; overflow: hidden; container-type: size; }
+
+  /* The cap belongs with the rules that make it survivable, not outside them.
+     It used to apply at every height while the shrinking above it applied only
+     here, so a short viewport got a box capped at 30rem holding content that
+     could not shrink to fit -- and `overflow: hidden` ate the difference. Below
+     this threshold the page scrolls by design, so the demo takes the height it
+     needs and nothing is cut. */
+  .screen-main .hero-demo { max-height: 30rem; }
 }
 
 /* Breadcrumb on the topic pages the landing hands off to. */
@@ -2606,7 +2711,7 @@ input[type="range"]::-moz-range-thumb {
   align-items: center;
   gap: clamp(1rem, 3vw, 2.25rem);
   width: 100%;
-  max-width: 62rem;
+  max-width: var(--screen-measure);
   flex: 0 0 auto;
   text-align: left;
 }
@@ -2704,14 +2809,3 @@ input[type="range"]::-moz-range-thumb {
   line-height: 1.5;
 }
 
-/* Keys the live session actually responds to, named in the footer so the
-   payoff of taking over is legible rather than something to guess at. */
-.hero-demo-foot kbd {
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  padding: 0.05rem 0.3rem;
-  margin: 0 0.1rem;
-  border: 1px solid var(--panel-border);
-  border-radius: 3px;
-  color: var(--axol-coral);
-}

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -2044,6 +2044,24 @@ html {
 .ansi-cyan { color: #00ffff; }
 .ansi-white { color: #ffffff; }
 
+.ansi-bright-black { color: #555555; }
+.ansi-bright-red { color: #ff5555; }
+.ansi-bright-green { color: #55ff55; }
+.ansi-bright-yellow { color: #ffff55; }
+.ansi-bright-blue { color: #5555ff; }
+.ansi-bright-magenta { color: #ff55ff; }
+.ansi-bright-cyan { color: #55ffff; }
+.ansi-bright-white { color: #ffffff; }
+
+/* Intensity and emphasis are orthogonal to colour, so these compose with the
+   colour classes above rather than replacing them: a bold cyan run carries
+   both. `SurfaceSource` refuses to decode an SGR code that has no class here,
+   so the two lists have to stay in step. */
+.ansi-bold { font-weight: 700; }
+.ansi-dim { opacity: 0.55; }
+.ansi-italic { font-style: italic; }
+.ansi-underline { text-decoration: underline; }
+
 .hero-live-wrap {
   padding: 1rem 1.25rem;
 }

--- a/web/lib/mix/tasks/raxol.docs.llms.ex
+++ b/web/lib/mix/tasks/raxol.docs.llms.ex
@@ -99,7 +99,14 @@ defmodule Mix.Tasks.Raxol.Docs.Llms do
   defp capability_summary do
     agent = Capabilities.agent()
     backends = Enum.join(agent.backends, ", ")
-    strategies = Enum.map_join(agent.strategies, ", ", &String.replace(&1, "Strategy.", ""))
+
+    strategies =
+      Enum.map_join(
+        agent.strategies,
+        ", ",
+        &String.replace(&1, "Strategy.", "")
+      )
+
     surfaces = Enum.map_join(Capabilities.surfaces(), ", ", & &1.name)
 
     """
@@ -223,7 +230,9 @@ defmodule Mix.Tasks.Raxol.Docs.Llms do
       |> Enum.uniq()
       |> Enum.map_join("\n\n", fn path ->
         rel = Path.relative_to(path, docs_root)
-        "<!-- docs/#{rel} -->\n\n" <> String.trim_trailing(File.read!(path)) <> "\n"
+
+        "<!-- docs/#{rel} -->\n\n" <>
+          String.trim_trailing(File.read!(path)) <> "\n"
       end)
 
     header <> body <> "\n"

--- a/web/lib/raxol_playground/application.ex
+++ b/web/lib/raxol_playground/application.ex
@@ -13,7 +13,8 @@ defmodule RaxolPlayground.Application do
       [
         RaxolPlaygroundWeb.Telemetry,
         {DNSCluster,
-         query: Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
+         query:
+           Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: RaxolPlayground.PubSub}
       ] ++
         maybe_raxol_pubsub() ++
@@ -69,19 +70,24 @@ defmodule RaxolPlayground.Application do
             # the public internet on one env var.
             app_module: Raxol.Playground.App,
             port: ssh_port(),
-            host_keys_dir: System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys",
+            host_keys_dir:
+              System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys",
             allow_anonymous: true,
             max_connections: ssh_max_connections(),
             max_per_ip: env_int("RAXOL_SSH_MAX_PER_IP", 10),
             idle_timeout: :timer.seconds(env_int("RAXOL_SSH_IDLE_SECONDS", 300)),
-            max_session_duration: :timer.seconds(env_int("RAXOL_SSH_MAX_SESSION_SECONDS", 3600))
+            max_session_duration:
+              :timer.seconds(env_int("RAXOL_SSH_MAX_SESSION_SECONDS", 3600))
           },
           restart: :temporary
         )
 
       case Supervisor.start_child(sup, spec) do
-        {:ok, _pid} -> :ok
-        {:error, reason} -> IO.puts("[SSH] playground not started: #{inspect(reason)}")
+        {:ok, _pid} ->
+          :ok
+
+        {:error, reason} ->
+          IO.puts("[SSH] playground not started: #{inspect(reason)}")
       end
     else
       _ -> :ok
@@ -92,7 +98,8 @@ defmodule RaxolPlayground.Application do
     :exit, reason -> IO.puts("[SSH] playground exit: #{inspect(reason)}")
   end
 
-  defp ssh_port, do: String.to_integer(System.get_env("RAXOL_SSH_PORT") || "2222")
+  defp ssh_port,
+    do: String.to_integer(System.get_env("RAXOL_SSH_PORT") || "2222")
 
   defp ssh_max_connections,
     do: String.to_integer(System.get_env("RAXOL_SSH_MAX_CONNECTIONS") || "50")

--- a/web/lib/raxol_playground/brand_marks.ex
+++ b/web/lib/raxol_playground/brand_marks.ex
@@ -49,9 +49,14 @@ defmodule RaxolPlayground.BrandMarks do
              raise "#{file} is not a 24x24 mark; the row's sizing assumes that viewBox"
            end
 
-           case Regex.scan(~r/<path[^>]*\sd="([^"]+)"/, svg, capture: :all_but_first) do
-             [[d]] -> {name, d}
-             found -> raise "#{file} has #{length(found)} paths; expected exactly 1"
+           case Regex.scan(~r/<path[^>]*\sd="([^"]+)"/, svg,
+                  capture: :all_but_first
+                ) do
+             [[d]] ->
+               {name, d}
+
+             found ->
+               raise "#{file} has #{length(found)} paths; expected exactly 1"
            end
          end)
 

--- a/web/lib/raxol_playground/capabilities.ex
+++ b/web/lib/raxol_playground/capabilities.ex
@@ -49,7 +49,11 @@ defmodule RaxolPlayground.Capabilities do
   # Inlined rather than factored into a function because a module attribute
   # cannot call a function of the module being defined.
   @providers Enum.map(Resolver.providers(), fn %{harness: harness, label: label} ->
-               %{harness: harness, name: label |> String.split(" (") |> hd(), label: label}
+               %{
+                 harness: harness,
+                 name: label |> String.split(" (") |> hd(),
+                 label: label
+               }
              end)
 
   @backends Enum.map(@providers, & &1.name)
@@ -159,7 +163,8 @@ defmodule RaxolPlayground.Capabilities do
   Same shape as `ssh_available?/0`: a channel is named only while it exists.
   """
   @spec acp_available?() :: boolean()
-  def acp_available?, do: Code.ensure_loaded?(Raxol.Agent.ClientProtocol.StdioAgent)
+  def acp_available?,
+    do: Code.ensure_loaded?(Raxol.Agent.ClientProtocol.StdioAgent)
 
   @doc "ACP-speaking editors, or `[]` when this build serves no ACP surface."
   @spec acp_editors() :: [String.t()]

--- a/web/lib/raxol_playground/recorded_frames.ex
+++ b/web/lib/raxol_playground/recorded_frames.ex
@@ -72,7 +72,11 @@ defmodule RaxolPlayground.RecordedFrames do
   @hero_artifacts Map.new(surface_paths, fn {name, %{ansi: ansi, mcp: mcp}} ->
                     {name,
                      %{
-                       browser: hero_paths |> Map.fetch!(name) |> List.first() |> File.read!(),
+                       browser:
+                         hero_paths
+                         |> Map.fetch!(name)
+                         |> List.first()
+                         |> File.read!(),
                        ssh: File.read!(ansi),
                        mcp: File.read!(mcp)
                      }}
@@ -185,7 +189,10 @@ defmodule RaxolPlayground.RecordedFrames do
   pane it is given and shrinks to fit a short one, instead of sitting at a
   fixed size with dead space beside it.
   """
-  @spec hero_frame_grid(String.t()) :: %{rows: pos_integer(), cols: pos_integer()}
+  @spec hero_frame_grid(String.t()) :: %{
+          rows: pos_integer(),
+          cols: pos_integer()
+        }
   def hero_frame_grid(example) do
     case hero_frames(example) do
       [frame | _] -> grid(frame)
@@ -207,7 +214,8 @@ defmodule RaxolPlayground.RecordedFrames do
 
     %{
       rows: max(length(lines), 1),
-      cols: lines |> Enum.map(&String.length/1) |> Enum.max(fn -> 1 end) |> max(1)
+      cols:
+        lines |> Enum.map(&String.length/1) |> Enum.max(fn -> 1 end) |> max(1)
     }
   end
 

--- a/web/lib/raxol_playground/recorded_frames.ex
+++ b/web/lib/raxol_playground/recorded_frames.ex
@@ -82,26 +82,41 @@ defmodule RaxolPlayground.RecordedFrames do
   # breaking, clamping, escaping and colouring are too.
   @hero_surfaces Map.new(@hero_artifacts, fn {name, artifacts} ->
                    panes =
-                     Map.new(artifacts, fn {surface, artifact} ->
-                       lines =
-                         case surface do
-                           :browser -> SurfaceSource.dom_lines(artifact)
-                           :ssh -> SurfaceSource.ansi_lines(artifact)
-                           :mcp -> SurfaceSource.json_lines(artifact)
-                         end
+                     Map.new(artifacts, fn
+                       # SSH is painted, not listed. The other two surfaces
+                       # carry structured text a reader reads line by line, so
+                       # they are broken to a line budget with a marker. This
+                       # one carries a picture, so it keeps its own grid whole
+                       # and the CSS fits the type to it, exactly as the
+                       # terminal pane beside it does.
+                       {:ssh, artifact} ->
+                         rows = SurfaceSource.ansi_rows(artifact)
 
-                       kind = %{browser: :dom, ssh: :ansi, mcp: :json}[surface]
+                         {:ssh,
+                          %{
+                            html: SurfaceSource.ansi_html(rows),
+                            grid: SurfaceSource.ansi_grid(rows)
+                          }}
 
-                       clamped =
-                         lines
-                         |> SurfaceSource.wrap()
-                         |> SurfaceSource.clamp(artifact)
+                       {surface, artifact} ->
+                         lines =
+                           case surface do
+                             :browser -> SurfaceSource.dom_lines(artifact)
+                             :mcp -> SurfaceSource.json_lines(artifact)
+                           end
 
-                       {surface,
-                        %{
-                          html: SurfaceSource.to_html(clamped, kind),
-                          lines: length(clamped)
-                        }}
+                         kind = %{browser: :dom, mcp: :json}[surface]
+
+                         clamped =
+                           lines
+                           |> SurfaceSource.wrap()
+                           |> SurfaceSource.clamp(artifact)
+
+                         {surface,
+                          %{
+                            html: SurfaceSource.to_html(clamped, kind),
+                            lines: length(clamped)
+                          }}
                      end)
 
                    {name, panes}
@@ -145,6 +160,18 @@ defmodule RaxolPlayground.RecordedFrames do
   @spec hero_surface_lines(String.t(), surface()) :: pos_integer()
   def hero_surface_lines(example, surface) do
     example |> pane(surface) |> Map.get(:lines, 1)
+  end
+
+  @doc """
+  Rows and columns in the decoded SSH pane, in painted characters.
+
+  The same two-axis fit the terminal frames get: the recording's grid is fixed
+  and the pane's is not, so the type follows the frame rather than the frame
+  being cut to a line budget it never fit.
+  """
+  @spec hero_ssh_grid(String.t()) :: %{rows: pos_integer(), cols: pos_integer()}
+  def hero_ssh_grid(example) do
+    example |> pane(:ssh) |> Map.get(:grid, %{rows: 1, cols: 1})
   end
 
   defp pane(example, surface) do

--- a/web/lib/raxol_playground/surface_source.ex
+++ b/web/lib/raxol_playground/surface_source.ex
@@ -2,12 +2,20 @@ defmodule RaxolPlayground.SurfaceSource do
   @moduledoc """
   Renders a recorded surface artifact into the hero's output pane.
 
-  The line functions only re-break the stream, so every emitted line is a
-  substring of the artifact. `clamp/2` is the one step that drops anything,
-  and it appends a marker naming what it dropped.
+  Two shapes, because the surfaces carry two kinds of thing.
 
-  Lines are broken rather than wrapped because the height budget is counted
-  in lines: a wrapped line costs two and pushes the marker off the pane.
+  The browser and MCP artifacts are structured text, read line by line. The
+  line functions only re-break the stream, so every emitted line is a substring
+  of the artifact; `clamp/2` is the one step that drops anything, and it
+  appends a marker naming what it dropped. Lines are broken rather than wrapped
+  because the height budget is counted in lines: a wrapped line costs two and
+  pushes the marker off the pane.
+
+  The SSH artifact is a picture. `ansi_rows/1` decodes its colour instead of
+  spelling it out, and nothing is clamped -- the pane reports its grid through
+  `ansi_grid/1` and the CSS fits the type to it, the way the terminal pane
+  beside it already worked. A frame cut to a line budget it never fit is not
+  the frame the channel delivered.
 
   Colouring runs over already-escaped text, so a `<` in an artifact reaches
   the page as `&lt;`.
@@ -76,31 +84,121 @@ defmodule RaxolPlayground.SurfaceSource do
     |> Enum.reverse()
   end
 
-  @doc """
-  Breaks an ANSI stream into one styled run per line, ESC spelled out.
+  # The SGR colours a recording may ask for, mapped to the class that paints
+  # them. `TerminalBridge` renders the terminal pane's frame from the same
+  # buffer this stream was projected from, so these classes must resolve to the
+  # colours it emits -- otherwise one program shows up in two palettes on two
+  # tabs of the same demo.
+  @sgr_colors %{
+    "30" => "ansi-black",
+    "31" => "ansi-red",
+    "32" => "ansi-green",
+    "33" => "ansi-yellow",
+    "34" => "ansi-blue",
+    "35" => "ansi-magenta",
+    "36" => "ansi-cyan",
+    "37" => "ansi-white"
+  }
 
-  Spelling `\\e` as `ESC` is the only edit; the byte is invisible in a
-  browser. Real newlines stay line breaks, so the row structure survives, and
-  the reset closing a run is folded onto it rather than spending a line.
+  @ansi_sequence ~r/\e\[[0-9;?]*[A-Za-z]/
+
+  @typedoc "A painted run: the class colouring it, or nil for the default."
+  @type run :: {String.t() | nil, String.t()}
+
+  @doc """
+  Decodes an ANSI stream into rows of painted runs.
+
+  The pane used to spell `\\e` as `ESC` and print the codes beside the text.
+  That is honestly what the channel carries, but escape codes on screen is the
+  universal signature of a terminal failing to render, so the one pane whose
+  job is to prove raxol runs over SSH was the one that looked broken. Painting
+  them shows the frame the remote terminal actually receives, which is the
+  claim the pane exists to make.
+
+  Colour carries across rows, as it does on a real terminal: a run left open at
+  the end of one row still colours the start of the next.
+
+  Raises on a sequence it cannot paint. Callers decode committed recordings at
+  compile time, so an unsupported code fails the build rather than reaching the
+  page as a silently unstyled run.
   """
-  @spec ansi_lines(String.t()) :: [String.t()]
-  def ansi_lines(ansi) do
+  @spec ansi_rows(String.t()) :: [[run()]]
+  def ansi_rows(ansi) do
     ansi
+    |> String.trim_trailing("\n")
     |> String.split("\n")
-    |> Enum.flat_map(&row_runs/1)
-    |> Enum.reject(&(&1 == ""))
+    |> Enum.map_reduce(nil, &row_runs/2)
+    |> elem(0)
   end
 
-  defp row_runs(row) do
-    case String.split(row, "\e") do
-      [only] ->
-        [only]
+  defp row_runs(row, class) do
+    @ansi_sequence
+    |> Regex.split(row, include_captures: true, trim: true)
+    |> Enum.reduce({[], class}, fn
+      <<"\e[", _rest::binary>> = seq, {runs, cls} -> {runs, sgr_class!(seq, cls)}
+      text, {runs, cls} -> {[{cls, text} | runs], cls}
+    end)
+    |> then(fn {runs, cls} -> {Enum.reverse(runs), cls} end)
+  end
 
-      [head | rest] ->
-        [head | Enum.map(rest, &("ESC" <> &1))]
-        |> Enum.reject(&(&1 == ""))
-        |> fold_onto_previous(&String.starts_with?(&1, "ESC[0m"))
+  defp sgr_class!(sequence, class) do
+    params =
+      case String.split_at(sequence, -1) do
+        {<<"\e[", params::binary>>, "m"} ->
+          params
+
+        _ ->
+          raise ArgumentError,
+                "#{inspect(sequence)} is not an SGR sequence; the hero panes paint colour only"
+      end
+
+    # No parameters is a reset: `ESC[m` and `ESC[0m` mean the same thing.
+    case String.split(params, ";", trim: true) do
+      [] -> nil
+      codes -> Enum.reduce(codes, class, &apply_sgr!/2)
     end
+  end
+
+  defp apply_sgr!("0", _class), do: nil
+
+  defp apply_sgr!(code, _class) do
+    Map.get_lazy(@sgr_colors, code, fn ->
+      raise ArgumentError,
+            "no colour is mapped for SGR #{code}; add it to SurfaceSource " <>
+              "alongside the CSS that paints it"
+    end)
+  end
+
+  @doc """
+  Escaped markup for decoded `rows`, one line per row.
+
+  Nothing is dropped: the pane sizes its type to the grid rather than cutting
+  to a line budget, so unlike the browser and MCP panes there is no marker and
+  no elision.
+  """
+  @spec ansi_html([[run()]]) :: String.t()
+  def ansi_html(rows) do
+    Enum.map_join(rows, "\n", fn runs ->
+      Enum.map_join(runs, "", fn
+        {nil, text} -> escape(text)
+        {class, text} -> ~s(<span class="#{class}">#{escape(text)}</span>)
+      end)
+    end)
+  end
+
+  @doc """
+  The row count and widest row of decoded `rows`, in painted characters.
+
+  Measured on the text only. Escape sequences occupy no columns on a terminal,
+  and counting them as width is what made the old pane wrap a 70-column frame
+  into fragments.
+  """
+  @spec ansi_grid([[run()]]) :: %{rows: pos_integer(), cols: pos_integer()}
+  def ansi_grid(rows) do
+    widths =
+      Enum.map(rows, fn runs -> Enum.reduce(runs, 0, &(String.length(elem(&1, 1)) + &2)) end)
+
+    %{rows: max(length(rows), 1), cols: max(Enum.max(widths, fn -> 1 end), 1)}
   end
 
   @doc "Lines of a pretty-printed JSON artifact, as recorded."
@@ -129,7 +227,7 @@ defmodule RaxolPlayground.SurfaceSource do
   Colouring runs over the escaped text, so it wraps entities and can never
   re-open markup the artifact contained.
   """
-  @spec to_html([String.t()], :dom | :ansi | :json) :: String.t()
+  @spec to_html([String.t()], :dom | :json) :: String.t()
   def to_html(lines, kind) do
     lines
     |> Enum.map_join("\n", fn line ->
@@ -151,10 +249,6 @@ defmodule RaxolPlayground.SurfaceSource do
     line
     |> String.replace(~r/&quot;([^&]*)&quot;/, ~S(&quot;<span class="hg">\1</span>&quot;))
     |> String.replace(~r{&lt;(/?[a-z]+)}, ~S(&lt;<span class="hk">\1</span>))
-  end
-
-  defp colorize(line, :ansi) do
-    String.replace(line, ~r/^ESC\[[0-9;?]*[A-Za-z]/, ~S(<span class="hk">\0</span>))
   end
 
   defp colorize(line, :json) do

--- a/web/lib/raxol_playground/surface_source.ex
+++ b/web/lib/raxol_playground/surface_source.ex
@@ -97,13 +97,55 @@ defmodule RaxolPlayground.SurfaceSource do
     "34" => "ansi-blue",
     "35" => "ansi-magenta",
     "36" => "ansi-cyan",
-    "37" => "ansi-white"
+    "37" => "ansi-white",
+    "90" => "ansi-bright-black",
+    "91" => "ansi-bright-red",
+    "92" => "ansi-bright-green",
+    "93" => "ansi-bright-yellow",
+    "94" => "ansi-bright-blue",
+    "95" => "ansi-bright-magenta",
+    "96" => "ansi-bright-cyan",
+    "97" => "ansi-bright-white"
   }
+
+  # Intensity and emphasis are ORTHOGONAL to colour, which is why a run carries
+  # a set of classes rather than one. Holding a single class meant `bold cyan`
+  # had nowhere to go, so the decoder raised on SGR 1 -- and `text(..., style:
+  # [:bold])` is ordinary View DSL, used throughout the demo catalog. Promoting
+  # any of those demos to a hero example failed the build on a code the
+  # recording legitimately contained.
+  @sgr_attributes %{
+    "1" => :bold,
+    "2" => :dim,
+    "3" => :italic,
+    "4" => :underline
+  }
+
+  # The codes that turn an attribute back off, and the attributes each clears.
+  @sgr_resets %{
+    "22" => [:bold, :dim],
+    "23" => [:italic],
+    "24" => [:underline]
+  }
+
+  @attribute_classes %{
+    bold: "ansi-bold",
+    dim: "ansi-dim",
+    italic: "ansi-italic",
+    underline: "ansi-underline"
+  }
+
+  # Attribute order is fixed so the same styling always renders the same class
+  # string, which keeps the recorded markup stable across regenerations.
+  @attribute_order [:bold, :dim, :italic, :underline]
 
   @ansi_sequence ~r/\e\[[0-9;?]*[A-Za-z]/
 
-  @typedoc "A painted run: the class colouring it, or nil for the default."
-  @type run :: {String.t() | nil, String.t()}
+  @typedoc "The SGR state a run inherits: a colour class and set attributes."
+  @type style :: %{color: String.t() | nil, attributes: [atom()]}
+
+  @typedoc "A painted run: the classes styling it, and its text."
+  @type run :: {[String.t()], String.t()}
 
   @doc """
   Decodes an ANSI stream into rows of painted runs.
@@ -127,21 +169,36 @@ defmodule RaxolPlayground.SurfaceSource do
     ansi
     |> String.trim_trailing("\n")
     |> String.split("\n")
-    |> Enum.map_reduce(nil, &row_runs/2)
+    |> Enum.map_reduce(reset_style(), &row_runs/2)
     |> elem(0)
   end
 
-  defp row_runs(row, class) do
+  defp reset_style, do: %{color: nil, attributes: []}
+
+  defp row_runs(row, style) do
     @ansi_sequence
     |> Regex.split(row, include_captures: true, trim: true)
-    |> Enum.reduce({[], class}, fn
-      <<"\e[", _rest::binary>> = seq, {runs, cls} -> {runs, sgr_class!(seq, cls)}
-      text, {runs, cls} -> {[{cls, text} | runs], cls}
+    |> Enum.reduce({[], style}, fn
+      <<"\e[", _rest::binary>> = seq, {runs, sty} ->
+        {runs, sgr_style!(seq, sty)}
+
+      text, {runs, sty} ->
+        {[{classes(sty), text} | runs], sty}
     end)
-    |> then(fn {runs, cls} -> {Enum.reverse(runs), cls} end)
+    |> then(fn {runs, sty} -> {Enum.reverse(runs), sty} end)
   end
 
-  defp sgr_class!(sequence, class) do
+  # A colour first, then attributes in a fixed order.
+  defp classes(%{color: color, attributes: attributes}) do
+    ordered =
+      @attribute_order
+      |> Enum.filter(&(&1 in attributes))
+      |> Enum.map(&Map.fetch!(@attribute_classes, &1))
+
+    if color, do: [color | ordered], else: ordered
+  end
+
+  defp sgr_style!(sequence, style) do
     params =
       case String.split_at(sequence, -1) do
         {<<"\e[", params::binary>>, "m"} ->
@@ -154,19 +211,32 @@ defmodule RaxolPlayground.SurfaceSource do
 
     # No parameters is a reset: `ESC[m` and `ESC[0m` mean the same thing.
     case String.split(params, ";", trim: true) do
-      [] -> nil
-      codes -> Enum.reduce(codes, class, &apply_sgr!/2)
+      [] -> reset_style()
+      codes -> Enum.reduce(codes, style, &apply_sgr!/2)
     end
   end
 
-  defp apply_sgr!("0", _class), do: nil
+  defp apply_sgr!("0", _style), do: reset_style()
 
-  defp apply_sgr!(code, _class) do
-    Map.get_lazy(@sgr_colors, code, fn ->
-      raise ArgumentError,
-            "no colour is mapped for SGR #{code}; add it to SurfaceSource " <>
-              "alongside the CSS that paints it"
-    end)
+  # Default foreground, leaving attributes in place.
+  defp apply_sgr!("39", style), do: %{style | color: nil}
+
+  defp apply_sgr!(code, style) do
+    cond do
+      color = Map.get(@sgr_colors, code) ->
+        %{style | color: color}
+
+      attribute = Map.get(@sgr_attributes, code) ->
+        %{style | attributes: Enum.uniq([attribute | style.attributes])}
+
+      cleared = Map.get(@sgr_resets, code) ->
+        %{style | attributes: style.attributes -- cleared}
+
+      true ->
+        raise ArgumentError,
+              "no styling is mapped for SGR #{code}; add it to SurfaceSource " <>
+                "alongside the CSS that paints it"
+    end
   end
 
   @doc """
@@ -180,8 +250,11 @@ defmodule RaxolPlayground.SurfaceSource do
   def ansi_html(rows) do
     Enum.map_join(rows, "\n", fn runs ->
       Enum.map_join(runs, "", fn
-        {nil, text} -> escape(text)
-        {class, text} -> ~s(<span class="#{class}">#{escape(text)}</span>)
+        {[], text} ->
+          escape(text)
+
+        {classes, text} ->
+          ~s(<span class="#{Enum.join(classes, " ")}">#{escape(text)}</span>)
       end)
     end)
   end
@@ -196,7 +269,9 @@ defmodule RaxolPlayground.SurfaceSource do
   @spec ansi_grid([[run()]]) :: %{rows: pos_integer(), cols: pos_integer()}
   def ansi_grid(rows) do
     widths =
-      Enum.map(rows, fn runs -> Enum.reduce(runs, 0, &(String.length(elem(&1, 1)) + &2)) end)
+      Enum.map(rows, fn runs ->
+        Enum.reduce(runs, 0, &(String.length(elem(&1, 1)) + &2))
+      end)
 
     %{rows: max(length(rows), 1), cols: max(Enum.max(widths, fn -> 1 end), 1)}
   end
@@ -247,14 +322,23 @@ defmodule RaxolPlayground.SurfaceSource do
   # Values first, so one containing a word is not re-marked as a tag.
   defp colorize(line, :dom) do
     line
-    |> String.replace(~r/&quot;([^&]*)&quot;/, ~S(&quot;<span class="hg">\1</span>&quot;))
+    |> String.replace(
+      ~r/&quot;([^&]*)&quot;/,
+      ~S(&quot;<span class="hg">\1</span>&quot;)
+    )
     |> String.replace(~r{&lt;(/?[a-z]+)}, ~S(&lt;<span class="hk">\1</span>))
   end
 
   defp colorize(line, :json) do
     line
-    |> String.replace(~r/&quot;([^&]*)&quot;:/, ~S(&quot;<span class="hk">\1</span>&quot;:))
-    |> String.replace(~r/: &quot;([^&]*)&quot;/, ~S(: &quot;<span class="hg">\1</span>&quot;))
+    |> String.replace(
+      ~r/&quot;([^&]*)&quot;:/,
+      ~S(&quot;<span class="hk">\1</span>&quot;:)
+    )
+    |> String.replace(
+      ~r/: &quot;([^&]*)&quot;/,
+      ~S(: &quot;<span class="hg">\1</span>&quot;)
+    )
   end
 
   defp dim_marker(html) do

--- a/web/lib/raxol_playground_web/components/core_components.ex
+++ b/web/lib/raxol_playground_web/components/core_components.ex
@@ -30,9 +30,13 @@ defmodule RaxolPlaygroundWeb.CoreComponents do
     doc: "used for styling and flash lookup"
   )
 
-  attr(:rest, :global, doc: "the arbitrary HTML attributes to add to the flash container")
+  attr(:rest, :global,
+    doc: "the arbitrary HTML attributes to add to the flash container"
+  )
 
-  slot(:inner_block, doc: "the optional inner block that renders the flash message")
+  slot(:inner_block,
+    doc: "the optional inner block that renders the flash message"
+  )
 
   def flash(assigns) do
     assigns = assign_new(assigns, :id, fn -> "flash-#{assigns.kind}" end)
@@ -71,7 +75,11 @@ defmodule RaxolPlaygroundWeb.CoreComponents do
       <.flash_group flash={@flash} />
   """
   attr(:flash, :map, required: true, doc: "the map of flash messages")
-  attr(:id, :string, default: "flash-group", doc: "the optional id of flash container")
+
+  attr(:id, :string,
+    default: "flash-group",
+    doc: "the optional id of flash container"
+  )
 
   def flash_group(assigns) do
     ~H"""

--- a/web/lib/raxol_playground_web/components/landing_components.ex
+++ b/web/lib/raxol_playground_web/components/landing_components.ex
@@ -167,7 +167,10 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   # the TUI wraps the same way).
   @halo_faces Jason.encode!(
                 for state <- [:idle, :thinking, :working, :done] do
-                  %{state: state, frames: for(f <- 0..3, do: AxolFace.glyph(state, f))}
+                  %{
+                    state: state,
+                    frames: for(f <- 0..3, do: AxolFace.glyph(state, f))
+                  }
                 end
               )
 
@@ -267,7 +270,8 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   attr(:example, :string, required: true)
 
   def screen_hero(assigns) do
-    assigns = assign(assigns, halo_faces: @halo_faces, network_count: @network_count)
+    assigns =
+      assign(assigns, halo_faces: @halo_faces, network_count: @network_count)
 
     ~H"""
     <%!-- The brand mark beside the claim rather than above it: an upright box
@@ -573,7 +577,8 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         out_browser: RecordedFrames.hero_surface(assigns.example, :browser),
         out_ssh: RecordedFrames.hero_surface(assigns.example, :ssh),
         out_mcp: RecordedFrames.hero_surface(assigns.example, :mcp),
-        browser_lines: RecordedFrames.hero_surface_lines(assigns.example, :browser),
+        browser_lines:
+          RecordedFrames.hero_surface_lines(assigns.example, :browser),
         ssh_grid: RecordedFrames.hero_ssh_grid(assigns.example),
         mcp_lines: RecordedFrames.hero_surface_lines(assigns.example, :mcp)
       )
@@ -662,7 +667,9 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   def hero_example_names, do: Enum.map(@hero_examples, &elem(&1, 0))
 
   defp example_title(name) do
-    Enum.find_value(@hero_examples, name, fn {n, t, _c, _l} -> n == name && t end)
+    Enum.find_value(@hero_examples, name, fn {n, t, _c, _l} ->
+      n == name && t
+    end)
   end
 
   @doc "Line and column counts of one example's source, as the pane sizes from."
@@ -932,8 +939,11 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   @token_order %{"USDC" => 0, "USDT" => 1, "USDG" => 2, "WETH" => 3}
 
   @payments_version Enum.find_value(Capabilities.packages(), fn
-                      %{name: "raxol_payments", version: v} -> String.replace(v, "~> ", "")
-                      _ -> nil
+                      %{name: "raxol_payments", version: v} ->
+                        String.replace(v, "~> ", "")
+
+                      _ ->
+                        nil
                     end)
 
   attr(:matrix, :map, required: true)
@@ -954,7 +964,8 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         token: @token,
         token_pair_url: @token_pair_url,
         rows: reach_rows(assigns.matrix),
-        show_future_svm: not Enum.any?(assigns.matrix.chains, &(&1.vm_type == :svm)),
+        show_future_svm:
+          not Enum.any?(assigns.matrix.chains, &(&1.vm_type == :svm)),
         live?: assigns.matrix.source == :live
       )
 

--- a/web/lib/raxol_playground_web/components/landing_components.ex
+++ b/web/lib/raxol_playground_web/components/landing_components.ex
@@ -227,23 +227,30 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   def screen_header(assigns) do
     ~H"""
     <header class="screen-header" role="banner">
-      <a href="/" class="screen-mark">raxol</a>
+      <%!-- The bar spans the viewport so its rule does; the row inside it is
+           held to the same measure as the hero, so the mark starts on the
+           h1's column instead of out in the gutter. --%>
+      <div class="screen-bar">
+        <a href="/" class="screen-mark">raxol</a>
 
-      <nav class="screen-nav" aria-label="Main navigation">
-        <a :for={{href, label} <- nav_links()} href={href} class="nav-link">{label}</a>
-      </nav>
+        <nav class="screen-nav" aria-label="Main navigation">
+          <a :for={{href, label} <- nav_links()} href={href} class="nav-link">{label}</a>
+        </nav>
 
-      <button
-        type="button"
-        phx-click="toggle_mobile_menu"
-        class="screen-menu-btn"
-        aria-label={if @mobile_menu_open, do: "Close menu", else: "Open menu"}
-        aria-expanded={to_string(@mobile_menu_open)}
-        aria-controls="screen-mobile-nav"
-      >
-        <span aria-hidden="true">{if @mobile_menu_open, do: "close", else: "menu"}</span>
-      </button>
+        <button
+          type="button"
+          phx-click="toggle_mobile_menu"
+          class="screen-menu-btn"
+          aria-label={if @mobile_menu_open, do: "Close menu", else: "Open menu"}
+          aria-expanded={to_string(@mobile_menu_open)}
+          aria-controls="screen-mobile-nav"
+        >
+          <span aria-hidden="true">{if @mobile_menu_open, do: "close", else: "menu"}</span>
+        </button>
+      </div>
 
+      <%!-- Outside the measured row: the overlay spans the header's full width
+           and anchors to it, so it drops directly under the button. --%>
       <nav
         :if={@mobile_menu_open}
         id="screen-mobile-nav"
@@ -389,14 +396,16 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   def screen_footer(assigns) do
     ~H"""
     <footer class="screen-footer" role="contentinfo">
-      <nav class="screen-topics" aria-label="Deep dives">
-        <a :for={{path, label} <- topic_links()} href={path} class="topic-link">{label}</a>
-      </nav>
+      <div class="screen-bar">
+        <nav class="screen-topics" aria-label="Deep dives">
+          <a :for={{path, label} <- topic_links()} href={path} class="topic-link">{label}</a>
+        </nav>
 
-      <span class="screen-meta">
-        v{Capabilities.version_minor()} &middot; {Capabilities.package_count()} packages &middot;
-        <a href="https://hex.pm/packages/raxol" class="subtle-link">Hex</a>
-      </span>
+        <span class="screen-meta">
+          v{Capabilities.version_minor()} &middot; {Capabilities.package_count()} packages &middot;
+          <a href="https://hex.pm/packages/raxol" class="subtle-link">Hex</a>
+        </span>
+      </div>
     </footer>
     """
   end
@@ -434,7 +443,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
          to first did not exist on five of them, and the brand link sat outside
          any landmark. Matches `screen_header` on the landing. --%>
     <header class="sticky top-0 z-50 surface-bar" role="banner">
-      <div class="max-w-5xl mx-auto px-6 py-3 flex items-center justify-between">
+      <div class="measure py-3 flex items-center justify-between">
         <a href="/" class="font-mono text-lg font-bold text-axol-coral tracking-wide">
           raxol
         </a>
@@ -565,7 +574,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         out_ssh: RecordedFrames.hero_surface(assigns.example, :ssh),
         out_mcp: RecordedFrames.hero_surface(assigns.example, :mcp),
         browser_lines: RecordedFrames.hero_surface_lines(assigns.example, :browser),
-        ssh_lines: RecordedFrames.hero_surface_lines(assigns.example, :ssh),
+        ssh_grid: RecordedFrames.hero_ssh_grid(assigns.example),
         mcp_lines: RecordedFrames.hero_surface_lines(assigns.example, :mcp)
       )
 
@@ -574,15 +583,29 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
          player caches its frame nodes, and patching them underneath it would
          leave it stepping elements that no longer exist. --%>
     <div id={"hero-demo-#{@example}"} phx-hook="HeroDemo" class="hero-demo mx-auto text-left">
+      <%!-- The player's controls live in the title bar, where a window's
+           controls belong and where nothing can clip them. They used to sit in
+           a footer below the panes: the demo box is height-capped, so on any
+           viewport too short for the one-screen layout the panes overflowed it
+           and `overflow: hidden` swallowed the footer whole -- the pause button
+           and the example switcher were unreachable, and scrolling did not help
+           because they were clipped in place rather than below the fold. --%>
       <div class="hero-demo-bar">
         <span class="hd-dot"></span><span class="hd-dot"></span><span class="hd-dot"></span>
         <span class="hd-title" data-role="title">{@title} -- rendering to the terminal</span>
+
+        <div class="hd-controls">
+          <button type="button" data-role="player-pause" class="hd-control">pause</button>
+          <button type="button" phx-click="next_example" class="hd-control hd-control--next">
+            {example_title(@next)} &rarr;
+          </button>
+        </div>
       </div>
 
       <div class="hero-tabs" role="tablist" aria-label="Render surface">
         <button type="button" class="hero-tab" role="tab" aria-selected="true" data-i="0" data-title={"#{@title} -- rendering to the terminal"} data-label="Rendered to the terminal">Terminal</button>
         <button type="button" class="hero-tab" role="tab" aria-selected="false" data-i="1" data-title={"#{@title} -- rendering to Phoenix LiveView"} data-label="The DOM LiveView patches">Browser</button>
-        <button type="button" class="hero-tab" role="tab" aria-selected="false" data-i="2" data-title={"#{@title} -- served over SSH"} data-label="The bytes down the channel">SSH</button>
+        <button type="button" class="hero-tab" role="tab" aria-selected="false" data-i="2" data-title={"#{@title} -- served over SSH"} data-label="The same frame, painted down a channel">SSH</button>
         <button type="button" class="hero-tab" role="tab" aria-selected="false" data-i="3" data-title={"#{@title} -- exposed as MCP tools"} data-label="The tree an agent reads">Agent / MCP</button>
       </div>
 
@@ -612,9 +635,16 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
             <pre class="hero-pre hero-src" style={"--src-lines: #{@browser_lines}"}>{raw(@out_browser)}</pre>
           </div>
 
+          <%!-- SSH is the one non-terminal surface that delivers a picture
+               rather than a description of one, so it is painted rather than
+               listed: same frame, same colours, same two-axis fit as the
+               terminal pane, reached over a channel instead of a local tty.
+               That IS the claim the tab makes. --%>
           <div class="hero-out" data-surface="2" hidden>
             <pre class="hero-pre hero-cmd" aria-hidden="true"><span class="hc">$ ssh demo@localhost -p 2222</span></pre>
-            <pre class="hero-pre hero-src" style={"--src-lines: #{@ssh_lines}"}>{raw(@out_ssh)}</pre>
+            <div class="hero-frames raxol-terminal bg-synthwave-bg" data-theme="synthwave84" aria-hidden="true" style={"--frame-rows: #{@ssh_grid.rows}; --frame-cols: #{@ssh_grid.cols}"}>
+              <pre class="hero-ansi">{raw(@out_ssh)}</pre>
+            </div>
           </div>
 
           <div class="hero-out" data-surface="3" hidden>
@@ -624,22 +654,6 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         </div>
       </div>
 
-      <div class="hero-demo-foot">
-        <button
-          type="button"
-          data-role="player-pause"
-          class="label-text cursor-pointer hover:text-pearl-80 transition-colors"
-        >
-          pause
-        </button>
-        <button
-          type="button"
-          phx-click="next_example"
-          class="label-text cursor-pointer text-axol-coral hover:text-pearl-80 transition-colors"
-        >
-          {example_title(@next)} &rarr;
-        </button>
-      </div>
     </div>
     """
   end
@@ -676,7 +690,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     assigns = assign(assigns, :counter_code, @counter_code)
 
     ~H"""
-    <section class="landing-section px-6 py-12 md:py-20 max-w-5xl mx-auto" aria-labelledby="code-title">
+    <section class="landing-section py-12 md:py-20 measure" aria-labelledby="code-title">
       <h2 id="code-title" class="heading-2xl mb-3">Hello World</h2>
       <p class="body-text mb-8 max-w-2xl">
         Every Raxol app follows The Elm Architecture:
@@ -705,7 +719,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
   def surfaces_deep_dive(assigns) do
     ~H"""
-    <section class="landing-section px-6 py-14 md:py-24 max-w-5xl mx-auto" aria-labelledby="surfaces-title">
+    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="surfaces-title">
       <div class="mb-10">
         <span class="section-numeral" aria-hidden="true">01</span>
         <span class="section-eyebrow">Surfaces</span>
@@ -774,7 +788,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
   def ssh_deep_dive(assigns) do
     ~H"""
-    <section class="landing-section px-6 py-14 md:py-24 max-w-5xl mx-auto" aria-labelledby="ssh-deep-title">
+    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="ssh-deep-title">
       <div class="grid grid-cols-1 md:grid-cols-2 gap-8 md:gap-12 items-center">
         <div>
           <span class="section-numeral" aria-hidden="true">02</span>
@@ -808,7 +822,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     assigns = assign(assigns, :agent_code, @agent_code)
 
     ~H"""
-    <section class="landing-section px-6 py-14 md:py-24 max-w-5xl mx-auto" aria-labelledby="agent-deep-title">
+    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="agent-deep-title">
       <div class="mb-8">
         <span class="section-numeral" aria-hidden="true">03</span>
         <span class="section-eyebrow">Agent runtime</span>
@@ -844,7 +858,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
   def coding_agent_deep_dive(assigns) do
     ~H"""
-    <section class="landing-section px-6 py-14 md:py-24 max-w-5xl mx-auto" aria-labelledby="coding-agent-title">
+    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="coding-agent-title">
       <div class="mb-8">
         <span class="section-numeral" aria-hidden="true">04</span>
         <span class="section-eyebrow">Coding agent</span>
@@ -945,7 +959,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
       )
 
     ~H"""
-    <section class="landing-section px-6 py-14 md:py-24 max-w-5xl mx-auto" aria-labelledby="payments-title">
+    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="payments-title">
       <div class="mb-8">
         <span class="section-numeral" aria-hidden="true">05</span>
         <span class="section-eyebrow">Agent payments</span>
@@ -1110,7 +1124,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
   def features_section(assigns) do
     ~H"""
-    <section class="landing-section px-6 py-14 md:py-24 max-w-5xl mx-auto" aria-labelledby="features-title">
+    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="features-title">
       <span class="section-eyebrow">More capabilities</span>
       <h2 id="features-title" class="heading-2xl mb-10">What OTP gives you.</h2>
 
@@ -1148,7 +1162,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
   def packages_section(assigns) do
     ~H"""
-    <section class="landing-section px-6 py-12 md:py-20 max-w-5xl mx-auto" aria-labelledby="packages-title">
+    <section class="landing-section py-12 md:py-20 measure" aria-labelledby="packages-title">
       <h2 id="packages-title" class="heading-2xl mb-3">Pick what you need</h2>
       <p class="body-text mb-10 max-w-2xl">Full framework or just the parts that matter.</p>
 
@@ -1197,7 +1211,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     assigns = assign(assigns, :faqs, @faqs)
 
     ~H"""
-    <section class="landing-section px-6 py-14 md:py-24 max-w-5xl mx-auto" aria-labelledby="faq-title">
+    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="faq-title">
       <span class="section-eyebrow">FAQ</span>
       <h2 id="faq-title" class="heading-2xl mb-10">Questions, answered.</h2>
       <div class="faq-list max-w-3xl">
@@ -1220,7 +1234,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     assigns = assign(assigns, :install_command, @install_command)
 
     ~H"""
-    <section class="landing-section px-6 py-12 md:py-20 max-w-5xl mx-auto" aria-labelledby="try-title">
+    <section class="landing-section py-12 md:py-20 measure" aria-labelledby="try-title">
       <h2 id="try-title" class="heading-2xl mb-3">One module away from every surface.</h2>
       <p class="body-text mb-10 max-w-2xl">Starting is genuinely four commands.</p>
 
@@ -1243,21 +1257,20 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   # Footer
   # ---------------------------------------------------------------------------
 
+  @doc """
+  The topic pages' footer: a signature, not a second navigation.
+
+  It used to carry GitHub, Hex.pm, Docs, Playground and Skill. Four of those
+  five are in `nav_links/0`, three inches above on the same page, so the row
+  restated the header rather than adding to it -- a third of the page's links
+  pointing where the header already pointed. Hex.pm was the one destination it
+  owned, and the landing footer's meta line already carries it.
+  """
   def footer_section(assigns) do
     ~H"""
-    <footer class="landing-section px-6 py-16 border-t border-subtle">
-      <div class="max-w-5xl mx-auto">
-        <div class="flex flex-wrap gap-6 font-mono mb-10 tracking-wide text-sm">
-          <a href="https://github.com/DROOdotFOO/raxol" class="footer-link">GitHub</a>
-          <a href="https://hex.pm/packages/raxol" class="footer-link">Hex.pm</a>
-          <a href="https://hexdocs.pm/raxol" class="footer-link">Docs</a>
-          <a href="/playground" class="footer-link">Playground</a>
-          <a href="/skill.md" class="footer-link">Skill</a>
-        </div>
-
-        <div class="flex items-center justify-end font-mono caption-text tracking-wide">
-          <span>Made by <a href="https://axol.io" class="axol-link">axol.io</a></span>
-        </div>
+    <footer class="landing-section py-16 border-t border-subtle" role="contentinfo">
+      <div class="measure flex items-center justify-end font-mono caption-text tracking-wide">
+        <span>Made by <a href="https://axol.io" class="axol-link">axol.io</a></span>
       </div>
     </footer>
     """

--- a/web/lib/raxol_playground_web/controllers/capabilities_controller.ex
+++ b/web/lib/raxol_playground_web/controllers/capabilities_controller.ex
@@ -13,7 +13,10 @@ defmodule RaxolPlaygroundWeb.CapabilitiesController do
   alias RaxolPlayground.Capabilities
 
   @llms_txt_path Path.join(:code.priv_dir(:raxol_playground), "static/llms.txt")
-  @llms_full_path Path.join(:code.priv_dir(:raxol_playground), "static/llms-full.txt")
+  @llms_full_path Path.join(
+                    :code.priv_dir(:raxol_playground),
+                    "static/llms-full.txt"
+                  )
 
   def manifest(conn, _params) do
     json(conn, %{
@@ -45,13 +48,17 @@ defmodule RaxolPlaygroundWeb.CapabilitiesController do
 
   def llms_txt(conn, _params), do: serve_text(conn, @llms_txt_path, "llms.txt")
 
-  def llms_full(conn, _params), do: serve_text(conn, @llms_full_path, "llms-full.txt")
+  def llms_full(conn, _params),
+    do: serve_text(conn, @llms_full_path, "llms-full.txt")
 
   defp serve_text(conn, path, name) do
     content =
       case File.read(path) do
-        {:ok, data} -> data
-        {:error, _} -> "# Raxol\n\n#{name} not found. Run `mix raxol.docs.llms`."
+        {:ok, data} ->
+          data
+
+        {:error, _} ->
+          "# Raxol\n\n#{name} not found. Run `mix raxol.docs.llms`."
       end
 
     conn

--- a/web/lib/raxol_playground_web/controllers/health_controller.ex
+++ b/web/lib/raxol_playground_web/controllers/health_controller.ex
@@ -1,8 +1,12 @@
 defmodule RaxolPlaygroundWeb.HealthController do
   use RaxolPlaygroundWeb, :controller
 
-  @memory_warn_mb String.to_integer(System.get_env("HEALTH_MEMORY_WARN_MB") || "500")
-  @memory_crit_mb String.to_integer(System.get_env("HEALTH_MEMORY_CRIT_MB") || "900")
+  @memory_warn_mb String.to_integer(
+                    System.get_env("HEALTH_MEMORY_WARN_MB") || "500"
+                  )
+  @memory_crit_mb String.to_integer(
+                    System.get_env("HEALTH_MEMORY_CRIT_MB") || "900"
+                  )
 
   def check(conn, _params) do
     checks = %{
@@ -15,7 +19,8 @@ defmodule RaxolPlaygroundWeb.HealthController do
     # PubSub down breaks LiveView, and critical memory is unsafe. SSH is an
     # optional playground extra and a memory "warning" is tolerable, so neither
     # degrades the service to 503; the JSON still reports the real state.
-    critical? = checks.pubsub in ["down", "error"] or checks.memory == "critical"
+    critical? =
+      checks.pubsub in ["down", "error"] or checks.memory == "critical"
 
     all_ok = Enum.all?(checks, fn {_k, v} -> v in ["ok", "not_configured"] end)
 

--- a/web/lib/raxol_playground_web/live/demo_live.ex
+++ b/web/lib/raxol_playground_web/live/demo_live.ex
@@ -73,7 +73,8 @@ defmodule RaxolPlaygroundWeb.DemoLive do
       # carry a nil component.
       component =
         Catalog.get_component(name) ||
-          raise RaxolPlaygroundWeb.NotFoundError, "no demo named #{inspect(name)}"
+          raise RaxolPlaygroundWeb.NotFoundError,
+                "no demo named #{inspect(name)}"
 
       pos = catalog_position(name)
 

--- a/web/lib/raxol_playground_web/live/gallery_live.ex
+++ b/web/lib/raxol_playground_web/live/gallery_live.ex
@@ -37,7 +37,10 @@ defmodule RaxolPlaygroundWeb.GalleryLive do
   end
 
   def handle_event("filter_category", %{"category" => category}, socket) do
-    {:noreply, refilter(assign(socket, :active_category, String.to_existing_atom(category)))}
+    {:noreply,
+     refilter(
+       assign(socket, :active_category, String.to_existing_atom(category))
+     )}
   rescue
     ArgumentError -> {:noreply, socket}
   end
@@ -55,7 +58,10 @@ defmodule RaxolPlaygroundWeb.GalleryLive do
   end
 
   def handle_event("filter_complexity", %{"level" => level}, socket) do
-    {:noreply, refilter(assign(socket, :complexity_filter, String.to_existing_atom(level)))}
+    {:noreply,
+     refilter(
+       assign(socket, :complexity_filter, String.to_existing_atom(level))
+     )}
   rescue
     ArgumentError -> {:noreply, socket}
   end
@@ -204,7 +210,8 @@ defmodule RaxolPlaygroundWeb.GalleryLive do
   end
 
   defp component_card(assigns) do
-    assigns = assign(assigns, :preview, RecordedFrames.preview(assigns.component.name))
+    assigns =
+      assign(assigns, :preview, RecordedFrames.preview(assigns.component.name))
 
     ~H"""
     <div class="panel panel--glow transition-all duration-200 overflow-hidden flex flex-col">

--- a/web/lib/raxol_playground_web/live/landing_live.ex
+++ b/web/lib/raxol_playground_web/live/landing_live.ex
@@ -37,7 +37,9 @@ defmodule RaxolPlaygroundWeb.LandingLive do
        # XOCHI_CAPABILITIES_BASE_URL) skips the network entirely and serves
        # the static fallback, which renders as a "cached" badge.
        xochi_matrix:
-         XochiCapabilities.get(Application.get_env(:raxol_playground, :xochi_capabilities))
+         XochiCapabilities.get(
+           Application.get_env(:raxol_playground, :xochi_capabilities)
+         )
      )}
   end
 
@@ -49,7 +51,9 @@ defmodule RaxolPlaygroundWeb.LandingLive do
   def handle_event("next_example", _params, socket) do
     names = hero_example_names()
     idx = Enum.find_index(names, &(&1 == socket.assigns.example)) || 0
-    {:noreply, assign(socket, :example, Enum.at(names, rem(idx + 1, length(names))))}
+
+    {:noreply,
+     assign(socket, :example, Enum.at(names, rem(idx + 1, length(names))))}
   end
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}

--- a/web/lib/raxol_playground_web/live/playground/demo_lifecycle.ex
+++ b/web/lib/raxol_playground_web/live/playground/demo_lifecycle.ex
@@ -63,7 +63,9 @@ defmodule RaxolPlaygroundWeb.Playground.DemoLifecycle do
         end
       rescue
         e ->
-          Logger.warning("Demo #{component.name} failed: #{Exception.message(e)}")
+          Logger.warning(
+            "Demo #{component.name} failed: #{Exception.message(e)}"
+          )
 
           assign(socket, demo_error: "Failed to start demo")
       catch

--- a/web/lib/raxol_playground_web/live/playground_live.ex
+++ b/web/lib/raxol_playground_web/live/playground_live.ex
@@ -115,7 +115,9 @@ defmodule RaxolPlaygroundWeb.PlaygroundLive do
         {:noreply, socket}
 
       comps ->
-        idx = Enum.find_index(comps, &selected?(socket.assigns.selected, &1)) || 0
+        idx =
+          Enum.find_index(comps, &selected?(socket.assigns.selected, &1)) || 0
+
         step = if dir == "next", do: 1, else: -1
         next = Enum.at(comps, Integer.mod(idx + step, length(comps)))
         handle_event("select_component", %{"component" => next.name}, socket)
@@ -126,7 +128,8 @@ defmodule RaxolPlaygroundWeb.PlaygroundLive do
     search = if query == "", do: nil, else: query
     components = sort_components(Catalog.filter(search: search))
 
-    {:noreply, socket |> assign(:search_query, query) |> assign(:components, components)}
+    {:noreply,
+     socket |> assign(:search_query, query) |> assign(:components, components)}
   end
 
   def handle_event("toggle_code", _params, socket) do
@@ -138,7 +141,8 @@ defmodule RaxolPlaygroundWeb.PlaygroundLive do
   end
 
   def handle_event("toggle_users_panel", _params, socket) do
-    {:noreply, assign(socket, :show_users_panel, !socket.assigns.show_users_panel)}
+    {:noreply,
+     assign(socket, :show_users_panel, !socket.assigns.show_users_panel)}
   end
 
   def handle_event("toggle_sync", _params, socket) do
@@ -146,7 +150,8 @@ defmodule RaxolPlaygroundWeb.PlaygroundLive do
   end
 
   def handle_event("toggle_sidebar", _params, socket) do
-    {:noreply, assign(socket, :sidebar_collapsed, !socket.assigns.sidebar_collapsed)}
+    {:noreply,
+     assign(socket, :sidebar_collapsed, !socket.assigns.sidebar_collapsed)}
   end
 
   def handle_event("select_theme", %{"theme" => theme}, socket) do
@@ -205,10 +210,12 @@ defmodule RaxolPlaygroundWeb.PlaygroundLive do
     do: {:noreply, DemoLifecycle.render_update(socket, html)}
 
   def handle_info(%Phoenix.Socket.Broadcast{event: "presence_diff"}, socket),
-    do: {:noreply, assign(socket, :online_users, PlaygroundPresence.list_users())}
+    do:
+      {:noreply, assign(socket, :online_users, PlaygroundPresence.list_users())}
 
   def handle_info(
-        {:playground_event, :component_selected, %{component: name, user_id: from}},
+        {:playground_event, :component_selected,
+         %{component: name, user_id: from}},
         socket
       ) do
     if socket.assigns.sync_enabled and from != socket.assigns.user_id do
@@ -410,7 +417,8 @@ defmodule RaxolPlaygroundWeb.PlaygroundLive do
     # category, dense name-only rows underneath. @components is already
     # category-sorted (sort_components/1), so chunking cannot split a
     # category into duplicate runs and j/k follows the visual order.
-    assigns = assign(assigns, :groups, Enum.chunk_by(assigns.components, & &1.category))
+    assigns =
+      assign(assigns, :groups, Enum.chunk_by(assigns.components, & &1.category))
 
     ~H"""
     <aside class={[

--- a/web/lib/raxol_playground_web/live/topic_live.ex
+++ b/web/lib/raxol_playground_web/live/topic_live.ex
@@ -81,7 +81,7 @@ defmodule RaxolPlaygroundWeb.TopicLive do
     <div class="relative z-10">
       <.nav_bar mobile_menu_open={@mobile_menu_open} />
       <main id="main-content" tabindex="-1">
-        <nav class="topic-crumb max-w-5xl mx-auto px-6 pt-8" aria-label="Breadcrumb">
+        <nav class="topic-crumb measure pt-8" aria-label="Breadcrumb">
           <a href="/" class="subtle-link">raxol</a>
           <span aria-hidden="true">/</span>
           <span aria-current="page"><%= @title %></span>
@@ -89,7 +89,7 @@ defmodule RaxolPlaygroundWeb.TopicLive do
 
         <.topic_body topic={@live_action} matrix={@xochi_matrix} />
 
-        <div class="max-w-5xl mx-auto px-6 pb-16">
+        <div class="measure pb-16">
           <a href="/" class="subtle-link">&larr; back</a>
         </div>
       </main>

--- a/web/test/raxol_playground_web/landing_components_test.exs
+++ b/web/test/raxol_playground_web/landing_components_test.exs
@@ -65,9 +65,9 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
 
   # The hero claims one module reaches four surfaces, each pane an encoding of
   # one recorded render. These two tests stop a pane reverting to authored text.
-  test "every non-terminal hero pane is a recorded artifact, line for line" do
+  test "every listed hero pane is a recorded artifact, line for line" do
     for name <- LandingComponents.hero_example_names(),
-        surface <- [:browser, :ssh, :mcp] do
+        surface <- [:browser, :mcp] do
       artifact = RecordedFrames.hero_artifact(name, surface)
       pane = RecordedFrames.hero_surface(name, surface)
 
@@ -79,7 +79,7 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       body = if marker?, do: Enum.drop(lines, -1), else: lines
 
       for line <- body do
-        assert String.contains?(artifact, unspell(line, surface)),
+        assert String.contains?(artifact, line),
                "#{name}/#{surface} shows a line that is not in the artifact:\n#{inspect(line)}"
       end
 
@@ -94,6 +94,63 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
                "#{name}/#{surface} shows #{length(body)} of #{length(full)} lines and says nothing"
       end
     end
+  end
+
+  # The SSH pane is painted rather than listed, so it gets its own invariant:
+  # the whole recording, in colour, with nothing authored and nothing dropped.
+  test "the SSH pane paints the whole recording and invents nothing" do
+    for name <- LandingComponents.hero_example_names() do
+      artifact = RecordedFrames.hero_artifact(name, :ssh)
+      pane = RecordedFrames.hero_surface(name, :ssh)
+
+      assert artifact != "", "#{name}/ssh has no recorded artifact"
+
+      # The regression this pane exists to not have: escape codes on screen
+      # read as a terminal failing to render, on the one tab that claims a
+      # terminal works.
+      refute pane =~ "ESC[",
+             "#{name}/ssh is showing escape codes as text again"
+
+      # Painted, not merely stripped -- the colours are the frame.
+      assert pane =~ ~s(class="ansi-),
+             "#{name}/ssh dropped its colour instead of painting it"
+
+      # Every character the artifact paints, and only those.
+      assert pane |> pane_lines() |> Enum.join("\n") ==
+               artifact |> strip_ansi() |> String.trim_trailing("\n"),
+             "#{name}/ssh does not show exactly what the recording paints"
+
+      # The grid the CSS fits type to describes the frame it is given.
+      grid = RecordedFrames.hero_ssh_grid(name)
+      rows = artifact |> strip_ansi() |> String.trim_trailing("\n") |> String.split("\n")
+
+      assert grid.rows == length(rows)
+      assert grid.cols == rows |> Enum.map(&String.length/1) |> Enum.max()
+    end
+  end
+
+  # A recording is a build input, so a code with no colour behind it has to stop
+  # the build rather than reach the page as an unstyled run.
+  test "an unpaintable escape sequence fails loudly, not silently" do
+    assert_raise ArgumentError, ~r/no colour is mapped for SGR 7/, fn ->
+      SurfaceSource.ansi_rows("\e[7mreversed\e[0m")
+    end
+
+    assert_raise ArgumentError, ~r/is not an SGR sequence/, fn ->
+      SurfaceSource.ansi_rows("\e[2Jcleared")
+    end
+  end
+
+  # Colour is terminal state, not per-row markup: a run left open at the end of
+  # one row still colours the next, the way it does down a real channel.
+  test "colour carries across rows until it is reset" do
+    rows = SurfaceSource.ansi_rows("\e[36mone\ntwo\e[0m\nthree")
+
+    assert rows == [
+             [{"ansi-cyan", "one"}],
+             [{"ansi-cyan", "two"}],
+             [{nil, "three"}]
+           ]
   end
 
   # The hero shows a program's source; the frames beside it are that program's
@@ -347,8 +404,9 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
   end
 
   defp break_lines(artifact, :browser), do: SurfaceSource.dom_lines(artifact)
-  defp break_lines(artifact, :ssh), do: SurfaceSource.ansi_lines(artifact)
   defp break_lines(artifact, :mcp), do: SurfaceSource.json_lines(artifact)
+
+  defp strip_ansi(text), do: String.replace(text, ~r/\e\[[0-9;?]*[A-Za-z]/, "")
 
   # Undoes SurfaceSource's colour spans and escaping, leaving the lines as its
   # line-breaking produced them.
@@ -358,10 +416,6 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     |> unescape()
     |> String.split("\n")
   end
-
-  # ANSI lines carry ESC spelled out; put the byte back before checking.
-  defp unspell(line, :ssh), do: String.replace(line, "ESC", "\e")
-  defp unspell(line, _surface), do: line
 
   defp unescape(text) do
     # &amp; last, or an escaped &amp;lt; would come back as a literal <.

--- a/web/test/raxol_playground_web/landing_components_test.exs
+++ b/web/test/raxol_playground_web/landing_components_test.exs
@@ -55,7 +55,9 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     for name <- LandingComponents.hero_example_names() do
       frames = RaxolPlayground.RecordedFrames.hero_frames(name)
 
-      assert length(frames) > 1, "#{name} has #{length(frames)} recorded frame(s)"
+      assert length(frames) > 1,
+             "#{name} has #{length(frames)} recorded frame(s)"
+
       assert Enum.uniq(frames) == frames, "#{name} recorded identical frames"
 
       hero = render_component(&LandingComponents.screen_hero/1, example: name)
@@ -122,17 +124,22 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
 
       # The grid the CSS fits type to describes the frame it is given.
       grid = RecordedFrames.hero_ssh_grid(name)
-      rows = artifact |> strip_ansi() |> String.trim_trailing("\n") |> String.split("\n")
+
+      rows =
+        artifact
+        |> strip_ansi()
+        |> String.trim_trailing("\n")
+        |> String.split("\n")
 
       assert grid.rows == length(rows)
       assert grid.cols == rows |> Enum.map(&String.length/1) |> Enum.max()
     end
   end
 
-  # A recording is a build input, so a code with no colour behind it has to stop
-  # the build rather than reach the page as an unstyled run.
+  # A recording is a build input, so a code with no styling behind it has to
+  # stop the build rather than reach the page as an unstyled run.
   test "an unpaintable escape sequence fails loudly, not silently" do
-    assert_raise ArgumentError, ~r/no colour is mapped for SGR 7/, fn ->
+    assert_raise ArgumentError, ~r/no styling is mapped for SGR 7/, fn ->
       SurfaceSource.ansi_rows("\e[7mreversed\e[0m")
     end
 
@@ -147,10 +154,100 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     rows = SurfaceSource.ansi_rows("\e[36mone\ntwo\e[0m\nthree")
 
     assert rows == [
-             [{"ansi-cyan", "one"}],
-             [{"ansi-cyan", "two"}],
-             [{nil, "three"}]
+             [{["ansi-cyan"], "one"}],
+             [{["ansi-cyan"], "two"}],
+             [{[], "three"}]
            ]
+  end
+
+  # Intensity and emphasis are orthogonal to colour, so a run holds a SET of
+  # classes. Holding one meant `bold cyan` had nowhere to go and the decoder
+  # raised on SGR 1 -- which `text(..., style: [:bold])` emits, so promoting an
+  # ordinary catalog demo to a hero example failed the build on a code its own
+  # recording legitimately contained.
+  describe "attributes compose with colour" do
+    test "bold and colour are both carried" do
+      assert [[{classes, "hi"}]] = SurfaceSource.ansi_rows("\e[36m\e[1mhi\e[0m")
+      assert classes == ["ansi-cyan", "ansi-bold"]
+    end
+
+    test "a combined parameter list is applied in order" do
+      assert [[{classes, "hi"}]] = SurfaceSource.ansi_rows("\e[1;33mhi\e[0m")
+      assert classes == ["ansi-yellow", "ansi-bold"]
+    end
+
+    test "every attribute the demos use decodes" do
+      for {seq, class} <- [
+            {"1", "ansi-bold"},
+            {"2", "ansi-dim"},
+            {"3", "ansi-italic"},
+            {"4", "ansi-underline"}
+          ] do
+        assert [[{[^class], "x"}]] = SurfaceSource.ansi_rows("\e[#{seq}mx\e[0m")
+      end
+    end
+
+    test "bright colours decode" do
+      assert [[{["ansi-bright-cyan"], "x"}]] =
+               SurfaceSource.ansi_rows("\e[96mx\e[0m")
+    end
+
+    test "22 clears intensity but leaves colour" do
+      assert [[_bold, {classes, "b"}]] =
+               SurfaceSource.ansi_rows("\e[36;1ma\e[22mb\e[0m")
+
+      assert classes == ["ansi-cyan"]
+    end
+
+    test "39 clears colour but leaves attributes" do
+      assert [[_first, {classes, "b"}]] =
+               SurfaceSource.ansi_rows("\e[36;1ma\e[39mb\e[0m")
+
+      assert classes == ["ansi-bold"]
+    end
+
+    test "attributes carry across rows like colour does" do
+      rows = SurfaceSource.ansi_rows("\e[1mone\ntwo\e[0m\nthree")
+
+      assert rows == [
+               [{["ansi-bold"], "one"}],
+               [{["ansi-bold"], "two"}],
+               [{[], "three"}]
+             ]
+    end
+
+    test "the markup names every class the run carries" do
+      html =
+        "\e[36;1mhi\e[0m"
+        |> SurfaceSource.ansi_rows()
+        |> SurfaceSource.ansi_html()
+
+      assert html == ~s(<span class="ansi-cyan ansi-bold">hi</span>)
+    end
+
+    # The decoder refuses a code it has no class for, which stops an unstyled
+    # run reaching the page. It cannot tell whether the class it DOES emit is
+    # painted by anything, so a mapping added without its CSS would render as
+    # plain text and every test above would still pass.
+    @app_css Path.expand("../../assets/css/app.css", __DIR__)
+    @external_resource @app_css
+
+    test "every class the decoder can emit is painted by the stylesheet" do
+      css = File.read!(@app_css)
+
+      codes =
+        Enum.map(30..37, &to_string/1) ++
+          Enum.map(90..97, &to_string/1) ++ ["1", "2", "3", "4"]
+
+      for code <- codes do
+        assert [[{classes, "x"}]] = SurfaceSource.ansi_rows("\e[#{code}mx\e[0m")
+
+        for class <- classes do
+          assert css =~ ".#{class} ",
+                 "SGR #{code} decodes to .#{class}, which app.css does not paint"
+        end
+      end
+    end
   end
 
   # The hero shows a program's source; the frames beside it are that program's
@@ -165,11 +262,16 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
 
     landing =
       File.read!(
-        Path.expand("../../lib/raxol_playground_web/components/landing_components.ex", __DIR__)
+        Path.expand(
+          "../../lib/raxol_playground_web/components/landing_components.ex",
+          __DIR__
+        )
       )
 
     for {name, module} <- [{"pulse", "Pulse"}, {"halo", "Halo"}] do
-      assert [_, tail] = String.split(landing, "@#{name}_source ~S\"\"\"\n", parts: 2)
+      assert [_, tail] =
+               String.split(landing, "@#{name}_source ~S\"\"\"\n", parts: 2)
+
       assert [heredoc, _] = String.split(tail, "\n  \"\"\"", parts: 2)
 
       shown =
@@ -323,13 +425,17 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
   # its name. Both directions are held: a mark left behind for something no
   # longer offered would otherwise rot in the directory unnoticed.
   test "marks decorate the derived entries without narrowing them" do
-    entries = Enum.flat_map(LandingComponents.integration_groups(), &elem(&1, 1))
+    entries =
+      Enum.flat_map(LandingComponents.integration_groups(), &elem(&1, 1))
+
     row = render_component(&LandingComponents.screen_integrations/1, %{})
     names = Enum.map(entries, & &1.name)
 
     for entry <- entries do
       shown = if entry.mark, do: entry.label, else: entry.name
-      assert row =~ ">#{shown}</span>", "the row drops #{entry.name}, which is derived"
+
+      assert row =~ ">#{shown}</span>",
+             "the row drops #{entry.name}, which is derived"
     end
 
     for name <- BrandMarks.known() do
@@ -339,7 +445,9 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     # Two runs are rendered: the visible one and the aria-hidden copy the loop
     # needs, so every marked entry appears twice.
     marked = Enum.filter(entries, & &1.mark)
-    assert length(String.split(row, "integrations-item--marked")) - 1 == length(marked) * 2
+
+    assert length(String.split(row, "integrations-item--marked")) - 1 ==
+             length(marked) * 2
 
     # The no-mark path has to be live, not theoretical. Were every entry to
     # gain a mark this test would still pass while the fallback rotted, so the
@@ -359,7 +467,8 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       Capabilities.connectable_providers()
       |> Enum.filter(&(&1.label != &1.name and BrandMarks.path(&1.name)))
 
-    assert qualified != [], "no marked provider carries a qualifier worth revealing"
+    assert qualified != [],
+           "no marked provider carries a qualifier worth revealing"
 
     for %{label: label} <- qualified do
       assert row =~ ">#{label}</span>", "the row never reveals #{label} in full"
@@ -369,7 +478,9 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     # row stays scannable and does not widen to fit every qualifier.
     for %{name: name, label: label} <- Capabilities.connectable_providers(),
         is_nil(BrandMarks.path(name)) and label != name do
-      assert row =~ ">#{name}</span>", "#{name} should sit in the flow unqualified"
+      assert row =~ ">#{name}</span>",
+             "#{name} should sit in the flow unqualified"
+
       refute row =~ ">#{label}</span>"
     end
   end
@@ -387,7 +498,9 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     for name <- BrandMarks.known() do
       d = BrandMarks.path(name)
       assert is_binary(d) and d != "", "#{name} has an empty mark"
-      assert String.starts_with?(d, ["M", "m"]), "#{name}'s mark is not path data"
+
+      assert String.starts_with?(d, ["M", "m"]),
+             "#{name}'s mark is not path data"
     end
   end
 
@@ -486,8 +599,11 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
   end
 
   test "nav links the demo index on desktop and mobile" do
-    closed = render_component(&LandingComponents.nav_bar/1, mobile_menu_open: false)
-    open = render_component(&LandingComponents.nav_bar/1, mobile_menu_open: true)
+    closed =
+      render_component(&LandingComponents.nav_bar/1, mobile_menu_open: false)
+
+    open =
+      render_component(&LandingComponents.nav_bar/1, mobile_menu_open: true)
 
     assert closed =~ ~s(href="/demos")
     assert open =~ ~s(href="/demos")
@@ -500,8 +616,16 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       %{chain_id: 728_126_428, chain_name: "Tron", vm_type: :tvm}
     ],
     tokens: [
-      %{symbol: "WETH", roles: [:origin, :destination], addresses: %{8453 => "0xweth"}},
-      %{symbol: "USDC", roles: [:origin, :destination], addresses: %{8453 => "0xabc"}},
+      %{
+        symbol: "WETH",
+        roles: [:origin, :destination],
+        addresses: %{8453 => "0xweth"}
+      },
+      %{
+        symbol: "USDC",
+        roles: [:origin, :destination],
+        addresses: %{8453 => "0xabc"}
+      },
       %{
         symbol: "USDT",
         roles: [:origin, :destination],
@@ -512,7 +636,10 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
   }
 
   test "payments section renders the ladder, dated proof, and a live matrix honestly" do
-    payments = render_component(&LandingComponents.payments_deep_dive/1, matrix: @live_matrix)
+    payments =
+      render_component(&LandingComponents.payments_deep_dive/1,
+        matrix: @live_matrix
+      )
 
     # Dated proof leads; maturity is labeled.
     assert payments =~ "2026-06-28"
@@ -570,7 +697,11 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
 
   test "an unreachable solver renders the cached badge, never fake liveness" do
     fallback = Raxol.Payments.Xochi.Capabilities.fallback()
-    payments = render_component(&LandingComponents.payments_deep_dive/1, matrix: fallback)
+
+    payments =
+      render_component(&LandingComponents.payments_deep_dive/1,
+        matrix: fallback
+      )
 
     assert payments =~ "source: cached"
     refute payments =~ "source: live"
@@ -581,7 +712,10 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
   # Pinned: these are the only strings on the site meant to be pasted into a
   # chain explorer, and a wrong character looks identical to a right one.
   test "the token block prints the verified contract and no market numbers" do
-    payments = render_component(&LandingComponents.payments_deep_dive/1, matrix: @live_matrix)
+    payments =
+      render_component(&LandingComponents.payments_deep_dive/1,
+        matrix: @live_matrix
+      )
 
     assert payments =~ "$RAXOL"
     assert payments =~ "0xf44702b17d9abD53815F703e772F35E9c71A53af"
@@ -643,9 +777,14 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       refute Capabilities.ssh_available?()
       assert Capabilities.ssh_command() == nil
 
-      banner = render_component(&PlaygroundComponents.ssh_callout/1, variant: :banner)
-      footer = render_component(&PlaygroundComponents.ssh_callout/1, variant: :footer)
-      fallback = render_component(&PlaygroundComponents.terminal_fallback/1, %{})
+      banner =
+        render_component(&PlaygroundComponents.ssh_callout/1, variant: :banner)
+
+      footer =
+        render_component(&PlaygroundComponents.ssh_callout/1, variant: :footer)
+
+      fallback =
+        render_component(&PlaygroundComponents.terminal_fallback/1, %{})
 
       rendered = Enum.join([banner, footer, fallback])
 
@@ -673,7 +812,11 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
         assert Capabilities.ssh_command() == "ssh -p 2222 playground@raxol.io"
         assert Capabilities.links().ssh == "ssh -p 2222 playground@raxol.io"
 
-        banner = render_component(&PlaygroundComponents.ssh_callout/1, variant: :banner)
+        banner =
+          render_component(&PlaygroundComponents.ssh_callout/1,
+            variant: :banner
+          )
+
         assert banner =~ "playground@raxol.io"
       after
         System.delete_env("RAXOL_SSH_PLAYGROUND")


### PR DESCRIPTION
A design review of the landing and topic pages, and the four defects it
turned up. Every number below was measured on the running site, not estimated.

## The chrome did not share the content's column

The header and footer spanned the viewport while the hero was capped at 62rem,
so the brand mark sat 164px outside the column it introduces and the nav ended
164px past its right edge. The measure itself was written down four times, and
the topic pages reached for Tailwind's `max-w-5xl` (64rem) instead, so the mark
moved when a reader crossed between page types.

One `--screen-measure` token now, with `--screen-gutter` beside it. The gutter
lives *outside* the column rather than inside it, which is the part that
actually closes the gap: the topic pages padded within their measure via
`px-6`, starting their text a gutter further in than the landing. `.measure`
grows its cap by the gutter and owns the padding, so the content box is exactly
62rem everywhere. `px-6` came off all 14 call sites.

| | before | after |
| --- | --- | --- |
| landing mark / hero | 32 / 196 | **196 / 196** |
| topic mark / prose / footer | 32 / 220 / 24 | **196 / 196 / 196** |
| header nav right edge | 1352 | **1188** (the hero's edge) |

## The topic footer was a copy of the header

It listed GitHub, Hex.pm, Docs, Playground and Skill. Four of those five are in
`nav_links/0`, on the same page, so a third of the page's links pointed where
the header already pointed. It is a signature line now, and it carries the
`contentinfo` landmark those pages never had.

Topic pages go from 13 chrome links to 8. The landing is deliberately unchanged
at 13: its footer's five deep dives appear nowhere else, so there was nothing to
dedupe.

**One deliberate loss:** hex.pm is no longer linked from a topic page. It was
the only non-duplicate in that row, and it stays one hop away via Docs or the
landing footer. Easy to restore if you would rather keep it.

## The SSH pane read as broken

It spelled `\e` as `ESC` and printed the codes, splitting each row at every
escape. That is honestly what the channel carries, but escape codes on screen is
the universal signature of a terminal failing to render — so the one pane whose
job is to prove raxol runs over SSH was the one that looked like it did not.

It decodes SGR now and paints the frame the remote terminal actually receives.
Three things make it match the terminal tab rather than merely stop looking
broken:

- **Same colours.** The `.ansi-*` classes resolve to the hexes `TerminalBridge`
  writes into the recorded frames, so one program cannot appear in two palettes
  on two tabs of one demo.
- **Same fit.** It reports its grid and uses the existing two-axis type fit.
  Measured side by side, the panes are now identical in layout: same font-size,
  same box, same overflow state.
- **Nothing cut.** Width is measured on painted text only. The old path counted
  escape bytes as columns, which is why the 70-column `halo` recording came out
  as fragments.

It fails the build, not the page: an unmapped SGR code or a non-SGR sequence
raises, and recordings decode at compile time, so a re-record with an
unsupported code stops the build with a message naming the code rather than
reaching the page as a silently unstyled run.

Verified both recordings decode with run counts matching their original escape
inventory exactly — `pulse` 31 cyan + 21 magenta, `halo` 13 cyan. Every colour
start became one painted run: nothing lost, nothing invented.

## The landing scrolled sideways on every phone

`.screen-main` is a grid item, so it defaulted to `min-width: auto` and the
track could never be narrower than the hero's min-content — a fixed 62rem. Every
viewport under that got a 1032px page. One line fixes it, and it is the
horizontal twin of a `min-height: 0` already sitting there. It works because the
pieces below were already right: panes stack under 767px and their `pre`s
already scroll.

| viewport | before | after |
| --- | --- | --- |
| 390 x 844 | 1032 | **390** |
| 430 x 932 | 1032 | **430** |
| 768 x 1024 | 1032 | **768** |
| 1440 x 900 | 1032 | 1440 |

I stashed the branch and re-measured to confirm this was pre-existing rather
than introduced here.

## The demo's controls were unreachable on a short viewport

`max-height: 30rem` applied at every height, while the rules that let content
shrink into that cap (`flex: 1 1 auto`, `min-height: 0`, `overflow: hidden` on
the pane) applied only above 950px. Below that, 531px of content went into a
478px `overflow: hidden` box and the footer — the last child — went whole. Pause
and the example switcher were clipped *in place* rather than below the fold, so
scrolling never revealed them.

The controls move into the title bar, where a window's controls belong and where
nothing can clip them; the title takes the slack and truncates so it yields
before the buttons do. The cap moves inside the media query that holds the rules
making it survivable, which also un-clips the bottom of the code and output
panes.

| viewport height | demo clips | controls reachable |
| --- | --- | --- |
| 700 | ~~yes~~ no | ~~no~~ **yes** |
| 800 | ~~yes~~ no | ~~no~~ **yes** |
| 900 | ~~yes~~ no | ~~no~~ **yes** |
| 1000 | no | yes (cap still engages) |

## Also fixed on the way

`.screen-header` had no `position`, so the mobile menu's `top: 100%` resolved
against `.screen` — a `100dvh` grid. The menu was opening a full viewport below
the button that opened it. It anchors to the header now.

Dead code removed: `.footer-link`, `.hero-demo-foot` and its orphaned `kbd`
rule, all unreferenced after the changes above.

## Tests

Three new, covering the pane that changed meaning:

- the SSH pane equals the whole recording with SGR stripped — nothing authored,
  nothing dropped — with `refute pane =~ "ESC["` as the regression guard
- an unpaintable escape sequence raises rather than rendering unstyled
- colour carries across rows until reset, as it does on a real terminal

The existing "every non-terminal hero pane is a recorded artifact, line for
line" test now covers browser and MCP; SSH gets the stronger whole-recording
invariant instead of the line-substring one, since it is no longer line-broken.

## Manual testing

- [ ] Header mark and nav align with the hero's left and right edges
- [ ] Crossing `/` to `/surfaces` does not move the brand mark
- [ ] Topic footer shows only the axol.io signature
- [ ] SSH tab paints a cyan/magenta chart, no `ESC[` anywhere
- [ ] SSH tab and Terminal tab show the same frame at the same size
- [ ] Switch to `halo` and check the SSH tab is whole, not fragmented
- [ ] No horizontal scrollbar at 390px, 430px and 768px wide
- [ ] At a viewport ~800px tall, PAUSE and the next-example link are visible in
      the title bar and both work
- [ ] Mobile menu opens directly under its button, not at the page bottom

## Notes

`web/` is not covered by any format gate — the root `.formatter.exs` inputs
cover `lib/`, `config/`, `examples/`, `test/` and delegate `packages/*`, but
nothing matches `web/`, which has no `.formatter.exs` of its own. These files are
formatted and the root check passes, but that is a real hole worth its own
change.

The SSH pane's `data-label` was updated to match what it now shows. That
attribute is read by nothing — all four are dead markup — which seemed worth
noting rather than cleaning up here.
