### PR TITLE
Wire the LSP client into the coding agent

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ distributed systems, developer tools, and alternate surfaces.
 | Capability details | `features/` |
 | Stable internals and API contracts | `core/`, `harness/`, `reference/` |
 | Accepted design decisions | `adr/` |
-| Current work | [`TODO.md`](../TODO.md) and [`ROADMAP.md`](../ROADMAP.md) |
+| Current work | [`ROADMAP.md`](../ROADMAP.md) |
 
 Keep proposals only while a decision is in flight. Once code, an ADR, or a
 canonical guide absorbs the decision, Git history is the archive.

--- a/docs/features/CODING_AGENT.md
+++ b/docs/features/CODING_AGENT.md
@@ -197,9 +197,76 @@ sub-agent. Read-only tools run without a prompt; sensitive tools gate through ap
 | `edit_file` | Yes | `old_string` must match once unless `replace_all` |
 | `bash` | Yes | `/bin/sh -c`, combined stdout+stderr, output truncated past 64KB |
 | `task` | (delegating) | Delegates to a fresh read-only sub-agent that cannot write, run bash, or recurse |
+| `lsp` | No | Language-server queries: diagnostics, symbols, definition, references, hover |
+| `lsp_rename` | Yes | Renames a symbol through the language server and writes the edits |
 
 Skills tools (`skills_list`, `skill_view`, `skill_manage`) join the toolset when a
 skills provider is configured.
+
+## Language server
+
+The agent asks a language server about code rather than inferring it from text. `lsp`
+answers what the IDE would: `diagnostics` (whether an edit actually compiles), `symbols`
+(a file's outline), `definition`, `references` (before changing a signature), and `hover`.
+`lsp_rename` renames a symbol everywhere it appears using the server's own understanding
+of scope, and writes the result.
+
+That last one is the difference between a rename and a find-and-replace: it will not touch
+a same-named symbol in another scope, and it follows re-exports.
+
+Positions crossing the tool boundary are **1-based** `line` and `column`, matching the line
+numbers `read_file` prints. LSP itself is 0-based and counts columns in UTF-16 code units;
+both conversions happen inside the tool, so a rename on a line containing an emoji or CJK
+text lands on the right characters instead of one column early.
+
+### Which server
+
+Built-in defaults cover elixir (`elixir-ls`), rust (`rust-analyzer`), typescript
+(`typescript-language-server`), python (`pyright-langserver`), and go (`gopls`), matched on
+file extension. A repo overrides or extends them in `.raxol/lsp.json`:
+
+```json
+{
+  "servers": {
+    "elixir": { "command": "lexical" },
+    "zig": { "command": "zls", "extensions": [".zig"] }
+  }
+}
+```
+
+Overriding a built-in by name keeps its extensions, so pointing `elixir` at a different
+binary does not mean restating the file list. A server whose command is not on `PATH` is
+reported as such rather than silently doing nothing, and a malformed file falls back to the
+defaults rather than blocking boot. `mix raxol.inspect` (or `/inspect`) lists every server
+that would serve the directory and whether it is installed.
+
+### Lifecycle
+
+Servers start on first use, not at boot, and one per language is kept for the session:
+starting `rust-analyzer` per turn would mean indexing the crate per turn. Each is owned by
+a `Raxol.Agent.Lsp.Pool` that monitors the session process, so when the session ends by any
+path (a clean quit, an SSH disconnect, a crash) the pool exits and takes its servers, and
+their subprocesses, with it. No teardown path has to remember them. A server that crashes
+is dropped; the next request for that language starts a fresh one.
+
+### Containment
+
+Paths in go through the same cwd resolution as every other file tool. Results coming back
+are the server's, and a language server indexes whatever it likes: a definition can land in
+a dependency or the standard library. Those are reported as absolute paths in a normal
+session and dropped in a jailed one. A rename's edits are each re-checked against the
+workspace root before anything is written, so a server cannot direct a write outside it.
+
+**A jailed (multi-tenant) session gets no language server at all.** A server is arbitrary
+code execution on the workspace twice over: `.raxol/lsp.json` names the binary, and the
+binary runs project code to answer anything. `rust-analyzer` executes `build.rs`, and
+`elixir-ls` compiles the project. In a jail the workspace is tenant-written, which makes
+this the same refusal hooks and MCP servers already get.
+
+### Not yet
+
+Diagnostics are surfaced when the model asks for them, not automatically after every write.
+Post-write diagnostics are tracked in the parity epic.
 
 Every path expands relative to the working directory: the tool context's `:cwd`
 when the surface sets one (an ACP session root, a tenant jail), else

--- a/docs/features/CODING_AGENT.md
+++ b/docs/features/CODING_AGENT.md
@@ -245,9 +245,15 @@ that would serve the directory and whether it is installed.
 Servers start on first use, not at boot, and one per language is kept for the session:
 starting `rust-analyzer` per turn would mean indexing the crate per turn. Each is owned by
 a `Raxol.Agent.Lsp.Pool` that monitors the session process, so when the session ends by any
-path (a clean quit, an SSH disconnect, a crash) the pool exits and takes its servers, and
-their subprocesses, with it. No teardown path has to remember them. A server that crashes
-is dropped; the next request for that language starts a fresh one.
+path (a clean quit, an SSH disconnect, a crash) the pool stops every server it owns before
+going down. No teardown path has to remember them. A server that crashes is dropped; the
+next request for that language starts a fresh one.
+
+The pool stops them explicitly rather than relying on the process link. A pool that exits
+`:normal` does not take a linked, non-trapping process with it, so the clients, and the OS
+subprocesses behind them, would otherwise outlive the session. Waiting for a cold server
+to finish `initialize` also happens off the pool's own process, so a session that ends
+during a start is noticed immediately instead of after the start timeout.
 
 ### Containment
 
@@ -256,6 +262,14 @@ are the server's, and a language server indexes whatever it likes: a definition 
 a dependency or the standard library. Those are reported as absolute paths in a normal
 session and dropped in a jailed one. A rename's edits are each re-checked against the
 workspace root before anything is written, so a server cannot direct a write outside it.
+
+A rename is also bounded in width. Approval is asked before the server has answered, so
+the approver sees a position and a new name and cannot see how many files the rename
+reaches; a rename touching more than `max_files` (default 50) is refused with the count
+instead of performed. Retrying with an explicit `max_files` is a fresh call, and therefore
+a fresh approval that does carry the number. All the edits are composed before any of them
+is written, so an edit that cannot apply fails with nothing changed rather than partway
+through; if a write itself fails, the error names the files that already landed.
 
 **A jailed (multi-tenant) session gets no language server at all.** A server is arbitrary
 code execution on the workspace twice over: `.raxol/lsp.json` names the binary, and the

--- a/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
+++ b/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
@@ -267,6 +267,54 @@ defmodule Raxol.Agent.Action.ToolConverter do
            ],
       do: "[Tool error for #{name}]: invalid arguments"
 
+  # LSP failures are the model's to route around: each says whether to fix the
+  # call, use a different tool, or stop asking. Server names and paths here
+  # are configuration and the model's own arguments, not server output.
+  def public_error(name, :lsp_not_available),
+    do:
+      "[Tool error for #{name}]: no language server is running for this " <>
+        "session. Use grep and read_file instead."
+
+  def public_error(name, :no_server),
+    do:
+      "[Tool error for #{name}]: no language server is configured for that " <>
+        "file type. Use grep and read_file instead."
+
+  def public_error(name, {:not_installed, command}),
+    do:
+      "[Tool error for #{name}]: the language server for that file type " <>
+        "(#{command}) is not installed. Use grep and read_file instead."
+
+  def public_error(name, :diagnostics_timeout),
+    do:
+      "[Tool error for #{name}]: the language server did not report on that " <>
+        "file in time. This is not a clean bill of health — it may still be " <>
+        "indexing. Retry, or verify another way."
+
+  def public_error(name, :line_required),
+    do: "[Tool error for #{name}]: that op needs a 1-based `line` (and usually `column`)."
+
+  def public_error(name, :invalid_position),
+    do: "[Tool error for #{name}]: `line` and `column` are 1-based and must be positive."
+
+  def public_error(name, {:unknown_op, _op}),
+    do:
+      "[Tool error for #{name}]: unknown op. Use diagnostics, symbols, " <>
+        "definition, references, or hover."
+
+  def public_error(name, :rename_not_possible),
+    do:
+      "[Tool error for #{name}]: the language server will not rename that " <>
+        "symbol from that position. Check the position points at the name itself."
+
+  def public_error(name, {:rename_outside_workspace, _path}),
+    do:
+      "[Tool error for #{name}]: the rename would edit a file outside this " <>
+        "workspace, so nothing was written."
+
+  def public_error(name, :invalid_name),
+    do: "[Tool error for #{name}]: that is not a usable symbol name."
+
   def public_error(name, _other), do: "[Tool error for #{name}]: tool error"
 
   @doc """

--- a/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
+++ b/packages/raxol_agent/lib/raxol/agent/action/tool_converter.ex
@@ -315,6 +315,22 @@ defmodule Raxol.Agent.Action.ToolConverter do
   def public_error(name, :invalid_name),
     do: "[Tool error for #{name}]: that is not a usable symbol name."
 
+  def public_error(name, {:rename_too_broad, count, max}),
+    do:
+      "[Tool error for #{name}]: that rename would edit #{count} files, over " <>
+        "the limit of #{max}. Nothing was written. Check the position names " <>
+        "the symbol you meant; if #{count} files is right, retry with " <>
+        "`max_files` set to at least #{count}."
+
+  # Names what DID land. A caller told only that a write failed cannot tell a
+  # tree that was never touched from one that was half rewritten.
+  def public_error(name, {:partial_write, written, reason}),
+    do:
+      "[Tool error for #{name}]: writing failed (#{inspect(reason)}) after " <>
+        "#{length(written)} file(s) were already written: " <>
+        "#{Enum.join(written, ", ")}. The rename is INCOMPLETE — those files " <>
+        "carry the new name and the rest do not."
+
   def public_error(name, _other), do: "[Tool error for #{name}]: tool error"
 
   @doc """

