### PR TITLE
Close a strict-sandbox escape and two MCP connection leaks

### DIFF
--- a/lib/raxol/repl/capture_io.ex
+++ b/lib/raxol/repl/capture_io.ex
@@ -28,15 +28,23 @@ defmodule Raxol.REPL.CaptureIO do
   use GenServer
 
   @doc """
-  Start a capture server holding at most `limit` bytes.
+  Start a capture server holding at most `limit` bytes, owned by the caller.
 
-  Started unlinked on purpose: the caller sets it as its own group leader and
-  closes it in an `after` block, and a link would turn a killed evaluation
-  into a crash report for a process that is simply no longer needed.
+  Unlinked on purpose: the caller sets it as its own group leader and closes it
+  in an `after` block, and a link would turn a killed evaluation into a crash
+  report for a process that is simply no longer needed.
+
+  Unlinked is not unattached. The caller is MONITORED, and the server stops
+  when it goes: an `after` block does not run when the evaluation is killed by
+  `Process.exit(pid, :brutal_kill)` on timeout, or by the VM on a
+  `max_heap_size` breach -- which are the two paths hostile input is meant to
+  take. Without the monitor each of them orphaned one capture server holding up
+  to `limit` bytes, forever, on a surface served anonymously over SSH. Stopping
+  on `:DOWN` is a normal exit, so it still produces no crash report.
   """
   @spec start(pos_integer()) :: {:ok, pid()}
   def start(limit) when is_integer(limit) and limit > 0 do