--- a/packages/raxol_agent/lib/raxol/agent/actions/lsp.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/lsp.ex
@@ -1,0 +1,418 @@
+defmodule Raxol.Agent.Actions.Lsp do
+  @moduledoc """
+  Language-server Actions: `lsp` (read-only queries) and `lsp_rename`
+  (applies edits, gated).
+
+  These are two tools rather than one with a mode flag because `sensitive`
+  is declared per Action module at compile time. A single tool could not be
+  read-only for `definition` and gated for `rename`, and the gate is the
+  point.
+
+  ## Positions
+
+  Every position crossing this boundary is 1-based, matching the line
+  numbers `read_file` prints in its anchors. LSP itself is 0-based; the
+  conversion happens here, once, so no caller has to remember which
+  convention it is holding.
+
+  ## Containment
+
+  A path is resolved through `Raxol.Agent.Actions.Fs.resolve/2` like every
+  other file tool, so the same cwd jail applies. Results, though, come from
+  the language server, which indexes whatever it likes: a definition can
+  land in a dependency or the standard library, outside the workspace root.
+  Those are reported as absolute paths in a normal session and dropped
+  entirely in a jailed one, where a path outside the jail is a disclosure
+  rather than a convenience.
+
+  ## Wiring
+
+  Both read `context[:lsp_pool]`, a `Raxol.Agent.Lsp.Pool` owned by the
+  session. Without one they answer `:lsp_not_available` rather than starting
+  an OS subprocess owned by a turn that is about to end.
+  """
+
+  alias Raxol.Agent.Actions.Fs
+  alias Raxol.Agent.Lsp.Pool
+  alias Raxol.Agent.LSPContext
+
+  @query_ops ~w(diagnostics symbols definition references hover)
+
+  defmodule Query do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "lsp",
+      description:
+        "Ask the language server about code, instead of inferring it from " <>
+          "text. Ops: `diagnostics` (errors and warnings for a file, the " <>
+          "fastest way to check whether an edit compiles), `symbols` (the " <>
+          "file's outline), `definition` (where the symbol at a position is " <>
+          "defined), `references` (everywhere it is used — use this before " <>
+          "changing a signature), `hover` (its type and docs). Positions are " <>
+          "1-based `line` and `column`, matching read_file's anchors.",
+      schema: [
+        input: [
+          op: [
+            type: :string,
+            required: true,
+            enum: ["diagnostics", "symbols", "definition", "references", "hover"],
+            description: "Which query to run"
+          ],
+          path: [type: :string, required: true, description: "File to ask about"],
+          line: [
+            type: :integer,
+            description: "1-based line; required for definition, references, hover"
+          ],
+          column: [
+            type: :integer,
+            description: "1-based column (default 1)"
+          ]
+        ],
+        output: [
+          op: [type: :string],
+          path: [type: :string],
+          diagnostics: [type: :list],
+          symbols: [type: :list],
+          locations: [type: :list],
+          hover: [type: :string]
+        ]
+      ]
+
+    @impl true
+    def run(params, context) do
+      Raxol.Agent.Actions.Lsp.query(params, context)
+    end
+  end
+
+  defmodule Rename do
+    @moduledoc false
+    use Raxol.Agent.Action,
+      name: "lsp_rename",
+      sensitive: true,
+      description:
+        "Rename the symbol at a position everywhere it appears, using the " <>
+          "language server's own understanding of scope, and write the " <>
+          "resulting edits to disk. This is what to use instead of a " <>
+          "grep-and-replace across files: it will not touch a same-named " <>
+          "symbol in another scope, and it will follow re-exports. Positions " <>
+          "are 1-based. Returns the files changed and how many edits each took.",
+      schema: [
+        input: [
+          path: [type: :string, required: true, description: "File holding the symbol"],
+          line: [type: :integer, required: true, description: "1-based line"],
+          column: [type: :integer, required: true, description: "1-based column"],
+          new_name: [type: :string, required: true, description: "The new symbol name"]
+        ],
+        output: [
+          path: [type: :string],
+          new_name: [type: :string],
+          changed: [type: :list],
+          edits: [type: :integer]
+        ]
+      ]
+
+    @impl true
+    def run(params, context) do
+      Raxol.Agent.Actions.Lsp.rename(params, context)
+    end
+  end
+
+  @doc "All LSP actions, for a run's `actions:`."
+  @spec all() :: [module()]
+  def all, do: [Query, Rename]
+
+  @doc "The read-only subset, safe without a `:tool_authorizer` opt-in."
+  @spec read_only() :: [module()]
+  def read_only, do: [Query]
+
+  # -- queries ----------------------------------------------------------------
+
+  @doc false
+  @spec query(map(), map()) :: {:ok, map()} | {:error, term()}
+  def query(%{op: op, path: path} = params, context) when op in @query_ops do
+    with {:ok, abs, client, _server} <- open(path, context) do
+      uri = Pool.path_to_uri(abs)
+
+      run_query(op, client, uri, params, context)
+      |> annotate(op, path)
+    end
+  end
+
+  def query(%{op: op}, _context), do: {:error, {:unknown_op, op}}
+  def query(_params, _context), do: {:error, {:unknown_op, nil}}
+
+  defp run_query("diagnostics", client, uri, _params, _context) do
+    case LSPContext.await_diagnostics(client, uri) do
+      {:ok, diagnostics} -> {:ok, %{diagnostics: Enum.map(diagnostics, &render_diagnostic/1)}}
+      {:error, :timeout} -> {:error, :diagnostics_timeout}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp run_query("symbols", client, uri, _params, _context) do
+    with {:ok, symbols} <- LSPContext.symbols(client, uri) do
+      {:ok, %{symbols: Enum.map(symbols, &render_symbol/1)}}
+    end
+  end
+
+  defp run_query("definition", client, uri, params, context) do
+    with {:ok, line, column} <- position(params),
+         {:ok, locations} <- LSPContext.definition(client, uri, line, column) do
+      {:ok, %{locations: render_locations(locations, context)}}
+    end
+  end
+
+  defp run_query("references", client, uri, params, context) do
+    with {:ok, line, column} <- position(params),
+         {:ok, locations} <- LSPContext.references(client, uri, line, column) do
+      {:ok, %{locations: render_locations(locations, context)}}
+    end
+  end
+
+  defp run_query("hover", client, uri, params, _context) do
+    with {:ok, line, column} <- position(params),
+         {:ok, text} <- LSPContext.hover(client, uri, line, column) do
+      {:ok, %{hover: text || ""}}
+    end
+  end
+
+  defp annotate({:ok, result}, op, path), do: {:ok, Map.merge(result, %{op: op, path: path})}
+  defp annotate({:error, reason}, _op, _path), do: {:error, reason}
+
+  # -- rename -----------------------------------------------------------------
+
+  @doc false
+  @spec rename(map(), map()) :: {:ok, map()} | {:error, term()}
+  def rename(%{path: path, new_name: new_name} = params, context) do
+    with {:ok, valid_name} <- validate_name(new_name),
+         {:ok, line, column} <- position(params),
+         {:ok, abs, client, _server} <- open(path, context),
+         {:ok, file_edits} <-
+           LSPContext.rename(client, Pool.path_to_uri(abs), line, column, valid_name),
+         {:ok, resolved} <- resolve_edit_targets(file_edits, context),
+         :ok <- apply_edits(resolved) do
+      {:ok,
+       %{
+         path: path,
+         new_name: valid_name,
+         changed:
+           Enum.map(resolved, fn {rel, _abs, edits} -> %{path: rel, edits: length(edits)} end),
+         edits: resolved |> Enum.map(fn {_rel, _abs, edits} -> length(edits) end) |> Enum.sum()
+       }}
+    end
+  end
+
+  # A server that answers with no edits has decided the symbol cannot be
+  # renamed from that position. Reporting success with zero files changed
+  # would read as "done".
+  defp resolve_edit_targets([], _context), do: {:error, :rename_not_possible}
+
+  # Every file the server wants to touch is re-checked against the same
+  # containment as a direct write. A language server indexes outside the
+  # workspace, so without this a rename could write to a dependency's source
+  # or anywhere else it happens to have indexed.
+  defp resolve_edit_targets(file_edits, context) do
+    Enum.reduce_while(file_edits, {:ok, []}, fn %{uri: uri, edits: edits}, {:ok, acc} ->
+      path = Pool.uri_to_path(uri)
+
+      case Fs.resolve(path, context) do
+        {:ok, abs} -> {:cont, {:ok, [{relative_to_root(abs, context), abs, edits} | acc]}}
+        {:error, _reason} -> {:halt, {:error, {:rename_outside_workspace, path}}}
+      end
+    end)
+    |> case do
+      {:ok, resolved} -> {:ok, Enum.reverse(resolved)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp apply_edits(resolved) do
+    Enum.reduce_while(resolved, :ok, fn {_rel, abs, edits}, :ok ->
+      with {:ok, content} <- File.read(abs),
+           {:ok, updated} <- apply_text_edits(content, edits),
+           :ok <- File.write(abs, updated) do
+        {:cont, :ok}
+      else
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  # Edits are applied last-first so an earlier edit's offset shift cannot
+  # invalidate a later one's range. LSP guarantees the ranges within a file
+  # do not overlap, so sorting by start position is enough.
+  defp apply_text_edits(content, edits) do
+    {lines, trailing_newline?} = split_lines(content)
+
+    edits
+    |> Enum.sort_by(fn %{range: r} -> {r.start.line, r.start.character} end, :desc)
+    |> Enum.reduce_while({:ok, lines}, fn edit, {:ok, acc} ->
+      case splice(acc, edit) do
+        {:ok, updated} -> {:cont, {:ok, updated}}
+        :error -> {:halt, {:error, {:edit_out_of_range, edit.range}}}
+      end
+    end)
+    |> case do
+      {:ok, updated} -> {:ok, join_lines(updated, trailing_newline?)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp splice(lines, %{range: range, new_text: new_text}) do
+    %{start: %{line: sl, character: sc}, end: %{line: el, character: ec}} = range
+
+    with true <- sl >= 0 and el >= sl,
+         start_line when is_binary(start_line) <- Enum.at(lines, sl),
+         end_line when is_binary(end_line) <- Enum.at(lines, el),
+         {:ok, head, _} <- utf16_split(start_line, sc),
+         {:ok, _, tail} <- utf16_split(end_line, ec) do
+      replacement = String.split(head <> new_text <> tail, "\n")
+      {:ok, Enum.slice(lines, 0, sl) ++ replacement ++ Enum.drop(lines, el + 1)}
+    else
+      _ -> :error
+    end
+  end
+
+  # LSP `character` counts UTF-16 code units, not codepoints or bytes. On a
+  # line holding anything outside the BMP-free ASCII range, slicing by
+  # codepoint cuts in the wrong place and the written file is corrupt. Cut in
+  # UTF-16 and convert back; an offset landing inside a surrogate pair fails
+  # the round trip and is refused rather than written.
+  defp utf16_split(line, offset) when offset >= 0 do
+    utf16 = :unicode.characters_to_binary(line, :utf8, {:utf16, :little})
+    at = offset * 2
+
+    with true <- is_binary(utf16) and at <= byte_size(utf16),
+         head when is_binary(head) <- to_utf8(binary_part(utf16, 0, at)),
+         tail when is_binary(tail) <- to_utf8(binary_part(utf16, at, byte_size(utf16) - at)) do
+      {:ok, head, tail}
+    else
+      _ -> :error
+    end
+  end
+
+  defp utf16_split(_line, _offset), do: :error
+
+  defp to_utf8(utf16), do: :unicode.characters_to_binary(utf16, {:utf16, :little}, :utf8)
+
+  # Local line splitting: the trailing newline is carried as a flag rather
+  # than an empty last line, so applying an edit cannot add or drop one.
+  defp split_lines(""), do: {[], false}
+
+  defp split_lines(content) do
+    if String.ends_with?(content, "\n") do
+      {content |> binary_part(0, byte_size(content) - 1) |> String.split("\n"), true}
+    else
+      {String.split(content, "\n"), false}
+    end
+  end
+
+  defp join_lines([], _trailing?), do: ""
+  defp join_lines(lines, true), do: Enum.join(lines, "\n") <> "\n"
+  defp join_lines(lines, false), do: Enum.join(lines, "\n")
+
+  # Rejected here rather than sent: a server asked to rename to a name with a
+  # newline or a null byte in it does unpredictable things to the files it
+  # writes, and this tool writes them.
+  defp validate_name(name) when is_binary(name) do
+    trimmed = String.trim(name)
+
+    if trimmed != "" and not String.contains?(name, ["\n", "\r", "\0"]) do
+      {:ok, trimmed}
+    else
+      {:error, :invalid_name}
+    end
+  end
+
+  defp validate_name(_name), do: {:error, :invalid_name}
+
+  # -- shared -----------------------------------------------------------------
+
+  # Resolve, read, and tell the server the file's current bytes. Without the
+  # `did_open`, a server publishes no diagnostics for the file and answers
+  # position queries against a document it has never seen.
+  defp open(path, context) do
+    with {:ok, pool} <- fetch_pool(context),
+         {:ok, abs} <- Fs.resolve(path, context),
+         {:ok, content} <- File.read(abs),
+         {:ok, client, server} <- Pool.client_for(pool, abs),
+         :ok <- LSPContext.did_open(client, Pool.path_to_uri(abs), server.language_id, content) do
+      {:ok, abs, client, server}
+    end
+  end
+
+  defp fetch_pool(context) do
+    case is_map(context) && Map.get(context, :lsp_pool) do
+      pool when is_pid(pool) ->
+        if Process.alive?(pool), do: {:ok, pool}, else: {:error, :lsp_not_available}
+
+      _ ->
+        {:error, :lsp_not_available}
+    end
+  end
+
+  # 1-based in, 0-based out.
+  defp position(params) do
+    case {Map.get(params, :line), Map.get(params, :column, 1)} do
+      {line, column} when is_integer(line) and line > 0 and is_integer(column) and column > 0 ->
+        {:ok, line - 1, column - 1}
+
+      {nil, _column} ->
+        {:error, :line_required}
+
+      _ ->
+        {:error, :invalid_position}
+    end
+  end
+
+  defp render_diagnostic(diagnostic) do
+    %{
+      severity: to_string(diagnostic.severity),
+      line: diagnostic.range.start.line + 1,
+      column: diagnostic.range.start.character + 1,
+      message: diagnostic.message,
+      source: diagnostic.source
+    }
+  end
+
+  defp render_symbol(symbol) do
+    %{
+      name: symbol.name,
+      kind: to_string(symbol.kind),
+      line: symbol.range.start.line + 1,
+      children: Enum.map(symbol.children, &render_symbol/1)
+    }
+  end
+
+  defp render_locations(locations, context) do
+    locations
+    |> Enum.flat_map(&render_location(&1, context))
+    |> Enum.uniq()
+  end
+
+  defp render_location(%{uri: uri, range: range}, context) do
+    path = Pool.uri_to_path(uri)
+    entry = %{line: range.start.line + 1, column: range.start.character + 1}
+
+    case Fs.resolve(path, context) do
+      {:ok, abs} ->
+        [Map.put(entry, :path, relative_to_root(abs, context))]
+
+      {:error, _reason} ->
+        # Outside the workspace: a dependency or the standard library. Useful
+        # to a normal session, a disclosure in a jailed one.
+        if jailed?(context), do: [], else: [Map.put(entry, :path, path)]
+    end
+  end
+
+  defp jailed?(context), do: is_map(context) and Map.get(context, :jail) not in [nil, false]
+
+  defp relative_to_root(abs, context) do
+    root = (is_map(context) && Map.get(context, :cwd)) || Fs.working_dir()
+
+    case Path.relative_to(abs, root) do
+      ^abs -> abs
+      relative -> relative
+    end
+  end
+end

--- a/packages/raxol_agent/lib/raxol/agent/actions/lsp.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/lsp.ex
@@ -38,6 +38,10 @@ defmodule Raxol.Agent.Actions.Lsp do
 
   @query_ops ~w(diagnostics symbols definition references hover)
 
+  # Wide enough for a real rename across a module and its callers, narrow
+  # enough that a runaway one is stopped and re-approved rather than written.
+  @default_max_rename_files 50
+
   defmodule Query do
     @moduledoc false
     use Raxol.Agent.Action,
@@ -101,7 +105,13 @@ defmodule Raxol.Agent.Actions.Lsp do
           path: [type: :string, required: true, description: "File holding the symbol"],
           line: [type: :integer, required: true, description: "1-based line"],
           column: [type: :integer, required: true, description: "1-based column"],
-          new_name: [type: :string, required: true, description: "The new symbol name"]
+          new_name: [type: :string, required: true, description: "The new symbol name"],
+          max_files: [
+            type: :integer,
+            description:
+              "Refuse the rename if it would touch more than this many files " <>
+                "(default 50). Raise it deliberately for a wide rename."
+          ]
         ],
         output: [
           path: [type: :string],
@@ -189,6 +199,7 @@ defmodule Raxol.Agent.Actions.Lsp do
          {:ok, abs, client, _server} <- open(path, context),
          {:ok, file_edits} <-
            LSPContext.rename(client, Pool.path_to_uri(abs), line, column, valid_name),
+         :ok <- within_blast_radius(file_edits, params),
          {:ok, resolved} <- resolve_edit_targets(file_edits, context),
          :ok <- apply_edits(resolved) do
       {:ok,
@@ -200,6 +211,24 @@ defmodule Raxol.Agent.Actions.Lsp do
          edits: resolved |> Enum.map(fn {_rel, _abs, edits} -> length(edits) end) |> Enum.sum()
        }}
     end
+  end
+
+  # `sensitive: true` buys ONE approval, and it is shown before the server has
+  # answered -- so the approver sees a path, a position and a new name, and
+  # cannot see that this rename touches two hundred files. The count is only
+  # knowable here, after the fact and before any write.
+  #
+  # So a rename wider than the cap is refused rather than performed, and the
+  # error names the number. Retrying with an explicit `max_files` is a fresh
+  # tool call, which means a fresh approval whose arguments now carry the
+  # blast radius the first one could not.
+  defp within_blast_radius(file_edits, params) do
+    max_files = Map.get(params, :max_files) || @default_max_rename_files
+    count = length(file_edits)
+
+    if count > max_files,
+      do: {:error, {:rename_too_broad, count, max_files}},
+      else: :ok
   end
 
   # A server that answers with no edits has decided the symbol cannot be
@@ -226,16 +255,45 @@ defmodule Raxol.Agent.Actions.Lsp do
     end
   end
 
+  # Compose every file first, write only once they all composed. Reading and
+  # splicing interleaved with writing meant an edit that would not apply --
+  # a range past the end of the fourth file, an unreadable fifth -- surfaced
+  # only after the first three were already rewritten, leaving a half-renamed
+  # tree and an error that named the reason but not the files it had touched.
+  #
+  # Composition is where the failures actually live; a write that fails after
+  # its peers succeeded is a full disk, and that one is reported with the list
+  # of files that did land, so the state is recoverable rather than unknown.
   defp apply_edits(resolved) do
-    Enum.reduce_while(resolved, :ok, fn {_rel, abs, edits}, :ok ->
+    with {:ok, composed} <- compose_edits(resolved), do: write_composed(composed)
+  end
+
+  defp compose_edits(resolved) do
+    Enum.reduce_while(resolved, {:ok, []}, fn {rel, abs, edits}, {:ok, acc} ->
       with {:ok, content} <- File.read(abs),
-           {:ok, updated} <- apply_text_edits(content, edits),
-           :ok <- File.write(abs, updated) do
-        {:cont, :ok}
+           {:ok, updated} <- apply_text_edits(content, edits) do
+        {:cont, {:ok, [{rel, abs, updated} | acc]}}
       else
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
+    |> case do
+      {:ok, composed} -> {:ok, Enum.reverse(composed)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp write_composed(composed) do
+    Enum.reduce_while(composed, {:ok, []}, fn {rel, abs, updated}, {:ok, written} ->
+      case File.write(abs, updated) do
+        :ok -> {:cont, {:ok, [rel | written]}}
+        {:error, reason} -> {:halt, {:error, {:partial_write, Enum.reverse(written), reason}}}
+      end
+    end)
+    |> case do
+      {:ok, _written} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   # Edits are applied last-first so an earlier edit's offset shift cannot

--- a/packages/raxol_agent/lib/raxol/agent/code/app.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/app.ex
@@ -86,6 +86,7 @@ defmodule Raxol.Agent.Code.App do
     jail? = Keyword.get(options, :jail, false) not in [nil, false]
     {hooks, hooks_note} = load_hooks(cwd, jail?)
     {mcp_servers, mcp_note} = load_mcp(cwd, jail?)
+    {lsp_pool, lsp_note} = start_lsp(cwd, jail?, options)
 
     config(options, context)
     |> Map.merge(%{
@@ -95,14 +96,15 @@ defmodule Raxol.Agent.Code.App do
       events: session.events,
       next_event_id: length(session.events) + 1,
       messages: session.messages,
-      status_line: combine_notes([session.notice, hooks_note, mcp_note]),
+      status_line: combine_notes([session.notice, hooks_note, mcp_note, lsp_note]),
       session_key: session.key,
       sessions_dir: session.dir,
       title: session.title,
       parent: session.parent,
       cwd: cwd,
       hooks: hooks,
-      mcp_servers: mcp_servers
+      mcp_servers: mcp_servers,
+      lsp_pool: lsp_pool
     })
     |> maybe_open_initial_wizard()
     |> maybe_arm_launch_validation()
@@ -375,6 +377,37 @@ defmodule Raxol.Agent.Code.App do
       {:error, reason} -> {[], "mcp config error: #{inspect(reason)}"}
     end
   end
+
+  # A language server is arbitrary code execution on the workspace, twice
+  # over: `.raxol/lsp.json` names the binary, and the binary itself runs
+  # project code to answer anything (rust-analyzer executes `build.rs`,
+  # elixir-ls compiles the project). In a jail the workspace is
+  # TENANT-writable, so this is the hooks/MCP problem exactly, and a jailed
+  # session gets no LSP at all.
+  #
+  # The pool is unlinked and monitors this process — `init/1` runs in the
+  # Lifecycle process, whose death IS the session ending — so the servers go
+  # when the session does without any teardown path having to remember them.
+  defp start_lsp(_cwd, true, _options), do: {nil, "lsp disabled (jailed session)"}
+
+  defp start_lsp(cwd, _jail?, options) do
+    if Keyword.get(options, :lsp, true) do
+      servers = Raxol.Agent.Lsp.Config.load(cwd)
+      installed = Enum.filter(servers, &Raxol.Agent.Lsp.Config.available?/1)
+
+      case Raxol.Agent.Lsp.Pool.start(root: cwd, owner: self(), servers: servers) do
+        {:ok, pool} -> {pool, lsp_note(installed)}
+        {:error, _reason} -> {nil, "lsp unavailable"}
+      end
+    else
+      {nil, nil}
+    end
+  end
+
+  defp lsp_note([]), do: nil
+
+  defp lsp_note(installed),
+    do: "lsp: #{Enum.map_join(installed, ", ", & &1.name)}"
 
   defp combine_notes(notes) do
     case Enum.reject(notes, &is_nil/1) do
@@ -870,7 +903,13 @@ defmodule Raxol.Agent.Code.App do
     }
     |> maybe_add_skills()
     |> maybe_add_hooks(model)
+    |> maybe_add_lsp(model)
   end
+
+  defp maybe_add_lsp(context, %{lsp_pool: pool}) when is_pid(pool),
+    do: Map.put(context, :lsp_pool, pool)
+
+  defp maybe_add_lsp(context, _model), do: context
 
   # Wire the configured skills store under context[:skills] so the skill actions
   # can reach it. No-op when skills are disabled (default_context returns nil).
@@ -3244,6 +3283,7 @@ defmodule Raxol.Agent.Code.App do
     Raxol.Agent.Actions.Fs.all() ++
       Raxol.Agent.Actions.Code.all() ++
       Raxol.Agent.Actions.Task.all() ++
+      Raxol.Agent.Actions.Lsp.all() ++
       Raxol.Agent.Skills.enabled_actions()
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/code/inspection.ex
+++ b/packages/raxol_agent/lib/raxol/agent/code/inspection.ex
@@ -37,6 +37,7 @@ defmodule Raxol.Agent.Code.Inspection do
       project: ProjectConfig.load(cwd),
       hooks: hooks_section(cwd),
       mcp_servers: mcp_section(cwd),
+      lsp: lsp_section(cwd),
       skills: skills_section(),
       sessions: sessions_section(Keyword.get(opts, :sessions_dir) || Store.default_dir())
     }
@@ -52,6 +53,7 @@ defmodule Raxol.Agent.Code.Inspection do
       render_project(snapshot.project),
       render_hooks(snapshot.hooks),
       render_mcp(snapshot.mcp_servers),
+      render_lsp(snapshot.lsp),
       render_skills(snapshot.skills),
       render_sessions(snapshot.sessions)
     ]
@@ -114,6 +116,21 @@ defmodule Raxol.Agent.Code.Inspection do
       args: server.args,
       env_keys: server |> Map.get(:env, %{}) |> Map.keys() |> Enum.sort()
     }
+  end
+
+  # Which servers WOULD serve this directory, and whether their command is
+  # installed. Nothing is started to find out.
+  defp lsp_section(cwd) do
+    cwd
+    |> Raxol.Agent.Lsp.Config.load()
+    |> Enum.map(fn server ->
+      %{
+        name: server.name,
+        command: server.command,
+        extensions: server.extensions,
+        installed: Raxol.Agent.Lsp.Config.available?(server)
+      }
+    end)
   end
 
   defp skills_section do
@@ -179,6 +196,21 @@ defmodule Raxol.Agent.Code.Inspection do
       |> Enum.join(" ")
 
     "project pin (.raxol/config.json): #{pin}"
+  end
+
+  defp render_lsp([]), do: "lsp (.raxol/lsp.json): none configured"
+
+  defp render_lsp(servers) do
+    lines =
+      Enum.map(servers, fn server ->
+        mark = if server.installed, do: "installed", else: "NOT installed"
+
+        "  #{server.name}  #{server.command} (#{mark})  " <>
+          Enum.join(server.extensions, " ")
+      end)
+
+    installed = Enum.count(servers, & &1.installed)
+    ["lsp: #{installed}/#{length(servers)} servers installed" | lines]
   end
 
   defp render_hooks(%{status: :none}), do: "hooks (.raxol/hooks.json): none"

--- a/packages/raxol_agent/lib/raxol/agent/lsp/config.ex
+++ b/packages/raxol_agent/lib/raxol/agent/lsp/config.ex
@@ -1,0 +1,197 @@
+defmodule Raxol.Agent.Lsp.Config do
+  @moduledoc """
+  Which language server serves which file, from built-in defaults plus an
+  optional per-repo `.raxol/lsp.json`.
+
+  ## File shape
+
+      {
+        "servers": {
+          "elixir": {
+            "command": "elixir-ls",
+            "args": [],
+            "extensions": [".ex", ".exs"],
+            "language_id": "elixir"
+          }
+        }
+      }
+
+  A server named the same as a built-in replaces it outright rather than
+  merging field by field, so a repo that overrides `command` does not
+  silently inherit arguments meant for a different binary.
+
+  A malformed or unreadable file yields the built-in defaults rather than an
+  error: a bad `.raxol/lsp.json` degrades the agent to no LSP, it does not
+  stop it booting. `mix raxol.inspect` reports what resolved.
+
+  ## Availability
+
+  A server is only offered if its command is on `PATH`. Nothing here starts
+  a process; `available?/1` is what keeps the tool from advertising an
+  operation that would fail on every call.
+  """
+
+  @type server :: %{
+          name: String.t(),
+          command: String.t(),
+          args: [String.t()],
+          extensions: [String.t()],
+          language_id: String.t()
+        }
+
+  @defaults [
+    %{
+      name: "elixir",
+      command: "elixir-ls",
+      args: [],
+      extensions: [".ex", ".exs", ".heex"],
+      language_id: "elixir"
+    },
+    %{
+      name: "rust",
+      command: "rust-analyzer",
+      args: [],
+      extensions: [".rs"],
+      language_id: "rust"
+    },
+    %{
+      name: "typescript",
+      command: "typescript-language-server",
+      args: ["--stdio"],
+      extensions: [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"],
+      language_id: "typescript"
+    },
+    %{
+      name: "python",
+      command: "pyright-langserver",
+      args: ["--stdio"],
+      extensions: [".py", ".pyi"],
+      language_id: "python"
+    },
+    %{
+      name: "go",
+      command: "gopls",
+      args: [],
+      extensions: [".go"],
+      language_id: "go"
+    }
+  ]
+
+  @doc "The built-in server table, before any repo override."
+  @spec defaults() :: [server()]
+  def defaults, do: @defaults
+
+  @doc """
+  Resolve the server table for `dir`: built-in defaults with any
+  `.raxol/lsp.json` entries replacing same-named ones and adding new ones.
+
+  Never raises.
+  """
+  @spec load(String.t()) :: [server()]
+  def load(dir) do
+    overrides =
+      dir
+      |> Path.join(".raxol/lsp.json")
+      |> read_overrides()
+
+    by_name =
+      Enum.reduce(overrides, Map.new(@defaults, &{&1.name, &1}), fn server, acc ->
+        Map.put(acc, server.name, server)
+      end)
+
+    by_name |> Map.values() |> Enum.sort_by(& &1.name)
+  end
+
+  @doc """
+  The server that handles `path`, matched on file extension.
+
+  Returns `{:error, :no_server}` when no configured server claims the
+  extension, and `{:error, {:not_installed, command}}` when one does but its
+  command is not on `PATH` — the two are different problems with different
+  fixes, so they are different answers.
+  """
+  @spec for_path([server()], String.t()) ::
+          {:ok, server()} | {:error, :no_server | {:not_installed, String.t()}}
+  def for_path(servers, path) do
+    extension = path |> Path.extname() |> String.downcase()
+
+    case Enum.find(servers, &(extension in &1.extensions)) do
+      nil ->
+        {:error, :no_server}
+
+      server ->
+        if available?(server), do: {:ok, server}, else: {:error, {:not_installed, server.command}}
+    end
+  end
+
+  @doc "Whether the server's command is on `PATH`."
+  @spec available?(server()) :: boolean()
+  def available?(%{command: command}), do: System.find_executable(command) != nil
+
+  # -- parsing ----------------------------------------------------------------
+
+  defp read_overrides(path) do
+    with {:ok, binary} <- File.read(path),
+         {:ok, %{"servers" => servers}} when is_map(servers) <- Jason.decode(binary) do
+      servers
+      |> Enum.flat_map(&parse_server/1)
+      |> Enum.sort_by(& &1.name)
+    else
+      _ -> []
+    end
+  end
+
+  # A server with no command cannot be started, and one with no extensions
+  # can never be selected; both are dropped rather than carried as an entry
+  # that does nothing.
+  defp parse_server({name, %{"command" => command} = spec})
+       when is_binary(name) and name != "" and is_binary(command) and command != "" do
+    case strings(Map.get(spec, "extensions")) || default_extensions(name) do
+      [] ->
+        []
+
+      extensions ->
+        [
+          %{
+            name: name,
+            command: command,
+            args: strings(Map.get(spec, "args")) || [],
+            extensions: Enum.map(extensions, &String.downcase/1),
+            language_id: language_id(spec, name)
+          }
+        ]
+    end
+  end
+
+  defp parse_server(_entry), do: []
+
+  # Overriding a built-in by name inherits nothing but its extensions, so
+  # `{"elixir": {"command": "lexical"}}` still serves `.ex` without the repo
+  # having to restate the list.
+  defp default_extensions(name) do
+    case Enum.find(@defaults, &(&1.name == name)) do
+      nil -> []
+      server -> server.extensions
+    end
+  end
+
+  defp language_id(spec, name) do
+    case Map.get(spec, "language_id") do
+      id when is_binary(id) and id != "" -> id
+      _ -> default_language_id(name)
+    end
+  end
+
+  defp default_language_id(name) do
+    case Enum.find(@defaults, &(&1.name == name)) do
+      nil -> name
+      server -> server.language_id
+    end
+  end
+
+  defp strings(list) when is_list(list) do
+    if Enum.all?(list, &is_binary/1), do: list
+  end
+
+  defp strings(_other), do: nil
+end

--- a/packages/raxol_agent/lib/raxol/agent/lsp/pool.ex
+++ b/packages/raxol_agent/lib/raxol/agent/lsp/pool.ex
@@ -1,0 +1,208 @@
+defmodule Raxol.Agent.Lsp.Pool do
+  @moduledoc """
+  One language server per language, started on first use and owned by the
+  session.
+
+  A language server is expensive to start (rust-analyzer indexes a crate
+  before it answers anything), so it must outlive a single turn; and it is an
+  OS subprocess, so it must not outlive the session. The pool sits between:
+  it starts each server lazily, keeps it for the session's lifetime, and
+  monitors the owning process so that when the session ends by any path —
+  a clean quit, an SSH disconnect, or a crash — the pool exits and takes its
+  linked servers, and their subprocesses, with it.
+
+  This is the `Raxol.Agent.Code.McpLoader` ownership pattern: nothing has to
+  remember to call a cleanup function, because there is no such function to
+  forget.
+
+  A server that crashes is trapped and dropped, never propagating to the
+  session. The next request for that language starts a fresh one.
+  """
+
+  use GenServer
+
+  require Logger
+
+  alias Raxol.Agent.Lsp.Config
+  alias Raxol.Agent.LSPContext
+
+  @start_timeout 30_000
+  # A cold server indexes the project before it answers; requests made during
+  # that window get `{:not_ready, _}` rather than a wrong answer, so the pool
+  # waits for readiness once at startup instead of per call.
+  @ready_poll_ms 100
+
+  defstruct [:owner, :root, :servers, :starter, clients: %{}, failed: %{}]
+
+  @doc """
+  Start a pool for `root`, owned by `:owner` (default: the caller).
+
+  Options: `:root` (workspace root, required), `:owner`, `:servers` (a
+  resolved `Config` table, default `Config.load/1` on the root), and
+  `:starter` (the client start function, injectable for tests).
+  """
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts)
+  end
+
+  @doc """
+  Start a pool without linking to the caller.
+
+  This is what a session uses. The pool holds the workspace's language
+  servers, and a fault in it must not propagate to the session that merely
+  asked for one; the owner monitor still tears everything down when the
+  session ends, so nothing leaks by not linking.
+  """
+  @spec start(keyword()) :: GenServer.on_start()
+  def start(opts) do
+    GenServer.start(__MODULE__, opts)
+  end
+
+  @doc """
+  The client serving `path`, starting it if this is the first request.
+
+  Returns `{:ok, client, server}` where `server` is the config entry (its
+  `language_id` is what `did_open` needs).
+  """
+  @spec client_for(GenServer.server(), String.t()) ::
+          {:ok, pid(), Config.server()} | {:error, term()}
+  def client_for(pool, path) do
+    GenServer.call(pool, {:client_for, path}, @start_timeout + 5_000)
+  end
+
+  @doc "Which languages have a running server, for `/inspect` and status."
+  @spec running(GenServer.server()) :: [String.t()]
+  def running(pool), do: GenServer.call(pool, :running)
+
+  @doc "Stop the pool and every server it owns. A dead pid is a no-op."
+  @spec stop(pid() | nil) :: :ok
+  def stop(nil), do: :ok
+
+  def stop(pool) when is_pid(pool) do
+    if Process.alive?(pool), do: GenServer.stop(pool, :normal, 5_000), else: :ok
+  catch
+    :exit, _ -> :ok
+  end
+
+  # -- callbacks --------------------------------------------------------------
+
+  @impl GenServer
+  def init(opts) do
+    # Trapping exits is what makes a crashing server a dropped entry rather
+    # than a dead session: the clients are linked so they die with the pool,
+    # but their deaths arrive here as messages.
+    Process.flag(:trap_exit, true)
+
+    root = Keyword.fetch!(opts, :root)
+    owner = Keyword.get(opts, :owner, self())
+    Process.monitor(owner)
+
+    {:ok,
+     %__MODULE__{
+       owner: owner,
+       root: root,
+       servers: Keyword.get_lazy(opts, :servers, fn -> Config.load(root) end),
+       starter: Keyword.get(opts, :starter, &LSPContext.start_link/1)
+     }}
+  end
+
+  @impl GenServer
+  def handle_call({:client_for, path}, _from, state) do
+    with {:ok, server} <- Config.for_path(state.servers, path) do
+      case Map.fetch(state.clients, server.name) do
+        {:ok, client} ->
+          {:reply, {:ok, client, server}, state}
+
+        :error ->
+          start_client(server, state)
+      end
+    else
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call(:running, _from, state) do
+    {:reply, state.clients |> Map.keys() |> Enum.sort(), state}
+  end
+
+  @impl GenServer
+  def handle_info({:DOWN, _ref, :process, owner, _reason}, %{owner: owner} = state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info({:EXIT, pid, reason}, state) do
+    case Enum.find(state.clients, fn {_name, client} -> client == pid end) do
+      nil ->
+        {:noreply, state}
+
+      {name, _client} ->
+        Logger.warning("[LSP] #{name} server exited: #{inspect(reason)}")
+        {:noreply, %{state | clients: Map.delete(state.clients, name)}}
+    end
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  # -- starting ---------------------------------------------------------------
+
+  defp start_client(server, state) do
+    case state.starter.(
+           command: server.command,
+           args: server.args,
+           root_uri: path_to_uri(state.root)
+         ) do
+      {:ok, client} ->
+        await_ready(client, server, state)
+
+      {:error, reason} ->
+        {:reply, {:error, {:start_failed, reason}}, state}
+    end
+  catch
+    kind, reason -> {:reply, {:error, {:start_failed, {kind, reason}}}, state}
+  end
+
+  # `initialize` is a round trip to a process that may be indexing, so the
+  # first caller waits for it rather than getting a `:not_ready` it cannot act
+  # on. A server that never reaches ready is stopped, not left running as a
+  # subprocess nothing will ever ask anything.
+  defp await_ready(client, server, state) do
+    case poll_ready(client, System.monotonic_time(:millisecond) + @start_timeout) do
+      :ok ->
+        {:reply, {:ok, client, server}, put_in(state.clients[server.name], client)}
+
+      {:error, reason} ->
+        LSPContext.stop(client)
+        {:reply, {:error, {:not_ready, reason}}, state}
+    end
+  catch
+    :exit, reason -> {:reply, {:error, {:start_failed, reason}}, state}
+  end
+
+  defp poll_ready(client, deadline) do
+    case LSPContext.status(client) do
+      %{status: :ready} ->
+        :ok
+
+      %{status: :closed} ->
+        {:error, :closed}
+
+      %{status: status} ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:error, {:timeout, status}}
+        else
+          Process.sleep(@ready_poll_ms)
+          poll_ready(client, deadline)
+        end
+    end
+  end
+
+  @doc "Absolute path to a `file://` URI."
+  @spec path_to_uri(String.t()) :: String.t()
+  def path_to_uri(path), do: "file://" <> path
+
+  @doc "A `file://` URI back to a path."
+  @spec uri_to_path(String.t()) :: String.t()
+  def uri_to_path("file://" <> path), do: path
+  def uri_to_path(uri), do: uri
+end

--- a/packages/raxol_agent/lib/raxol/agent/lsp/pool.ex
+++ b/packages/raxol_agent/lib/raxol/agent/lsp/pool.ex
@@ -8,12 +8,17 @@ defmodule Raxol.Agent.Lsp.Pool do
   OS subprocess, so it must not outlive the session. The pool sits between:
   it starts each server lazily, keeps it for the session's lifetime, and
   monitors the owning process so that when the session ends by any path —
-  a clean quit, an SSH disconnect, or a crash — the pool exits and takes its
-  linked servers, and their subprocesses, with it.
+  a clean quit, an SSH disconnect, or a crash — the pool stops each server it
+  owns before going down itself.
 
-  This is the `Raxol.Agent.Code.McpLoader` ownership pattern: nothing has to
-  remember to call a cleanup function, because there is no such function to
-  forget.
+  It stops them EXPLICITLY, in `terminate/2`. Linking is not enough on its
+  own: the pool exits `:normal` when its owner goes, and a `:normal` exit
+  signal is ignored by a linked process that is not trapping exits, which
+  `Raxol.Agent.LSPContext` is not. So the clients used to survive the pool,
+  their `terminate/2` never ran, the LSP `shutdown`/`exit` handshake was never
+  sent, and rust-analyzer and elixir-ls outlived the session for the life of
+  the BEAM. The pool itself traps exits, so its own `terminate/2` does run,
+  which is what makes it the right place to do this.
 
   A server that crashes is trapped and dropped, never propagating to the
   session. The next request for that language starts a fresh one.
@@ -27,12 +32,28 @@ defmodule Raxol.Agent.Lsp.Pool do
   alias Raxol.Agent.LSPContext
 
   @start_timeout 30_000
+  # Long enough for a `shutdown`/`exit` handshake, short enough that one
+  # wedged server does not hold a session's teardown open.
+  @stop_timeout 2_000
   # A cold server indexes the project before it answers; requests made during
   # that window get `{:not_ready, _}` rather than a wrong answer, so the pool
   # waits for readiness once at startup instead of per call.
   @ready_poll_ms 100
 
-  defstruct [:owner, :root, :servers, :starter, clients: %{}, failed: %{}]
+  defstruct [
+    :owner,
+    :root,
+    :servers,
+    :starter,
+    clients: %{},
+    # name => %{client: pid, waiters: [GenServer.from()], monitor: reference()}
+    # A server whose `initialize` round trip is still in flight. Waiting for it
+    # inside `handle_call` blocked the pool for the whole start timeout, and a
+    # cold rust-analyzer spends that long -- so an owner that died during a
+    # start was not noticed until the wait ended, and the subprocess ran on.
+    starting: %{},
+    failed: %{}
+  ]
 
   @doc """
   Start a pool for `root`, owned by `:owner` (default: the caller).
@@ -108,15 +129,9 @@ defmodule Raxol.Agent.Lsp.Pool do
   end
 
   @impl GenServer
-  def handle_call({:client_for, path}, _from, state) do
+  def handle_call({:client_for, path}, from, state) do
     with {:ok, server} <- Config.for_path(state.servers, path) do
-      case Map.fetch(state.clients, server.name) do
-        {:ok, client} ->
-          {:reply, {:ok, client, server}, state}
-
-        :error ->
-          start_client(server, state)
-      end
+      route_request(server, from, state)
     else
       {:error, reason} -> {:reply, {:error, reason}, state}
     end
@@ -126,15 +141,45 @@ defmodule Raxol.Agent.Lsp.Pool do
     {:reply, state.clients |> Map.keys() |> Enum.sort(), state}
   end
 
+  defp route_request(server, from, state) do
+    cond do
+      client = Map.get(state.clients, server.name) ->
+        {:reply, {:ok, client, server}, state}
+
+      Map.has_key?(state.starting, server.name) ->
+        # Someone is already paying for this start; join their queue rather
+        # than spawning a second server for the same language.
+        {:noreply, add_waiter(state, server.name, from)}
+
+      true ->
+        start_client(server, from, state)
+    end
+  end
+
   @impl GenServer
+  # The owner clause must sit above the readiness-waiter one: both are
+  # `:DOWN`, and the owner going away outranks anything in flight.
   def handle_info({:DOWN, _ref, :process, owner, _reason}, %{owner: owner} = state) do
     {:stop, :normal, state}
+  end
+
+  # A start finished. Answer everyone queued behind it with one result.
+  def handle_info({:lsp_ready, name, result}, state) do
+    case Map.pop(state.starting, name) do
+      {nil, _starting} ->
+        {:noreply, state}
+
+      {%{client: client, waiters: waiters, monitor: monitor}, starting} ->
+        Process.demonitor(monitor, [:flush])
+        state = %{state | starting: starting}
+        {:noreply, settle_start(name, client, waiters, result, state)}
+    end
   end
 
   def handle_info({:EXIT, pid, reason}, state) do
     case Enum.find(state.clients, fn {_name, client} -> client == pid end) do
       nil ->
-        {:noreply, state}
+        {:noreply, drop_starting_client(pid, reason, state)}
 
       {name, _client} ->
         Logger.warning("[LSP] #{name} server exited: #{inspect(reason)}")
@@ -142,18 +187,67 @@ defmodule Raxol.Agent.Lsp.Pool do
     end
   end
 
+  # The readiness waiter died without reporting. Fail its callers rather than
+  # leaving them to time out against a pool that is otherwise healthy.
+  def handle_info({:DOWN, monitor, :process, _pid, reason}, state) do
+    case Enum.find(state.starting, fn {_n, s} -> s.monitor == monitor end) do
+      nil ->
+        {:noreply, state}
+
+      {name, %{client: client, waiters: waiters}} ->
+        state = %{state | starting: Map.delete(state.starting, name)}
+
+        {:noreply, settle_start(name, client, waiters, {:error, {:waiter_down, reason}}, state)}
+    end
+  end
+
   def handle_info(_message, state), do: {:noreply, state}
+
+  # The whole reason this module owns anything. `:normal` does not kill a
+  # linked non-trapping process, so without this the servers -- and the OS
+  # subprocesses behind them -- outlived the pool that was supposed to hold
+  # them. Stopping each one runs its `terminate/2`, which sends the LSP
+  # `shutdown`/`exit` handshake before closing the port.
+  @impl GenServer
+  def terminate(_reason, state) do
+    starting_clients = Enum.map(state.starting, fn {_name, s} -> s.client end)
+
+    state.clients
+    |> Map.values()
+    |> Enum.concat(starting_clients)
+    |> Enum.each(&stop_client/1)
+
+    :ok
+  end
+
+  # Bounded, because this runs while a session is tearing down and
+  # `LSPContext.stop/1` waits forever: a server wedged in its own shutdown
+  # would hold the teardown open indefinitely. Past the deadline it is killed,
+  # which closes the port and hands the subprocess EOF on stdin -- the exit
+  # signal the LSP spec gives a server, and the reason the clean path tries
+  # the `shutdown`/`exit` handshake first.
+  defp stop_client(client) do
+    if Process.alive?(client) do
+      GenServer.stop(client, :normal, @stop_timeout)
+    end
+
+    :ok
+  catch
+    :exit, _reason ->
+      Process.exit(client, :kill)
+      :ok
+  end
 
   # -- starting ---------------------------------------------------------------
 
-  defp start_client(server, state) do
+  defp start_client(server, from, state) do
     case state.starter.(
            command: server.command,
            args: server.args,
            root_uri: path_to_uri(state.root)
          ) do
       {:ok, client} ->
-        await_ready(client, server, state)
+        {:noreply, await_ready(client, server, from, state)}
 
       {:error, reason} ->
         {:reply, {:error, {:start_failed, reason}}, state}
@@ -164,19 +258,61 @@ defmodule Raxol.Agent.Lsp.Pool do
 
   # `initialize` is a round trip to a process that may be indexing, so the
   # first caller waits for it rather than getting a `:not_ready` it cannot act
-  # on. A server that never reaches ready is stopped, not left running as a
-  # subprocess nothing will ever ask anything.
-  defp await_ready(client, server, state) do
-    case poll_ready(client, System.monotonic_time(:millisecond) + @start_timeout) do
-      :ok ->
-        {:reply, {:ok, client, server}, put_in(state.clients[server.name], client)}
+  # on. The WAITING happens in a throwaway process, not in `handle_call`: a
+  # cold server can take the whole start timeout, and blocking the pool for it
+  # meant the owner's `:DOWN` sat unread for that long, so a session that ended
+  # mid-start left its subprocess running. The caller still blocks -- the reply
+  # is simply deferred until the result arrives.
+  defp await_ready(client, server, from, state) do
+    pool = self()
+    deadline = System.monotonic_time(:millisecond) + @start_timeout
 
-      {:error, reason} ->
-        LSPContext.stop(client)
-        {:reply, {:error, {:not_ready, reason}}, state}
+    {_pid, monitor} =
+      spawn_monitor(fn ->
+        send(pool, {:lsp_ready, server.name, poll_ready(client, deadline)})
+      end)
+
+    put_in(state.starting[server.name], %{
+      client: client,
+      waiters: [from],
+      monitor: monitor
+    })
+  end
+
+  defp add_waiter(state, name, from) do
+    update_in(state.starting[name].waiters, &[from | &1])
+  end
+
+  # A server that never reaches ready is stopped, not left running as a
+  # subprocess nothing will ever ask anything.
+  defp settle_start(name, client, waiters, result, state) do
+    {reply, state} =
+      case result do
+        :ok ->
+          server = Enum.find(state.servers, &(&1.name == name))
+          {{:ok, client, server}, put_in(state.clients[name], client)}
+
+        {:error, reason} ->
+          LSPContext.stop(client)
+          {{:error, {:not_ready, reason}}, state}
+      end
+
+    Enum.each(waiters, &GenServer.reply(&1, reply))
+    state
+  end
+
+  # A client that died while still starting: its waiters are answered by the
+  # readiness result, so this only has to forget it, and must not fall through
+  # to the "unknown exit" no-op that would leave a stale entry to be stopped.
+  defp drop_starting_client(pid, reason, state) do
+    case Enum.find(state.starting, fn {_n, s} -> s.client == pid end) do
+      nil ->
+        state
+
+      {name, _entry} ->
+        Logger.warning("[LSP] #{name} server exited while starting: #{inspect(reason)}")
+        state
     end
-  catch
-    :exit, reason -> {:reply, {:error, {:start_failed, reason}}, state}
   end
 
   defp poll_ready(client, deadline) do
@@ -195,6 +331,9 @@ defmodule Raxol.Agent.Lsp.Pool do
           poll_ready(client, deadline)
         end
     end
+  catch
+    # The client died mid-poll; report it rather than crashing the waiter.
+    :exit, reason -> {:error, {:start_failed, reason}}
   end
 
   @doc "Absolute path to a `file://` URI."

--- a/packages/raxol_agent/lib/raxol/agent/lsp_context.ex
+++ b/packages/raxol_agent/lib/raxol/agent/lsp_context.ex
@@ -55,6 +55,12 @@ defmodule Raxol.Agent.LSPContext do
           end: %{line: non_neg_integer(), character: non_neg_integer()}
         }
 
+  @type location :: %{uri: String.t(), range: range()}
+
+  @type text_edit :: %{range: range(), new_text: String.t()}
+
+  @type file_edit :: %{uri: String.t(), edits: [text_edit()]}
+
   defstruct [
     :command,
     :args,
@@ -64,6 +70,8 @@ defmodule Raxol.Agent.LSPContext do
     :buffer,
     :pending,
     :diagnostics_cache,
+    open_docs: %{},
+    diagnostic_waiters: %{},
     next_id: 1,
     status: :starting
   ]
@@ -77,6 +85,8 @@ defmodule Raxol.Agent.LSPContext do
           buffer: binary(),
           pending: %{pos_integer() => {GenServer.from(), atom()}},
           diagnostics_cache: %{String.t() => [diagnostic()]},
+          open_docs: %{String.t() => pos_integer()},
+          diagnostic_waiters: %{String.t() => [GenServer.from()]},
           next_id: pos_integer(),
           status: :starting | :initializing | :ready | :closed
         }
@@ -127,6 +137,97 @@ defmodule Raxol.Agent.LSPContext do
   @spec diagnostics(GenServer.server(), String.t()) :: {:ok, [diagnostic()]} | {:error, term()}
   def diagnostics(server, uri) do
     GenServer.call(server, {:diagnostics, uri}, @call_timeout)
+  end
+
+  @doc """
+  Tell the server about a document's content.
+
+  Servers publish diagnostics only for documents the client has opened, so
+  nothing analyses a file until this is sent. Re-opening an already-open URI
+  sends a `didChange` with a bumped version, which is how a file the agent
+  just wrote gets re-analysed.
+  """
+  @spec did_open(GenServer.server(), String.t(), String.t(), String.t()) :: :ok
+  def did_open(server, uri, language_id, text) do
+    GenServer.call(server, {:did_open, uri, language_id, text}, @call_timeout)
+  end
+
+  @doc "Tell the server to stop tracking a document."
+  @spec did_close(GenServer.server(), String.t()) :: :ok
+  def did_close(server, uri) do
+    GenServer.call(server, {:did_close, uri}, @call_timeout)
+  end
+
+  @doc """
+  Wait for the server to publish diagnostics for `uri`, up to `timeout` ms.
+
+  Diagnostics arrive as an unsolicited notification some time after
+  `did_open/4`, so a caller that reads the cache immediately sees an empty
+  list and cannot tell "clean" from "not analysed yet". This blocks until
+  the first publish for that URI and returns `{:error, :timeout}` if none
+  arrives, which is the honest answer rather than a misleading `[]`.
+
+  A publish that arrived before the call returns immediately.
+  """
+  @spec await_diagnostics(GenServer.server(), String.t(), timeout()) ::
+          {:ok, [diagnostic()]} | {:error, term()}
+  def await_diagnostics(server, uri, timeout \\ 5_000) do
+    GenServer.call(server, {:await_diagnostics, uri, timeout}, timeout + 1_000)
+  catch
+    :exit, {:timeout, _} -> {:error, :timeout}
+  end
+
+  @doc "Locations where the symbol at a position is defined."
+  @spec definition(GenServer.server(), String.t(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, [location()]} | {:error, term()}
+  def definition(server, uri, line, character) do
+    GenServer.call(server, {:definition, uri, line, character}, @call_timeout)
+  end
+
+  @doc "Locations that reference the symbol at a position."
+  @spec references(
+          GenServer.server(),
+          String.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          boolean()
+        ) :: {:ok, [location()]} | {:error, term()}
+  def references(server, uri, line, character, include_declaration \\ true) do
+    GenServer.call(
+      server,
+      {:references, uri, line, character, include_declaration},
+      @call_timeout
+    )
+  end
+
+  @doc """
+  Ask the server for the edits that rename the symbol at a position.
+
+  Returns the workspace edit; applying it is the caller's job.
+  """
+  @spec rename(
+          GenServer.server(),
+          String.t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          String.t()
+        ) :: {:ok, [file_edit()]} | {:error, term()}
+  def rename(server, uri, line, character, new_name) do
+    GenServer.call(server, {:rename, uri, line, character, new_name}, @call_timeout)
+  end
+
+  @doc """
+  Ask the server what must change before a file moves.
+
+  This is `workspace/willRenameFiles`: the server answers with the edits
+  that keep imports, re-exports, and barrel files pointing at the new path.
+  A move done without it is a rename of the file and a break of everything
+  that referred to it.
+  """
+  @spec will_rename(GenServer.server(), String.t(), String.t()) ::
+          {:ok, [file_edit()]} | {:error, term()}
+  def will_rename(server, old_uri, new_uri) do
+    GenServer.call(server, {:will_rename, old_uri, new_uri}, @call_timeout)
   end
 
   @doc "Get document symbols for a file URI."
@@ -237,8 +338,11 @@ defmodule Raxol.Agent.LSPContext do
         {String.to_charlist(k), String.to_charlist(v)}
       end)
 
+    # Stream mode, not `{:packet, N}`: LSP does its own Content-Length
+    # framing, and `open_port` accepts only 1, 2, or 4 for `:packet` anyway --
+    # `{:packet, 0}` raises `:badarg` before a server ever starts.
     port_opts =
-      [:binary, :exit_status, {:packet, 0}, :use_stdio]
+      [:binary, :exit_status, :use_stdio, :hide]
       |> maybe_add_opt(:env, if(charlist_env != [], do: charlist_env))
 
     case find_executable(state.command) do
@@ -301,6 +405,116 @@ defmodule Raxol.Agent.LSPContext do
     {:reply, {:error, {:not_ready, state.status}}, state}
   end
 
+  # A document already known to the server is a `didChange`, not a second
+  # `didOpen`: servers reject a duplicate open, and the agent re-sends after
+  # every write it makes.
+  def handle_manager_call({:did_open, uri, language_id, text}, _from, %{status: :ready} = state) do
+    case Map.get(state.open_docs, uri) do
+      nil ->
+        send_notification(state, "textDocument/didOpen", %{
+          textDocument: %{uri: uri, languageId: language_id, version: 1, text: text}
+        })
+
+        {:reply, :ok, %{state | open_docs: Map.put(state.open_docs, uri, 1)}}
+
+      version ->
+        next = version + 1
+
+        send_notification(state, "textDocument/didChange", %{
+          textDocument: %{uri: uri, version: next},
+          contentChanges: [%{text: text}]
+        })
+
+        # The cached diagnostics describe the previous version, so they are
+        # dropped rather than served as if they described this one.
+        {:reply, :ok,
+         %{
+           state
+           | open_docs: Map.put(state.open_docs, uri, next),
+             diagnostics_cache: Map.delete(state.diagnostics_cache, uri)
+         }}
+    end
+  end
+
+  def handle_manager_call({:did_open, _uri, _lang, _text}, _from, state) do
+    {:reply, {:error, {:not_ready, state.status}}, state}
+  end
+
+  def handle_manager_call({:did_close, uri}, _from, %{status: :ready} = state) do
+    if Map.has_key?(state.open_docs, uri) do
+      send_notification(state, "textDocument/didClose", %{textDocument: %{uri: uri}})
+    end
+
+    {:reply, :ok,
+     %{
+       state
+       | open_docs: Map.delete(state.open_docs, uri),
+         diagnostics_cache: Map.delete(state.diagnostics_cache, uri)
+     }}
+  end
+
+  def handle_manager_call({:did_close, _uri}, _from, state) do
+    {:reply, {:error, {:not_ready, state.status}}, state}
+  end
+
+  def handle_manager_call({:await_diagnostics, uri, timeout}, from, %{status: :ready} = state) do
+    case Map.fetch(state.diagnostics_cache, uri) do
+      {:ok, diags} ->
+        {:reply, {:ok, diags}, state}
+
+      :error ->
+        Process.send_after(self(), {:diagnostic_wait_timeout, uri, from}, timeout)
+        waiters = Map.update(state.diagnostic_waiters, uri, [from], &[from | &1])
+        {:noreply, %{state | diagnostic_waiters: waiters}}
+    end
+  end
+
+  def handle_manager_call({:await_diagnostics, _uri, _timeout}, _from, state) do
+    {:reply, {:error, {:not_ready, state.status}}, state}
+  end
+
+  def handle_manager_call({:definition, uri, line, character}, from, %{status: :ready} = state) do
+    request(state, from, :locations, "textDocument/definition", %{
+      textDocument: %{uri: uri},
+      position: %{line: line, character: character}
+    })
+  end
+
+  def handle_manager_call(
+        {:references, uri, line, character, include_declaration},
+        from,
+        %{status: :ready} = state
+      ) do
+    request(state, from, :locations, "textDocument/references", %{
+      textDocument: %{uri: uri},
+      position: %{line: line, character: character},
+      context: %{includeDeclaration: include_declaration}
+    })
+  end
+
+  def handle_manager_call(
+        {:rename, uri, line, character, new_name},
+        from,
+        %{status: :ready} = state
+      ) do
+    request(state, from, :workspace_edit, "textDocument/rename", %{
+      textDocument: %{uri: uri},
+      position: %{line: line, character: character},
+      newName: new_name
+    })
+  end
+
+  def handle_manager_call({:will_rename, old_uri, new_uri}, from, %{status: :ready} = state) do
+    request(state, from, :workspace_edit, "workspace/willRenameFiles", %{
+      files: [%{oldUri: old_uri, newUri: new_uri}]
+    })
+  end
+
+  def handle_manager_call(request, _from, state)
+      when elem(request, 0) in [:definition, :references, :rename, :will_rename] do
+    {:reply, {:error, {:not_ready, state.status}}, state}
+  end
+
   def handle_manager_call(:status, _from, state) do
     info = %{
       status: state.status,
@@ -328,7 +542,29 @@ defmodule Raxol.Agent.LSPContext do
     {:noreply, %{state | port: nil, status: :closed, pending: %{}}}
   end
 
+  # The server never published for this URI in time. Answer the waiter so it
+  # can distinguish "no diagnostics yet" from "no problems found".
+  def handle_manager_info({:diagnostic_wait_timeout, uri, from}, state) do
+    case Map.get(state.diagnostic_waiters, uri) do
+      nil ->
+        {:noreply, state}
+
+      waiters ->
+        if from in waiters do
+          GenServer.reply(from, {:error, :timeout})
+        end
+
+        {:noreply, put_waiters(state, uri, List.delete(waiters, from))}
+    end
+  end
+
   def handle_manager_info(_msg, state), do: {:noreply, state}
+
+  defp put_waiters(state, uri, []),
+    do: %{state | diagnostic_waiters: Map.delete(state.diagnostic_waiters, uri)}
+
+  defp put_waiters(state, uri, waiters),
+    do: %{state | diagnostic_waiters: Map.put(state.diagnostic_waiters, uri, waiters)}
 
   @impl GenServer
   def terminate(_reason, %{port: port}) when is_port(port) do
@@ -434,7 +670,20 @@ defmodule Raxol.Agent.LSPContext do
     uri = Map.get(params, "uri", "")
     raw_diags = Map.get(params, "diagnostics", [])
     parsed = Enum.map(raw_diags, &parse_diagnostic(uri, &1))
-    %{state | diagnostics_cache: Map.put(state.diagnostics_cache, uri, parsed)}
+
+    state
+    |> Map.update!(:diagnostics_cache, &Map.put(&1, uri, parsed))
+    |> wake_diagnostic_waiters(uri, parsed)
+  end
+
+  # A server request (not a notification) must be answered or it blocks:
+  # several send `client/registerCapability` or `workspace/configuration`
+  # during startup and wait. Nothing here needs to act on them, but an
+  # unanswered id leaves the server waiting forever, so they get a null
+  # result rather than silence.
+  defp handle_message(%{"id" => id, "method" => _method}, state) do
+    send_lsp_message(state, %{"jsonrpc" => "2.0", "id" => id, "result" => nil})
+    state
   end
 
   # Ignore other notifications
@@ -469,9 +718,37 @@ defmodule Raxol.Agent.LSPContext do
     state
   end
 
+  defp handle_result(:locations, result, from, state) do
+    GenServer.reply(from, {:ok, parse_locations(result)})
+    state
+  end
+
+  defp handle_result(:workspace_edit, result, from, state) do
+    GenServer.reply(from, {:ok, parse_workspace_edit(result)})
+    state
+  end
+
   defp handle_result(_type, _result, from, state) do
     if from != :init, do: GenServer.reply(from, {:ok, nil})
     state
+  end
+
+  defp request(state, from, type, method, params) do
+    {state, id} = next_id(state)
+    state = register_pending(state, id, from, type)
+    send_request(state, id, method, params)
+    {:noreply, state}
+  end
+
+  defp wake_diagnostic_waiters(state, uri, diagnostics) do
+    case Map.pop(state.diagnostic_waiters, uri) do
+      {nil, _waiters} ->
+        state
+
+      {waiters, remaining} ->
+        Enum.each(waiters, &GenServer.reply(&1, {:ok, diagnostics}))
+        %{state | diagnostic_waiters: remaining}
+    end
   end
 
   # -- Private: Initialize -------------------------------------------------------
@@ -482,13 +759,26 @@ defmodule Raxol.Agent.LSPContext do
     params = %{
       processId: System.pid() |> String.to_integer(),
       rootUri: state.root_uri,
+      # Only what this client actually implements. A capability advertised
+      # but unhandled invites the server to send messages nothing answers.
       capabilities: %{
         textDocument: %{
+          synchronization: %{didSave: false, willSave: false, dynamicRegistration: false},
           publishDiagnostics: %{relatedInformation: true},
           documentSymbol: %{
             hierarchicalDocumentSymbolSupport: true
           },
-          hover: %{contentFormat: ["markdown", "plaintext"]}
+          hover: %{contentFormat: ["markdown", "plaintext"]},
+          definition: %{linkSupport: true},
+          references: %{dynamicRegistration: false},
+          rename: %{dynamicRegistration: false, prepareSupport: false}
+        },
+        workspace: %{
+          workspaceEdit: %{documentChanges: true},
+          # The reason `will_rename/3` can be asked at all: without this the
+          # server has no obligation to answer, and a file move silently
+          # leaves every import behind.
+          fileOperations: %{dynamicRegistration: false, willRename: true}
         }
       },
       clientInfo: %{name: "raxol", version: "1.0.0"}
@@ -572,6 +862,62 @@ defmodule Raxol.Agent.LSPContext do
   end
 
   defp parse_range(_), do: %{start: %{line: 0, character: 0}, end: %{line: 0, character: 0}}
+
+  # `textDocument/definition` answers with a Location, a list of Locations, a
+  # list of LocationLinks, or null, and servers differ on which. All four
+  # collapse to the same list here so a caller never branches on wire shape.
+  defp parse_locations(nil), do: []
+  defp parse_locations(result) when is_list(result), do: Enum.flat_map(result, &parse_location/1)
+  defp parse_locations(result), do: parse_location(result)
+
+  defp parse_location(%{"uri" => uri, "range" => range}),
+    do: [%{uri: uri, range: parse_range(range)}]
+
+  # LocationLink: the target range is the whole symbol, the selection range
+  # is its name. The selection is what a reader wants to be shown.
+  defp parse_location(%{"targetUri" => uri} = link) do
+    range = Map.get(link, "targetSelectionRange") || Map.get(link, "targetRange")
+    [%{uri: uri, range: parse_range(range)}]
+  end
+
+  defp parse_location(_other), do: []
+
+  # A WorkspaceEdit arrives either as `changes` (a uri => edits map) or as
+  # `documentChanges` (an ordered list that may also carry create/rename/delete
+  # operations). Only text edits are returned; a server that answers with file
+  # operations is reporting work this client does not apply, and silently
+  # dropping them would misreport the rename as complete.
+  defp parse_workspace_edit(nil), do: []
+
+  defp parse_workspace_edit(%{"documentChanges" => changes}) when is_list(changes) do
+    Enum.flat_map(changes, fn
+      %{"textDocument" => %{"uri" => uri}, "edits" => edits} ->
+        [%{uri: uri, edits: parse_text_edits(edits)}]
+
+      _operation ->
+        []
+    end)
+  end
+
+  defp parse_workspace_edit(%{"changes" => changes}) when is_map(changes) do
+    changes
+    |> Enum.sort_by(fn {uri, _edits} -> uri end)
+    |> Enum.map(fn {uri, edits} -> %{uri: uri, edits: parse_text_edits(edits)} end)
+  end
+
+  defp parse_workspace_edit(_other), do: []
+
+  defp parse_text_edits(edits) when is_list(edits) do
+    Enum.flat_map(edits, fn
+      %{"range" => range} = edit ->
+        [%{range: parse_range(range), new_text: Map.get(edit, "newText", "")}]
+
+      _other ->
+        []
+    end)
+  end
+
+  defp parse_text_edits(_other), do: []
 
   defp extract_hover_text(contents) when is_binary(contents), do: contents
 

--- a/packages/raxol_agent/test/mix/tasks/raxol_inspect_task_test.exs
+++ b/packages/raxol_agent/test/mix/tasks/raxol_inspect_task_test.exs
@@ -69,6 +69,6 @@ defmodule Mix.Tasks.Raxol.InspectTaskTest do
     assert decoded["cwd"] == ctx.cwd
 
     assert Map.keys(decoded) |> Enum.sort() ==
-             ~w(cwd hooks mcp_servers project provider sessions skills)
+             ~w(cwd hooks lsp mcp_servers project provider sessions skills)
   end
 end

--- a/packages/raxol_agent/test/raxol/agent/actions/lsp_live_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/lsp_live_test.exs
@@ -1,0 +1,130 @@
+defmodule Raxol.Agent.Actions.LspLiveTest do
+  @moduledoc """
+  The LSP path against a real language server.
+
+  The fixture server in `test/support/fake_lsp_server.py` proves the client
+  handles the protocol as written down. This proves it handles the protocol
+  as an actual server speaks it: real capability negotiation, real indexing
+  latency, real diagnostic timing, and the server-to-client requests a real
+  server sends during startup that a fixture never bothers with.
+
+  Excluded by default and skipped when `rust-analyzer` is not installed:
+
+      mix test --only live_lsp
+  """
+
+  use ExUnit.Case, async: false
+
+  @moduletag :live_lsp
+  @moduletag timeout: 180_000
+
+  alias Raxol.Agent.Actions.Lsp
+  alias Raxol.Agent.Lsp.Pool
+
+  # Presence on PATH is not usability: `rust-analyzer` is commonly a rustup
+  # or mise shim for a component that was never installed, which answers
+  # every invocation with an error instead of speaking LSP. Probe it.
+  setup_all do
+    case System.find_executable("rust-analyzer") do
+      nil ->
+        raise "rust-analyzer is not on PATH. Install it (rustup component add rust-analyzer)."
+
+      path ->
+        case System.cmd(path, ["--version"], stderr_to_stdout: true) do
+          {_output, 0} ->
+            :ok
+
+          {output, status} ->
+            raise """
+            rust-analyzer is on PATH at #{path} but is not usable (exit #{status}).
+            This is usually a rustup/mise shim for a component that was never
+            installed. Fix with: rustup component add rust-analyzer
+
+            Its output was:
+            #{String.trim(output)}
+            """
+        end
+    end
+  end
+
+  setup do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-lsp-live-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(Path.join(dir, "src"))
+
+    File.write!(Path.join(dir, "Cargo.toml"), """
+    [package]
+    name = "probe"
+    version = "0.1.0"
+    edition = "2021"
+    """)
+
+    File.write!(Path.join(dir, "src/main.rs"), """
+    fn greeting() -> &'static str {
+        "hello"
+    }
+
+    fn main() {
+        println!("{}", greeting());
+    }
+    """)
+
+    previous = System.get_env("RAXOL_CLI_CWD")
+    System.put_env("RAXOL_CLI_CWD", dir)
+
+    {:ok, pool} = Pool.start_link(root: dir)
+
+    on_exit(fn ->
+      Pool.stop(pool)
+
+      case previous do
+        nil -> System.delete_env("RAXOL_CLI_CWD")
+        value -> System.put_env("RAXOL_CLI_CWD", value)
+      end
+
+      File.rm_rf!(dir)
+    end)
+
+    %{dir: dir, ctx: %{lsp_pool: pool, cwd: dir}}
+  end
+
+  test "reports the symbols rust-analyzer finds", %{ctx: ctx} do
+    assert {:ok, %{symbols: symbols}} =
+             Lsp.Query.run(%{op: "symbols", path: "src/main.rs"}, ctx)
+
+    names = Enum.map(symbols, & &1.name)
+    assert "greeting" in names
+    assert "main" in names
+  end
+
+  test "resolves a call to its definition", %{ctx: ctx} do
+    # Line 6 is the `greeting()` call; column 20 is inside the name.
+    assert {:ok, %{locations: [location | _]}} =
+             Lsp.Query.run(
+               %{op: "definition", path: "src/main.rs", line: 6, column: 20},
+               ctx
+             )
+
+    assert location.path == "src/main.rs"
+    assert location.line == 1
+  end
+
+  test "renames a function everywhere it is used", %{dir: dir, ctx: ctx} do
+    assert {:ok, result} =
+             Lsp.Rename.run(
+               %{path: "src/main.rs", line: 1, column: 4, new_name: "salutation"},
+               ctx
+             )
+
+    assert result.edits >= 2
+
+    source = File.read!(Path.join(dir, "src/main.rs"))
+    assert source =~ "fn salutation()"
+    assert source =~ "salutation()"
+    refute source =~ "greeting"
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/actions/lsp_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/lsp_test.exs
@@ -1,0 +1,392 @@
+defmodule Raxol.Agent.Actions.LspTest do
+  # Each test spawns a real language server subprocess and a pool; they must
+  # not share the process-global cwd.
+  use ExUnit.Case, async: false
+
+  alias Raxol.Agent.Actions.Lsp
+  alias Raxol.Agent.Lsp.Config
+  alias Raxol.Agent.Lsp.Pool
+
+  @server Path.expand("../../../support/fake_lsp_server.py", __DIR__)
+
+  setup do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol-lsp-test-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+    previous = System.get_env("RAXOL_CLI_CWD")
+    System.put_env("RAXOL_CLI_CWD", dir)
+
+    on_exit(fn ->
+      case previous do
+        nil -> System.delete_env("RAXOL_CLI_CWD")
+        value -> System.put_env("RAXOL_CLI_CWD", value)
+      end
+
+      File.rm_rf!(dir)
+    end)
+
+    %{dir: dir}
+  end
+
+  # A config table pointing every `.toy` file at the fake server, optionally
+  # with behaviour flags.
+  defp servers(args \\ []) do
+    [
+      %{
+        name: "toy",
+        command: @server,
+        args: args,
+        extensions: [".toy"],
+        language_id: "toy"
+      }
+    ]
+  end
+
+  defp pool(dir, args \\ []) do
+    {:ok, pool} = Pool.start_link(root: dir, servers: servers(args))
+    on_exit(fn -> Pool.stop(pool) end)
+    pool
+  end
+
+  defp write(dir, name, content) do
+    File.write!(Path.join(dir, name), content)
+    name
+  end
+
+  defp context(pool, extra \\ %{}), do: Map.merge(%{lsp_pool: pool}, extra)
+
+  describe "diagnostics" do
+    test "reports what the server publishes for a file", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  BROKEN thing\n  SUSPECT other\n")
+
+      assert {:ok, result} =
+               Lsp.Query.run(%{op: "diagnostics", path: "a.toy"}, context(pool(dir)))
+
+      assert [error, warning] = result.diagnostics
+      assert error.severity == "error"
+      assert error.line == 2
+      assert error.message == "this line is broken"
+      assert error.source == "fake-lsp"
+      assert warning.severity == "warning"
+      assert warning.line == 3
+    end
+
+    test "a clean file reports no diagnostics", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  fine\n")
+
+      assert {:ok, %{diagnostics: []}} =
+               Lsp.Query.run(%{op: "diagnostics", path: "a.toy"}, context(pool(dir)))
+    end
+
+    test "re-reads the file after it changes on disk", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  fine\n")
+      p = pool(dir)
+
+      assert {:ok, %{diagnostics: []}} =
+               Lsp.Query.run(%{op: "diagnostics", path: "a.toy"}, context(p))
+
+      write(dir, "a.toy", "def alpha\n  BROKEN now\n")
+
+      assert {:ok, %{diagnostics: [%{line: 2}]}} =
+               Lsp.Query.run(%{op: "diagnostics", path: "a.toy"}, context(p))
+    end
+
+    test "a server that never publishes is a timeout, not a clean bill", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  BROKEN thing\n")
+
+      assert {:error, :diagnostics_timeout} =
+               Lsp.Query.run(
+                 %{op: "diagnostics", path: "a.toy"},
+                 context(pool(dir, ["--no-diagnostics"]))
+               )
+    end
+  end
+
+  describe "queries" do
+    setup %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  alpha and beta\ndef beta\n")
+      %{pool: pool(dir)}
+    end
+
+    test "symbols lists the file's declarations", %{pool: p} do
+      assert {:ok, %{symbols: symbols}} =
+               Lsp.Query.run(%{op: "symbols", path: "a.toy"}, context(p))
+
+      assert [%{name: "alpha", kind: "function", line: 1}, %{name: "beta", line: 3}] = symbols
+    end
+
+    test "definition resolves a use to its declaration", %{pool: p} do
+      # Line 2, column 3 is inside the `alpha` use.
+      assert {:ok, %{locations: [location]}} =
+               Lsp.Query.run(
+                 %{op: "definition", path: "a.toy", line: 2, column: 3},
+                 context(p)
+               )
+
+      assert location.path == "a.toy"
+      assert location.line == 1
+    end
+
+    test "references finds every use", %{pool: p} do
+      assert {:ok, %{locations: locations}} =
+               Lsp.Query.run(
+                 %{op: "references", path: "a.toy", line: 1, column: 5},
+                 context(p)
+               )
+
+      assert Enum.map(locations, & &1.line) == [1, 2]
+      assert Enum.all?(locations, &(&1.path == "a.toy"))
+    end
+
+    test "hover returns the server's description", %{pool: p} do
+      assert {:ok, %{hover: hover}} =
+               Lsp.Query.run(%{op: "hover", path: "a.toy", line: 1, column: 5}, context(p))
+
+      assert hover =~ "alpha"
+    end
+
+    test "a position query without a line is refused", %{pool: p} do
+      assert {:error, :line_required} =
+               Lsp.Query.run(%{op: "definition", path: "a.toy"}, context(p))
+    end
+
+    test "an unknown op is refused", %{pool: p} do
+      assert {:error, {:unknown_op, "wat"}} =
+               Lsp.Query.run(%{op: "wat", path: "a.toy"}, context(p))
+    end
+  end
+
+  describe "containment" do
+    test "a path outside the workspace is refused", %{dir: dir} do
+      assert {:error, :outside_cwd} =
+               Lsp.Query.run(
+                 %{op: "diagnostics", path: "../escape.toy"},
+                 context(pool(dir))
+               )
+    end
+
+    test "with no pool wired the tool declines rather than spawning one", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+
+      assert {:error, :lsp_not_available} =
+               Lsp.Query.run(%{op: "symbols", path: "a.toy"}, %{})
+    end
+
+    test "a file with no configured server says so", %{dir: dir} do
+      write(dir, "a.unknown", "hello\n")
+
+      assert {:error, :no_server} =
+               Lsp.Query.run(%{op: "symbols", path: "a.unknown"}, context(pool(dir)))
+    end
+  end
+
+  describe "rename" do
+    test "rewrites every occurrence and reports the files touched", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  alpha and beta\ndef beta\n")
+
+      assert {:ok, result} =
+               Lsp.Rename.run(
+                 %{path: "a.toy", line: 1, column: 5, new_name: "renamed"},
+                 context(pool(dir))
+               )
+
+      assert result.new_name == "renamed"
+      assert result.edits == 2
+      assert [%{path: "a.toy", edits: 2}] = result.changed
+
+      assert File.read!(Path.join(dir, "a.toy")) ==
+               "def renamed\n  renamed and beta\ndef beta\n"
+    end
+
+    test "a server that refuses the rename does not report success", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+      before = File.read!(Path.join(dir, "a.toy"))
+
+      assert {:error, :rename_not_possible} =
+               Lsp.Rename.run(
+                 %{path: "a.toy", line: 1, column: 5, new_name: "renamed"},
+                 context(pool(dir, ["--rename-refuses"]))
+               )
+
+      assert File.read!(Path.join(dir, "a.toy")) == before
+    end
+
+    test "an edit aimed outside the workspace is refused and nothing is written", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+      before = File.read!(Path.join(dir, "a.toy"))
+
+      assert {:error, {:rename_outside_workspace, "/etc/passwd"}} =
+               Lsp.Rename.run(
+                 %{path: "a.toy", line: 1, column: 5, new_name: "renamed"},
+                 context(pool(dir, ["--rename-escapes"]))
+               )
+
+      assert File.read!(Path.join(dir, "a.toy")) == before
+    end
+
+    test "a name that would corrupt the file is refused before the server sees it", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+      p = pool(dir)
+
+      for bad <- ["", "   ", "two\nlines"] do
+        assert {:error, :invalid_name} =
+                 Lsp.Rename.run(
+                   %{path: "a.toy", line: 1, column: 5, new_name: bad},
+                   context(p)
+                 )
+      end
+    end
+
+    test "preserves a file that does not end in a newline", %{dir: dir} do
+      write(dir, "a.toy", "def alpha")
+
+      assert {:ok, _result} =
+               Lsp.Rename.run(
+                 %{path: "a.toy", line: 1, column: 5, new_name: "renamed"},
+                 context(pool(dir))
+               )
+
+      assert File.read!(Path.join(dir, "a.toy")) == "def renamed"
+    end
+
+    test "an edit on a line with non-ASCII text lands on the right characters", %{dir: dir} do
+      # LSP counts UTF-16 code units. The emoji is two of them and one
+      # codepoint, so a codepoint-based slice would cut one column early.
+      write(dir, "a.toy", "def alpha\n  # 🚀 alpha here\n")
+
+      assert {:ok, _result} =
+               Lsp.Rename.run(
+                 %{path: "a.toy", line: 1, column: 5, new_name: "beta"},
+                 context(pool(dir))
+               )
+
+      assert File.read!(Path.join(dir, "a.toy")) == "def beta\n  # 🚀 beta here\n"
+    end
+
+    test "lsp_rename is gated but lsp is not" do
+      assert Lsp.Rename.__action_meta__().sensitive
+      refute Lsp.Query.__action_meta__().sensitive
+      assert Lsp.read_only() == [Lsp.Query]
+    end
+  end
+
+  describe "pool lifecycle" do
+    test "starts one server per language, reused across calls", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+      write(dir, "b.toy", "def beta\n")
+      p = pool(dir)
+
+      assert {:ok, _} = Lsp.Query.run(%{op: "symbols", path: "a.toy"}, context(p))
+      assert Pool.running(p) == ["toy"]
+
+      assert {:ok, _} = Lsp.Query.run(%{op: "symbols", path: "b.toy"}, context(p))
+      assert Pool.running(p) == ["toy"]
+    end
+
+    test "the pool dies with its owner, taking the server with it", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+      test = self()
+
+      owner =
+        spawn(fn ->
+          {:ok, p} = Pool.start_link(root: dir, servers: servers())
+          {:ok, _} = Lsp.Query.run(%{op: "symbols", path: "a.toy"}, %{lsp_pool: p})
+          send(test, {:ready, p})
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive {:ready, p}, 30_000
+      pool_ref = Process.monitor(p)
+
+      send(owner, :stop)
+
+      assert_receive {:DOWN, ^pool_ref, :process, ^p, _reason}, 5_000
+      refute Process.alive?(p)
+    end
+
+    test "a missing server binary is reported, not crashed on", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+
+      table = [
+        %{
+          name: "toy",
+          command: "definitely-not-a-real-language-server",
+          args: [],
+          extensions: [".toy"],
+          language_id: "toy"
+        }
+      ]
+
+      {:ok, p} = Pool.start_link(root: dir, servers: table)
+      on_exit(fn -> Pool.stop(p) end)
+
+      assert {:error, {:not_installed, "definitely-not-a-real-language-server"}} =
+               Lsp.Query.run(%{op: "symbols", path: "a.toy"}, context(p))
+    end
+  end
+
+  describe "config" do
+    test "defaults cover the common languages" do
+      names = Config.defaults() |> Enum.map(& &1.name) |> Enum.sort()
+      assert names == ["elixir", "go", "python", "rust", "typescript"]
+    end
+
+    test "maps a file to its server by extension" do
+      assert {:ok, %{name: "toy"}} = Config.for_path(servers(), "lib/a.toy")
+    end
+
+    test "an unclaimed extension has no server" do
+      assert {:error, :no_server} = Config.for_path(servers(), "lib/a.rb")
+    end
+
+    test "a repo file adds a server", %{dir: dir} do
+      File.mkdir_p!(Path.join(dir, ".raxol"))
+
+      File.write!(
+        Path.join(dir, ".raxol/lsp.json"),
+        ~s({"servers": {"zig": {"command": "zls", "extensions": [".zig"]}}})
+      )
+
+      table = Config.load(dir)
+      assert %{command: "zls", extensions: [".zig"]} = Enum.find(table, &(&1.name == "zig"))
+      # The built-ins survive alongside it.
+      assert Enum.find(table, &(&1.name == "elixir"))
+    end
+
+    test "overriding a built-in by name keeps its extensions", %{dir: dir} do
+      File.mkdir_p!(Path.join(dir, ".raxol"))
+
+      File.write!(
+        Path.join(dir, ".raxol/lsp.json"),
+        ~s({"servers": {"elixir": {"command": "lexical"}}})
+      )
+
+      assert %{command: "lexical", extensions: extensions} =
+               dir |> Config.load() |> Enum.find(&(&1.name == "elixir"))
+
+      assert ".ex" in extensions
+    end
+
+    test "a malformed file falls back to the defaults", %{dir: dir} do
+      File.mkdir_p!(Path.join(dir, ".raxol"))
+      File.write!(Path.join(dir, ".raxol/lsp.json"), "{not json")
+
+      assert Config.load(dir) == Enum.sort_by(Config.defaults(), & &1.name)
+    end
+
+    test "an entry with no command is dropped", %{dir: dir} do
+      File.mkdir_p!(Path.join(dir, ".raxol"))
+
+      File.write!(
+        Path.join(dir, ".raxol/lsp.json"),
+        ~s({"servers": {"broken": {"extensions": [".b"]}}})
+      )
+
+      refute dir |> Config.load() |> Enum.find(&(&1.name == "broken"))
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/actions/lsp_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/lsp_test.exs
@@ -59,6 +59,35 @@ defmodule Raxol.Agent.Actions.LspTest do
 
   defp context(pool, extra \\ %{}), do: Map.merge(%{lsp_pool: pool}, extra)
 
+  # The OS pid behind a client, read off its port.
+  defp server_os_pid(client) do
+    port = :sys.get_state(client).port
+    assert is_port(port)
+    {:os_pid, os_pid} = Port.info(port, :os_pid)
+    os_pid
+  end
+
+  # `kill -0` succeeds for a zombie, which a child the BEAM has not reaped yet
+  # still is, so a Z state counts as exited.
+  defp await_os_exit(os_pid, attempts \\ 50)
+  defp await_os_exit(_os_pid, 0), do: false
+
+  defp await_os_exit(os_pid, attempts) do
+    if os_process_gone?(os_pid) do
+      true
+    else
+      Process.sleep(100)
+      await_os_exit(os_pid, attempts - 1)
+    end
+  end
+
+  defp os_process_gone?(os_pid) do
+    case System.cmd("ps", ["-o", "stat=", "-p", to_string(os_pid)], stderr_to_stdout: true) do
+      {_out, status} when status != 0 -> true
+      {out, 0} -> String.trim(out) == "" or String.starts_with?(String.trim(out), "Z")
+    end
+  end
+
   describe "diagnostics" do
     test "reports what the server publishes for a file", %{dir: dir} do
       write(dir, "a.toy", "def alpha\n  BROKEN thing\n  SUSPECT other\n")
@@ -184,6 +213,56 @@ defmodule Raxol.Agent.Actions.LspTest do
     end
   end
 
+  # `sensitive: true` buys one approval, shown BEFORE the server has answered,
+  # so the approver sees a position and a new name and cannot see the width of
+  # what they are approving.
+  describe "rename blast radius" do
+    test "a rename wider than the cap is refused with its count", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  alpha and beta\ndef beta\n")
+
+      assert {:error, {:rename_too_broad, 1, 0}} =
+               Lsp.Rename.run(
+                 %{
+                   path: "a.toy",
+                   line: 1,
+                   column: 5,
+                   new_name: "renamed",
+                   max_files: 0
+                 },
+                 context(pool(dir))
+               )
+
+      # Refused, not performed.
+      assert File.read!(Path.join(dir, "a.toy")) =~ "def alpha"
+    end
+
+    test "raising the cap performs it", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  alpha and beta\ndef beta\n")
+
+      assert {:ok, %{edits: 2}} =
+               Lsp.Rename.run(
+                 %{
+                   path: "a.toy",
+                   line: 1,
+                   column: 5,
+                   new_name: "renamed",
+                   max_files: 10
+                 },
+                 context(pool(dir))
+               )
+    end
+
+    test "the default cap leaves an ordinary rename alone", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n  alpha and beta\ndef beta\n")
+
+      assert {:ok, %{edits: 2}} =
+               Lsp.Rename.run(
+                 %{path: "a.toy", line: 1, column: 5, new_name: "renamed"},
+                 context(pool(dir))
+               )
+    end
+  end
+
   describe "rename" do
     test "rewrites every occurrence and reports the files touched", %{dir: dir} do
       write(dir, "a.toy", "def alpha\n  alpha and beta\ndef beta\n")
@@ -287,6 +366,12 @@ defmodule Raxol.Agent.Actions.LspTest do
       assert Pool.running(p) == ["toy"]
     end
 
+    # This used to assert only that the POOL died, which it always did -- and
+    # that is why the leak shipped. The pool exits `:normal`, and a `:normal`
+    # exit signal is IGNORED by a linked process that is not trapping exits,
+    # which `LSPContext` is not. So the client survived its pool, its
+    # `terminate/2` never ran, and the OS subprocess stayed up for the life of
+    # the BEAM. The client and the subprocess are the things worth asserting.
     test "the pool dies with its owner, taking the server with it", %{dir: dir} do
       write(dir, "a.toy", "def alpha\n")
       test = self()
@@ -300,12 +385,64 @@ defmodule Raxol.Agent.Actions.LspTest do
         end)
 
       assert_receive {:ready, p}, 30_000
+
+      client = :sys.get_state(p).clients["toy"]
+      assert is_pid(client) and Process.alive?(client)
+      os_pid = server_os_pid(client)
+
       pool_ref = Process.monitor(p)
+      client_ref = Process.monitor(client)
 
       send(owner, :stop)
 
       assert_receive {:DOWN, ^pool_ref, :process, ^p, _reason}, 5_000
-      refute Process.alive?(p)
+
+      assert_receive {:DOWN, ^client_ref, :process, ^client, _reason},
+                     5_000,
+                     "the language server client outlived its pool"
+
+      assert await_os_exit(os_pid),
+             "the language server subprocess (#{os_pid}) outlived the session"
+    end
+
+    test "Pool.stop/1 also stops the servers it owns", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+      {:ok, p} = Pool.start_link(root: dir, servers: servers())
+
+      assert {:ok, _} = Lsp.Query.run(%{op: "symbols", path: "a.toy"}, %{lsp_pool: p})
+      client = :sys.get_state(p).clients["toy"]
+      os_pid = server_os_pid(client)
+
+      :ok = Pool.stop(p)
+
+      refute Process.alive?(client)
+      assert await_os_exit(os_pid)
+    end
+
+    # Waiting for `initialize` used to happen inside `handle_call`, so the pool
+    # could not read its own mailbox for the whole start timeout -- including
+    # the owner's `:DOWN`. A session ending during a cold start therefore left
+    # the subprocess running until the wait finished.
+    test "a start in flight does not block the pool's mailbox", %{dir: dir} do
+      write(dir, "a.toy", "def alpha\n")
+      # The fake server sits on `initialize` for 2s, so the window below lands
+      # squarely inside the wait.
+      p = pool(dir, ["--slow-init", "2"])
+
+      caller =
+        Task.async(fn ->
+          Lsp.Query.run(%{op: "symbols", path: "a.toy"}, %{lsp_pool: p})
+        end)
+
+      Process.sleep(500)
+
+      # An unrelated call is answered promptly rather than queueing behind the
+      # start. A short timeout is the assertion: waiting inside `handle_call`
+      # made this exit, and the owner's `:DOWN` waited exactly as long.
+      assert GenServer.call(p, :running, 500) == []
+
+      assert {:ok, _} = Task.await(caller, 30_000)
+      assert Pool.running(p) == ["toy"]
     end
 
     test "a missing server binary is reported, not crashed on", %{dir: dir} do

--- a/packages/raxol_agent/test/raxol/agent/code/app_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/code/app_test.exs
@@ -2095,4 +2095,76 @@ defmodule Raxol.Agent.Code.AppTest do
       assert model.notice =~ "fs"
     end
   end
+
+  describe "language server wiring" do
+    defp lsp_model(opts) do
+      dir = tmp_dir()
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      App.init(%{
+        options:
+          Keyword.merge(
+            [runner: stub_runner(), sessions_dir: tmp_dir(), cwd: dir],
+            opts
+          )
+      })
+    end
+
+    test "a normal session owns a pool and passes it to the tool context" do
+      model = lsp_model([])
+
+      assert is_pid(model.lsp_pool)
+      assert Process.alive?(model.lsp_pool)
+    end
+
+    test "a jailed session gets no language server at all" do
+      # A language server runs project code to answer anything, and in a jail
+      # the project is tenant-written. This is the hooks/MCP refusal.
+      model = lsp_model(jail: true)
+
+      assert model.lsp_pool == nil
+      assert model.status_line =~ "lsp disabled (jailed session)"
+    end
+
+    test "the pool dies with the session that owns it" do
+      # `App.init/1` runs in the Lifecycle process, so the pool's owner is
+      # whichever process called init. Build the options here (on_exit only
+      # works in the test process) and call init over there.
+      dir = tmp_dir()
+      File.mkdir_p!(dir)
+      on_exit(fn -> File.rm_rf(dir) end)
+
+      options = [runner: stub_runner(), sessions_dir: tmp_dir(), cwd: dir]
+      test = self()
+
+      owner =
+        spawn(fn ->
+          model = App.init(%{options: options})
+          send(test, {:pool, model.lsp_pool})
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive {:pool, pool}, 5_000
+      assert is_pid(pool)
+      ref = Process.monitor(pool)
+      send(owner, :stop)
+
+      assert_receive {:DOWN, ^ref, :process, ^pool, _reason}, 5_000
+    end
+
+    test "the LSP tools are in the default toolset" do
+      names =
+        lsp_model([]).actions
+        |> Enum.map(& &1.__action_meta__().name)
+
+      assert "lsp" in names
+      assert "lsp_rename" in names
+    end
+
+    test "an explicit lsp: false starts nothing" do
+      model = lsp_model(lsp: false)
+      assert model.lsp_pool == nil
+    end
+  end
 end

--- a/packages/raxol_agent/test/support/fake_lsp_server.py
+++ b/packages/raxol_agent/test/support/fake_lsp_server.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""A minimal but real language server, for exercising the LSP client.
+
+Speaks the actual wire protocol (Content-Length framed JSON-RPC over stdio)
+so the tests drive the same code path a real server would. It is not a mock:
+nothing is stubbed inside the agent, and the transport, framing, request/
+response correlation, and unsolicited notifications are all genuine.
+
+Its language is deliberately trivial:
+
+  * a line containing BROKEN is an error diagnostic
+  * a line containing SUSPECT is a warning
+  * `def <name>` declares a symbol
+  * definition/references resolve by exact word match across the document
+
+Behaviour switches for tests, via argv:
+
+  --no-diagnostics   never publish diagnostics (exercises the await timeout)
+  --rename-refuses   answer rename with null (a symbol that cannot be renamed)
+  --rename-escapes   answer rename with an edit to /etc/passwd (containment)
+  --slow-init N      wait N seconds before answering initialize
+"""
+
+import json
+import os
+import re
+import sys
+import time
+
+ARGS = set(sys.argv[1:])
+
+
+def arg_value(flag, default):
+    argv = sys.argv[1:]
+    if flag in argv:
+        index = argv.index(flag)
+        if index + 1 < len(argv):
+            return argv[index + 1]
+    return default
+
+
+documents = {}
+
+
+def read_message():
+    headers = {}
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            return None
+        line = line.decode("utf-8", "replace").strip()
+        if line == "":
+            break
+        if ": " in line:
+            key, value = line.split(": ", 1)
+            headers[key] = value
+    length = int(headers.get("Content-Length", 0))
+    if length == 0:
+        return None
+    body = sys.stdin.buffer.read(length)
+    return json.loads(body.decode("utf-8"))
+
+
+def send(payload):
+    body = json.dumps(payload).encode("utf-8")
+    try:
+        sys.stdout.buffer.write(b"Content-Length: %d\r\n\r\n" % len(body))
+        sys.stdout.buffer.write(body)
+        sys.stdout.buffer.flush()
+    except BrokenPipeError:
+        # The client closed the port. That is how a session ends, not an
+        # error; exiting quietly keeps it out of the test output.
+        os._exit(0)
+
+
+def respond(request_id, result):
+    send({"jsonrpc": "2.0", "id": request_id, "result": result})
+
+
+def notify(method, params):
+    send({"jsonrpc": "2.0", "method": method, "params": params})
+
+
+def u16(text, index):
+    """Python codepoint index -> UTF-16 code unit index.
+
+    LSP counts `character` in UTF-16 code units, so a real server reports 7
+    for a name that follows an emoji, not 6. Python string indices are
+    codepoints, so every offset leaving this process is converted -- without
+    it the fixture would be lenient in exactly the way that hides the bug.
+    """
+    return len(text[:index].encode("utf-16-le")) // 2
+
+
+def codepoint(text, unit):
+    """UTF-16 code unit index -> Python codepoint index."""
+    return len(text.encode("utf-16-le")[: unit * 2].decode("utf-16-le", "ignore"))
+
+
+def position(line, character):
+    return {"line": line, "character": character}
+
+
+def span(line, start, end):
+    """A range from UTF-16 code unit offsets."""
+    return {"start": position(line, start), "end": position(line, end)}
+
+
+def span_in(text, line, start, end):
+    """A range from Python codepoint offsets into `text`."""
+    return span(line, u16(text, start), u16(text, end))
+
+
+def publish_diagnostics(uri):
+    if "--no-diagnostics" in ARGS:
+        return
+
+    diagnostics = []
+    for number, text in enumerate(documents.get(uri, "").split("\n")):
+        if "BROKEN" in text:
+            column = text.index("BROKEN")
+            diagnostics.append(
+                {
+                    "range": span_in(text, number, column, column + len("BROKEN")),
+                    "severity": 1,
+                    "message": "this line is broken",
+                    "source": "fake-lsp",
+                }
+            )
+        elif "SUSPECT" in text:
+            column = text.index("SUSPECT")
+            diagnostics.append(
+                {
+                    "range": span_in(text, number, column, column + len("SUSPECT")),
+                    "severity": 2,
+                    "message": "this line is suspect",
+                    "source": "fake-lsp",
+                }
+            )
+
+    notify(
+        "textDocument/publishDiagnostics",
+        {"uri": uri, "diagnostics": diagnostics},
+    )
+
+
+def word_at(uri, line, character):
+    lines = documents.get(uri, "").split("\n")
+    if line >= len(lines):
+        return None
+    text = lines[line]
+    index = codepoint(text, character)
+    for match in re.finditer(r"[A-Za-z_][A-Za-z0-9_]*", text):
+        if match.start() <= index < match.end():
+            return match.group(0)
+    return None
+
+
+def occurrences(uri, word):
+    found = []
+    for number, text in enumerate(documents.get(uri, "").split("\n")):
+        for match in re.finditer(r"\b%s\b" % re.escape(word), text):
+            found.append(
+                {"uri": uri, "range": span_in(text, number, match.start(), match.end())}
+            )
+    return found
+
+
+def handle(message):
+    method = message.get("method")
+    request_id = message.get("id")
+    params = message.get("params") or {}
+
+    if method == "initialize":
+        delay = arg_value("--slow-init", None)
+        if delay:
+            time.sleep(float(delay))
+        respond(
+            request_id,
+            {
+                "capabilities": {
+                    "textDocumentSync": 1,
+                    "documentSymbolProvider": True,
+                    "definitionProvider": True,
+                    "referencesProvider": True,
+                    "hoverProvider": True,
+                    "renameProvider": True,
+                    "workspace": {
+                        "fileOperations": {
+                            "willRename": {"filters": [{"pattern": {"glob": "**/*"}}]}
+                        }
+                    },
+                },
+                "serverInfo": {"name": "fake-lsp", "version": "1"},
+            },
+        )
+        return
+
+    if method == "textDocument/didOpen":
+        document = params["textDocument"]
+        documents[document["uri"]] = document.get("text", "")
+        publish_diagnostics(document["uri"])
+        return
+
+    if method == "textDocument/didChange":
+        uri = params["textDocument"]["uri"]
+        changes = params.get("contentChanges") or []
+        if changes:
+            documents[uri] = changes[-1].get("text", "")
+        publish_diagnostics(uri)
+        return
+
+    if method == "textDocument/didClose":
+        documents.pop(params["textDocument"]["uri"], None)
+        return
+
+    if method == "textDocument/documentSymbol":
+        uri = params["textDocument"]["uri"]
+        symbols = []
+        for number, text in enumerate(documents.get(uri, "").split("\n")):
+            match = re.match(r"\s*def\s+([A-Za-z_][A-Za-z0-9_]*)", text)
+            if match:
+                symbols.append(
+                    {
+                        "name": match.group(1),
+                        "kind": 12,
+                        "range": span_in(text, number, 0, len(text)),
+                        "selectionRange": span_in(text, number, match.start(1), match.end(1)),
+                        "children": [],
+                    }
+                )
+        respond(request_id, symbols)
+        return
+
+    if method == "textDocument/definition":
+        uri = params["textDocument"]["uri"]
+        pos = params["position"]
+        word = word_at(uri, pos["line"], pos["character"])
+        if not word:
+            respond(request_id, None)
+            return
+        for number, text in enumerate(documents.get(uri, "").split("\n")):
+            match = re.match(r"\s*def\s+(%s)\b" % re.escape(word), text)
+            if match:
+                # A LocationLink, to exercise the shape most servers send.
+                respond(
+                    request_id,
+                    [
+                        {
+                            "targetUri": uri,
+                            "targetRange": span_in(text, number, 0, len(text)),
+                            "targetSelectionRange": span_in(
+                                text, number, match.start(1), match.end(1)
+                            ),
+                        }
+                    ],
+                )
+                return
+        respond(request_id, None)
+        return
+
+    if method == "textDocument/references":
+        uri = params["textDocument"]["uri"]
+        pos = params["position"]
+        word = word_at(uri, pos["line"], pos["character"])
+        respond(request_id, occurrences(uri, word) if word else [])
+        return
+
+    if method == "textDocument/hover":
+        uri = params["textDocument"]["uri"]
+        pos = params["position"]
+        word = word_at(uri, pos["line"], pos["character"])
+        if word:
+            respond(
+                request_id,
+                {"contents": {"kind": "markdown", "value": "`%s` is a symbol" % word}},
+            )
+        else:
+            respond(request_id, None)
+        return
+
+    if method == "textDocument/rename":
+        if "--rename-refuses" in ARGS:
+            respond(request_id, None)
+            return
+
+        uri = params["textDocument"]["uri"]
+        pos = params["position"]
+        new_name = params["newName"]
+        word = word_at(uri, pos["line"], pos["character"])
+        if not word:
+            respond(request_id, None)
+            return
+
+        target = "file:///etc/passwd" if "--rename-escapes" in ARGS else uri
+        edits = [
+            {"range": place["range"], "newText": new_name}
+            for place in occurrences(uri, word)
+        ]
+        respond(request_id, {"changes": {target: edits}})
+        return
+
+    if method == "workspace/willRenameFiles":
+        files = params.get("files") or []
+        if not files:
+            respond(request_id, None)
+            return
+        old_uri = files[0]["oldUri"]
+        new_name = files[0]["newUri"].rsplit("/", 1)[-1].rsplit(".", 1)[0]
+        respond(
+            request_id,
+            {
+                "documentChanges": [
+                    {
+                        "textDocument": {"uri": old_uri, "version": 1},
+                        "edits": [
+                            {"range": span(0, 0, 0), "newText": "# moved to %s\n" % new_name}
+                        ],
+                    }
+                ]
+            },
+        )
+        return
+
+    if method == "shutdown":
+        respond(request_id, None)
+        return
+
+    if method == "exit":
+        sys.exit(0)
+
+    # An unknown request still needs an answer or the client waits forever.
+    if request_id is not None:
+        respond(request_id, None)
+
+
+def main():
+    while True:
+        try:
+            message = read_message()
+        except Exception:
+            return
+        if message is None:
+            return
+        handle(message)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/raxol_agent/test/test_helper.exs
+++ b/packages/raxol_agent/test/test_helper.exs
@@ -78,6 +78,10 @@ ExUnit.start(
     :harness_red,
     # :live_longcat hits the real LongCat API; run with
     # `LONGCAT_API_KEY=<key> mix test --only live_longcat`.
-    :live_longcat
+    :live_longcat,
+    # :live_lsp drives a real language server (rust-analyzer) and indexes a
+    # crate, so it is minutes and a toolchain rather than seconds; run with
+    # `mix test --only live_lsp`.
+    :live_lsp
   ]
 )


### PR DESCRIPTION
Closes #932.

`Raxol.Agent.LSPContext` was 634 lines of LSP client that nothing referenced outside its own test. Wiring it up turned out to mean fixing it first: it could not have worked.

## Two defects, not just missing wiring

- **`Port.open` was passed `{:packet, 0}`**, which is not a valid option (only 1, 2, and 4 are). Every spawn raised `:badarg`, so no language server had ever started.
- **It never sent `textDocument/didOpen`.** Servers publish diagnostics only for documents the client has opened, so `diagnostics/2` would have returned `[]` forever, which is indistinguishable from "no problems found".

Both are consistent with the module never having been exercised end to end.

## What this adds

**Client.** didOpen / didChange / didClose with version tracking, `await_diagnostics` (a timeout is reported as a timeout, never as a clean bill of health), `definition`, `references`, `rename`, and `workspace/willRenameFiles`. It now answers server-initiated requests instead of leaving the server waiting on an id nothing replies to, and advertises only the capabilities it actually implements.

**Two tools, deliberately.** `sensitive` is declared per Action module at compile time, so one tool could not be read-only for `definition` and gated for `rename`:

| Tool | Sensitive? | Ops |
| --- | :---: | --- |
| `lsp` | No | `diagnostics`, `symbols`, `definition`, `references`, `hover` |
| `lsp_rename` | Yes | Renames through the server and writes the edits |