-    GenServer.start(__MODULE__, limit)
+    GenServer.start(__MODULE__, {limit, self()})
   end
 
   @doc """
@@ -54,8 +62,9 @@ defmodule Raxol.REPL.CaptureIO do
   end
 
   @impl GenServer
-  def init(limit) do
-    {:ok, %{buffer: [], size: 0, limit: limit, truncated?: false}}
+  def init({limit, owner}) do
+    Process.monitor(owner)
+    {:ok, %{buffer: [], size: 0, limit: limit, truncated?: false, owner: owner}}
   end
 
   @impl GenServer
@@ -69,6 +78,15 @@ defmodule Raxol.REPL.CaptureIO do
     {reply, state} = io_request(request, state)
     send(from, {:io_reply, reply_as, reply})
     {:noreply, state}
+  end
+
+  # The evaluation this capture belongs to is gone, so nothing will ever read
+  # the buffer or call `close/1`. Stop, whatever killed it.
+  def handle_info(
+        {:DOWN, _ref, :process, owner, _reason},
+        %{owner: owner} = state
+      ) do
+    {:stop, :normal, state}
   end
 
   def handle_info(_message, state), do: {:noreply, state}

--- a/lib/raxol/repl/sandbox.ex
+++ b/lib/raxol/repl/sandbox.ex
@@ -209,19 +209,33 @@ defmodule Raxol.REPL.Sandbox do
   # `apply` was already refused for exactly this reason; this is the same hole
   # reached through the dot.
   #
-  # `map.field` has the SAME AST shape as `mod.fun()` and must stay allowed --
-  # it is how you read a map in a REPL. The two are told apart by `no_parens`,
-  # which the parser sets on field access and not on a call.
+  # `map.field` has the SAME AST shape as a zero-arity `mod.fun`, and NOTHING in
+  # the AST tells them apart. `no_parens: true` looked like it did, and does not:
+  # the parser sets it on a genuine remote call written without parentheses, and
+  # Elixir still dispatches that call. `m = System; m.halt` reached
+  # `System.halt/0` through this clause, as did `m.get_env` and `:init.stop` --
+  # at `:strict`, the level documented as safe for anonymous SSH exposure.
   #
-  # Both levels refuse the call form. Dynamic dispatch is a legitimate thing to
-  # want, and `:none` is where it lives -- a level that exists to constrain
-  # untrusted input cannot also resolve arbitrary modules at runtime.
+  # Deciding it needs the RECEIVER's value, which exists only at runtime. A
+  # checker that never evaluates therefore cannot allow the form safely, so both
+  # sandboxed levels refuse it whole. Dot access is not lost: `u[:a]` reads a
+  # map and `Map.fetch!(u, :a)` reads either (`Map` is whitelisted at `:strict`),
+  # and `:none` -- the local-terminal level -- is unaffected.
+  #
+  # Restoring `u.a` under a sandbox means rewriting the node to a guarded call
+  # that raises when the receiver is an atom, which makes `check/2` a transformer
+  # rather than a checker. That is a larger change than a security fix should
+  # carry; see the PR that introduced this comment.
   defp check_node({{:., _, [_mod, func]}, meta, _args}, level)
        when level in [:standard, :strict] and is_list(meta) do
     # Reached only when the earlier clauses did not match, i.e. the module is
     # neither a literal alias nor a literal atom.
     if Keyword.get(meta, :no_parens, false) do
-      []
+      [
+        "#{func} on a computed receiver is not allowed " <>
+          "(a zero-arity remote call and map field access are indistinguishable; " <>
+          "use u[:#{func}] or Map.fetch!(u, :#{func}) to read a field)"
+      ]
     else
       [
         "#{func} on a computed module is not allowed " <>

--- a/packages/raxol_mcp/lib/raxol/mcp/server.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/server.ex
@@ -272,6 +272,20 @@ defmodule Raxol.MCP.Server do
     if Map.get(state.subscribers, conn_id) == pid do
       {:noreply, state}
     else
+      # Taking an id AWAY from a live subscriber is a new connection on it, so
+      # it starts clean. The `:DOWN` path already reasons that a stale id must
+      # not hand its capabilities or its parked elicitation to whoever takes it
+      # next; that is just as true when the id is rebound while the old
+      # subscriber is still alive, which `Map.put` alone let through.
+      #
+      # Only on a REBIND. A first subscribe must not clear, or it would discard
+      # the capabilities of a connection that sent `initialize` before it
+      # subscribed -- which is the order a direct in-VM caller naturally uses.
+      state =
+        if Map.has_key?(state.subscribers, conn_id),
+          do: drop_connection(conn_id, state),
+          else: state
+
       # One monitor per PID, not per connection. `{:DOWN, ...}` already drops
       # every id that pid held, so a process subscribed under several ids
       # would otherwise accumulate monitors and deliver as many DOWNs, all but
@@ -364,6 +378,12 @@ defmodule Raxol.MCP.Server do
     # that changes behaviour: it is the difference between denying an ASK and
     # asking. Held globally, one client advertising it would turn prompting on
     # for every other client on the server.
+    #
+    # This map is keyed by connection and evicted on that connection's `:DOWN`,
+    # so every key must be one a subscriber can eventually own. A transport that
+    # mints a fresh key per REQUEST for callers it cannot identify would grow it
+    # without bound and without authentication; see `Transport.SSE`, which
+    # collapses those onto one shared key for that reason.
     client_capabilities =
       msg
       |> Map.get(:params, %{})

--- a/packages/raxol_mcp/lib/raxol/mcp/transport/sse.ex
+++ b/packages/raxol_mcp/lib/raxol/mcp/transport/sse.ex
@@ -194,15 +194,26 @@ if Code.ensure_loaded?(Plug.Router) do
 
     # -- Private ----------------------------------------------------------------
 
-    # The connection a request belongs to. A caller that presents no session id
-    # gets a FRESH anonymous id rather than a shared one: two unidentified
-    # callers must not land on the same connection, or one could answer the
-    # other's elicitation exactly as before. An anonymous connection has no
-    # subscriber, so it can never elicit and never owns anything to answer.
+    # The connection a request belongs to. Callers that present no session id
+    # all share ONE key. It is safe for them to: an elicitation can only be
+    # parked by a connection that has a subscriber (`elicitation_capable?/2`
+    # checks that first), and this key is never subscribed -- `GET /mcp/sse` is
+    # the only thing that subscribes, and it subscribes under the id it minted.
+    # So no elicitation can ever be owned here, and there is nothing for one
+    # unidentified caller to answer on another's behalf.
+    #
+    # A fresh id per request looked safer and was worse. `initialize` records
+    # capabilities under whatever key it is given, and that map is only ever
+    # evicted on a subscriber's `:DOWN` -- which a never-subscribed key does not
+    # have. One unauthenticated POST per permanent entry, with a caller-supplied
+    # map as its value, is unbounded memory growth with no way to reclaim it.
+    # One shared key is bounded by construction.
+    @anonymous_conn :anonymous
+
     defp conn_id(conn) do
       case Plug.Conn.get_req_header(conn, "mcp-session-id") do
         [id | _] when is_binary(id) and id != "" -> id
-        _ -> {:anonymous, mint_session_id()}
+        _ -> @anonymous_conn
       end
     end
 

--- a/packages/raxol_mcp/test/raxol/mcp/elicitation_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/elicitation_test.exs
@@ -325,6 +325,68 @@ defmodule Raxol.MCP.ElicitationTest do
       refute_receive {:mcp_notification, %{method: "elicitation/create"}}, 200
     end
 
+    test "taking over a live connection's id inherits nothing from it", %{server: server} do
+      # `:DOWN` clears a departing connection's capabilities and parked
+      # elicitation so the next holder of the id cannot inherit them. Rebinding
+      # the id while the old subscriber is still ALIVE is the same handover and
+      # was not covered: `subscribe/3` overwrote the pid and left both behind.
+      assert {:reply, nil} = call_a(server)
+      elicit_id = await_elicit_id()
+
+      # A new process takes "conn-a" over. A's parked spend and A's advertised
+      # elicitation capability must not come with it.
+      me = self()
+      c = spawn_link(fn -> forward(me) end)
+      Server.subscribe(server, c, "conn-a")
+      _ = Server.authorization_configured?(server)
+
+      # The inherited elicitation is not answerable: A's spend stays unrun.
+      assert {:reply, nil} = answer_as(server, "conn-a", elicit_id)
+      refute_receive {:mcp_notification, %{id: 7}}, 200
+      refute_receive {:b_got, _}, 200
+
+      # And the inherited capability is not in force: the taker never
+      # advertised elicitation, so an ASK denies rather than prompts.
+      assert {:reply, response} =
+               Server.handle_message(
+                 server,
+                 %{
+                   jsonrpc: "2.0",
+                   id: 11,
+                   method: "tools/call",
+                   params: %{"name" => "spend", "arguments" => %{"amount" => 5}}
+                 },
+                 "conn-a"
+               )
+
+      assert %{"error" => "authorization_required"} = decoded_payload(response)
+      refute_receive {:b_got, %{method: "elicitation/create"}}, 200
+    end
+
+    test "an unsubscribed connection can never park an elicitation", %{server: server} do
+      # This is what lets `Transport.SSE` collapse every unidentified caller
+      # onto one shared conn id instead of minting a fresh one per request --
+      # the fresh ids were never evicted and grew without bound. The safety of
+      # sharing rests entirely on this: no subscriber, no elicitation to own,
+      # so nothing for one anonymous caller to answer on another's behalf.
+      :ok = initialize(server, %{elicitation: %{}}, :anonymous)
+
+      assert {:reply, response} =
+               Server.handle_message(
+                 server,
+                 %{
+                   jsonrpc: "2.0",
+                   id: 13,
+                   method: "tools/call",
+                   params: %{"name" => "spend", "arguments" => %{"amount" => 5}}
+                 },
+                 :anonymous
+               )
+
+      assert %{"error" => "authorization_required"} = decoded_payload(response)
+      refute_receive {:mcp_notification, %{method: "elicitation/create"}}, 200
+    end
+
     defp call_a(server) do
       Server.handle_message(
         server,

--- a/packages/raxol_mcp/test/raxol/mcp/transport/sse_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/transport/sse_test.exs
@@ -280,5 +280,20 @@ defmodule Raxol.MCP.Transport.SSETest do
       # The tool never ran, and sess-1's parked call is untouched.
       refute_receive {:mcp_notification, %{id: 7}}, 200
     end
+
+    test "unidentified POSTs do not grow the server's state", %{ask_server: s} do
+      # `initialize` records the caller's capabilities under its conn id, and
+      # that map is only ever evicted on a subscriber's `:DOWN`. Minting a fresh
+      # id per unidentified REQUEST therefore left one permanent entry behind
+      # per POST -- unauthenticated, unbounded, with a caller-supplied map as
+      # the value. Every unidentified caller shares one id instead.
+      capabilities = %{elicitation: %{}, padding: String.duplicate("x", 512)}
+
+      for _ <- 1..50 do
+        post_mcp(s, Protocol.request(1, "initialize", %{capabilities: capabilities}))
+      end
+
+      assert map_size(:sys.get_state(s).client_capabilities) == 1
+    end
   end
 end

--- a/test/raxol/repl/evaluator_test.exs
+++ b/test/raxol/repl/evaluator_test.exs
@@ -195,6 +195,52 @@ defmodule Raxol.REPL.EvaluatorTest do
       assert_received {:eval_result, {:ok, :stale_untagged, [], ""}}
       assert_received {:eval_result, _, {:ok, :stale_tagged, [], ""}}
     end
+
+    test "a killed evaluation leaves no capture server behind" do
+      # Cleanup lives in an `after` block, which does NOT run when the process
+      # is killed by `Process.exit(pid, :brutal_kill)` on timeout or by the VM
+      # on a max_heap_size breach -- the two paths hostile input is designed to
+      # take. `CaptureIO` is started unlinked, so each of those orphaned one
+      # server holding up to the output limit, on an anonymous SSH surface.
+      #
+      # Counted rather than tracked by pid: the capture is private to the
+      # evaluation, and what matters is that the count comes back, not which
+      # process went.
+      eval = Evaluator.new()
+      before = capture_server_count()
+
+      assert {:error, timed_out, _eval} =
+               Evaluator.eval(eval, "Process.sleep(:infinity)", timeout: 100)
+
+      assert timed_out =~ "timed out"
+
+      assert {:error, over_heap, _eval} =
+               Evaluator.eval(
+                 eval,
+                 "Enum.reduce(1..10_000_000, [], fn i, acc -> [i | acc] end)",
+                 max_heap_bytes: 2 * 1024 * 1024,
+                 timeout: 30_000
+               )
+
+      assert over_heap =~ "memory limit"
+
+      # The servers stop asynchronously on the owner's :DOWN.
+      Process.sleep(200)
+      assert capture_server_count() == before
+    end
+  end
+
+  defp capture_server_count do
+    Enum.count(Process.list(), fn pid ->
+      case Process.info(pid, :dictionary) do
+        {:dictionary, dict} ->
+          Keyword.get(dict, :"$initial_call") ==
+            {Raxol.REPL.CaptureIO, :init, 1}
+
+        nil ->
+          false
+      end
+    end)
   end
 
   # `:io.format/2` does not send the finished bytes -- it sends

--- a/test/raxol/repl/sandbox_test.exs
+++ b/test/raxol/repl/sandbox_test.exs
@@ -200,12 +200,44 @@ defmodule Raxol.REPL.SandboxTest do
       end
     end
 
-    test "map field access is not mistaken for dynamic dispatch" do
-      # `map.field` and `mod.fun()` are the same AST shape, and reading a map
-      # is most of what a REPL session does.
-      assert :ok = Sandbox.check("m = %{count: 1}; m.count", :strict)
-      assert :ok = Sandbox.check("s.a.b", :strict)
-      assert :ok = Sandbox.check("conn.assigns.user", :standard)
+    test "a zero-arity call on a computed module cannot be dispatched through" do
+      # The no-parens form was allowed on the premise that the parser sets
+      # `no_parens: true` on map field access and not on a call. It sets it on
+      # BOTH, and Elixir dispatches the call: this reached `System.halt/0` on an
+      # anonymously-exposed SSH REPL, and `System.get_env/0` dumped every
+      # secret in the environment. Arity is the only thing the parens form had
+      # that this one does not.
+      for level <- [:standard, :strict] do
+        for code <- [
+              "m = System; m.halt",
+              "m = System; m.stop",
+              "m = System; m.get_env",
+              "m = :init; m.stop",
+              "m = Process; m.list"
+            ] do
+          assert {:error, [msg]} = Sandbox.check(code, level),
+                 "expected #{inspect(code)} to be refused at #{level}"
+
+          assert msg =~ "computed receiver"
+        end
+      end
+    end
+
+    test "field access has a whitelisted replacement under a sandbox" do
+      # Refusing the ambiguous form costs `u.a`, because nothing in the AST
+      # separates it from a call. Both replacements stay available, including
+      # at :strict where `Map` is whitelisted.
+      assert {:error, _} = Sandbox.check("m = %{count: 1}; m.count", :strict)
+
+      assert :ok = Sandbox.check("m = %{count: 1}; m[:count]", :strict)
+
+      assert :ok =
+               Sandbox.check("m = %{count: 1}; Map.fetch!(m, :count)", :strict)
+    end
+
+    test "dot access is untouched at :none, the local-terminal level" do
+      assert :ok = Sandbox.check("m = %{count: 1}; m.count", :none)
+      assert :ok = Sandbox.check("conn.assigns.user", :none)
     end
 
     test ":erlang.apply is denied at standard" do


### PR DESCRIPTION
Adversarial review findings on #931, fixed in its own lineage rather than
against master: #931 rewrites `sandbox.ex` itself, so patching master
separately would collide in the security-critical file.

Each fix was proven RED before GREEN.

## Refuse no-parens dispatch on a computed receiver

`m = System; m.halt` passed the **strict** sandbox and reached
`System.halt/0`. So did `m.get_env`, which returns every environment
variable, and `m = :init; m.stop`.

```
m = System\nm.halt()    {:error, ["halt on a computed module is not allowed"]}
m = System\nm.halt      :ok      <- before
m = System\nm.get_env   :ok      <- before
```

`ReplDemo` runs at `:strict` and is served anonymously over SSH, so this
is an unauthenticated node kill and a credential dump against the level
documented as safe for exactly that exposure.

The clause allowed the form on the premise that the parser sets
`no_parens: true` on map field access and not on a call. It sets it on
both, and Elixir dispatches the call — confirmed at runtime, `m.get_env`
returns a populated map. Nothing else in the AST separates `u.a` from a
zero-arity `mod.fun`; deciding it needs the receiver's value, which a
checker that never evaluates does not have.

Both sandboxed levels now refuse it. Dot access is not lost: `u[:a]`
reads a map, `Map.fetch!(u, :a)` reads either and `Map` is whitelisted at
`:strict`, and `:none` is untouched.

**Master is worse, not better.** Without this clause at all, both the
parens and no-parens forms return `:ok` there. #931 closes the parens
half; this closes the rest. Landing #931 is the production fix.

## Stop the capture server with the evaluation it serves

`CaptureIO` is started unlinked and closed in an `after` block. That
block does not run when the evaluation is killed by
`Process.exit(pid, :brutal_kill)` on timeout or by the VM on a
`max_heap_size` breach — the two paths hostile input is designed to take.
Each orphaned one capture server holding up to the output limit, forever,
on the same anonymous SSH surface. The module whose whole purpose is
bounding memory leaked on exactly the paths where its bound fires.

`StringIO`, which it replaced, died with its caller and did not have this,
so the regression arrives with #931.

Now monitors the owner and stops on `:DOWN`. Unlinked is still worth
keeping, but unlinked does not have to mean unattached, and a stop on
`:DOWN` is a normal exit, so no crash report appears either way.

With the monitor removed the new test finds exactly two orphans, one per
kill path.

## Bound MCP connection state, and clear an id on takeover

Two holes in the per-connection elicitation binding.

`initialize` records capabilities under the caller's conn id, and that map
is only evicted on a subscriber's `:DOWN`. The SSE transport minted a
fresh id per *unidentified request*, and such an id never subscribes, so
it never has a `:DOWN` — one unauthenticated POST left one permanent
entry, with a caller-supplied map as its value. Unbounded growth, no way
to reclaim it.

The fresh id existed so one unidentified caller could not answer
another's elicitation. It never could: parking one requires a subscriber
(`elicitation_capable?/2` checks that first) and these ids are never
subscribed. They now share one key, bounded by construction, with a test
pinning the invariant that makes that safe.

Second, `subscribe/3` overwrote the pid for an id already held by a
**live** subscriber and left its capabilities and parked elicitation in
place. The `:DOWN` path already reasons that a departing id must not hand
those to whoever takes it next; a rebind is the same handover. Without
this, the taking-over process answered the previous connection's parked
`tools/call` and received `"spent 5"` — the RED run fails exactly that
way. Only on a rebind: a first subscribe must not clear, or it discards
the capabilities of a connection that sent `initialize` before
subscribing.

## Not fixed here

- `mcp-session-id` is an unauthenticated bearer credential sent as a
  request header, where proxies and access logs capture it. Worth stating
  in the moduledoc.
- `capabilities.ex` derives package versions from the repo's `mix.exs`,
  but the claim it renders is "what you can `mix deps.get`". Between a
  version bump and the manual Hex publish, raxol.io advertises an
  unresolvable version. That is #942 content.
- Restoring `u.a` under a sandbox needs the node rewritten to a guarded
  call that raises on an atom receiver, which turns `check/2` into a
  transformer. Larger than a security fix should carry.

## Testing

- `mix test test/raxol/repl/` — 83 passing
- `mix test test/raxol/playground/` — included in the 410 above
- `packages/raxol_mcp` — 364 passing (31 properties, 333 tests)
- `mix format --check-formatted` clean at root and in `packages/raxol_mcp`
- `mix compile --warnings-as-errors` clean for both

## Manual testing

- [ ] `mix raxol.playground --ssh`, open the REPL demo, confirm
      `m = System; m.halt` is refused and the message names the
      replacement
- [ ] Confirm `u = %{a: 1}; u[:a]` and `Map.fetch!(u, :a)` still work in
      that REPL
- [ ] Drive an MCP SSE client through an elicitation round trip to
      confirm identified sessions still prompt and answer