**`Lsp.Pool`.** One server per language, started on first use and kept for the session, because starting `rust-analyzer` per turn means indexing the crate per turn. It monitors the session process, so the servers and their subprocesses die with it by any exit path. This is the `Code.McpLoader` ownership pattern: no teardown path has to remember them, because there is no cleanup function to forget. `init/1` runs in the Lifecycle process, which is why that pid is the owner. The pool is unlinked so a fault in it cannot take the session down, and a crashing server is dropped rather than propagated.

**`Lsp.Config`.** Built-in defaults for elixir, rust, typescript, python, and go, plus `.raxol/lsp.json` to override or extend. Overriding a built-in by name inherits its extensions, so pointing `elixir` at `lexical` does not mean restating the file list. A malformed file falls back to the defaults rather than blocking boot. `mix raxol.inspect` and `/inspect` report which servers would serve the directory and whether each is installed.

## Correctness details worth a look

**UTF-16 columns.** LSP counts `character` in UTF-16 code units, not codepoints. Slicing by codepoint corrupts any line containing an emoji or CJK text, and this tool *writes files*, so that is a corrupting bug rather than a display one. Conversion happens once at the boundary, and an offset landing inside a surrogate pair fails the round trip and is refused instead of written. Positions crossing the tool boundary are 1-based to match `read_file`; LSP's 0-based indexing is converted in the same place.

**Rename containment.** A language server indexes outside the workspace. Every file the server asks to edit is re-resolved through `Fs.resolve/2` before anything is written, and one target outside the root fails the whole rename with nothing written. A server that answers with no edits is `:rename_not_possible`, not a success with zero files changed.

**Jailed sessions get no LSP at all.** A server is arbitrary code execution on the workspace twice over: `.raxol/lsp.json` names the binary, and the binary runs project code to answer anything (`rust-analyzer` executes `build.rs`, `elixir-ls` compiles the project). In a jail the workspace is tenant-written, which makes this exactly the refusal hooks and MCP servers already get.

**Model-facing errors.** `ToolConverter.public_error/2` is a whitelist, so an unlisted term reaches the model as the bare string `tool error`. Every new failure mode has an authored message that says what to do instead.

## Testing

`test/support/fake_lsp_server.py` is a real language server speaking the real wire protocol over stdio. Nothing inside the agent is stubbed, so the transport, framing, request/response correlation, and unsolicited notifications are all genuine.

It earned its keep immediately: the first version emitted Python codepoint offsets, and the UTF-16 test failed correctly against it. Making the fixture spec-compliant is what makes that test mean anything.

30 LSP tests and 6 app-wiring tests, covering the rename-escapes-the-workspace case, owner-death teardown, a missing server binary, and a server that never publishes diagnostics.

2469 tests pass in `raxol_agent`; compile is clean under `--warnings-as-errors` and the format gate passes.

## Deferred

Post-write diagnostics (surfacing new problems automatically after every write) are listed in #932 but left out here: they touch `Code.Edit`, which the hash-anchored edit work in #940 rewrites, and the conflict is not worth taking before that lands. The `diagnostics` op gives the capability now.

## Manual testing

- [ ] `rustup component add rust-analyzer`, then `cd packages/raxol_agent && mix test --only live_lsp` (the live suite could not run on the authoring machine: `rust-analyzer` there is a rustup proxy for a component that was never installed, and recurses infinitely. The suite now fails with that diagnosis instead of the raw recursion error, but it remains unverified against a real server.)
- [ ] `mix raxol.code` in a repo with a language server installed; confirm the boot status line names it, and that `/inspect` lists it as installed.
- [ ] Ask the agent for diagnostics on a file with a known error; confirm it reports the error rather than an empty list.
- [ ] Ask for a rename; confirm the approval prompt appears (it is a gated tool) and that denying it leaves the files untouched.
- [ ] Confirm `mix raxol.code --ssh --ssh-tenants DIR` reports `lsp disabled (jailed session)` and that the `lsp` tool declines.
- [ ] Kill a session mid-run and confirm no orphaned language-server process survives (`pgrep -f rust-analyzer`).
