### PR TITLE
Browser pane as a page, and drop the routeless components

### DIFF
--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -2062,23 +2062,61 @@ html {
 .ansi-italic { font-style: italic; }
 .ansi-underline { text-decoration: underline; }
 
-.hero-live-wrap {
-  padding: 1rem 1.25rem;
-}
-
-.hero-live-wrap .raxol-terminal {
+/* The browser pane's page. The chrome is the whole point: the terminal tab
+   shows the same recording bare, so what distinguishes this one is that the
+   frame is an ELEMENT here, with a URL above it and page text around it. Take
+   the chrome away and the two tabs are one picture twice. */
+.hero-browser {
   border: 1px solid var(--panel-border);
   border-radius: 6px;
-  padding: 0.75rem 0.9rem;
+  overflow: hidden;
 }
 
-.hero-live-badge {
+.hero-browser__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem;
+  border-bottom: 1px solid var(--panel-border);
+  background: var(--panel-bg-subtle);
+}
+
+.hero-browser__dot {
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 50%;
+  background: var(--panel-border-hover);
+  flex: 0 0 auto;
+}
+
+.hero-browser__url {
   font-family: var(--font-mono);
-  font-size: 0.6rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: #8fca8f;
-  margin-right: auto;
+  font-size: 0.62rem;
+  color: var(--text-dim);
+  /* The bar is chrome and must never set the pane's width: an unclipped URL
+     on a narrow pane would widen the box past the frame it wraps. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hero-browser__page {
+  padding: 0.7rem 0.8rem;
+}
+
+.hero-browser__heading {
+  font-family: var(--font-heading);
+  font-size: 0.95rem;
+  color: var(--pearl-cream);
+  margin: 0 0 0.5rem;
+}
+
+.hero-browser__caption {
+  font-family: var(--font-body);
+  font-size: 0.62rem;
+  line-height: 1.5;
+  color: var(--text-dim);
+  margin: 0.5rem 0 0;
 }
 
 /* =============================================================================
@@ -2853,6 +2891,23 @@ input[type="range"]::-moz-range-thumb {
   /* Stated, not inherited: `.raxol-terminal` sets its line height in absolute
      units, so shrinking the type alone leaves the rows their original height
      and the frame keeps overflowing. */
+  line-height: 1.5;
+}
+
+/* The browser pane plays the same frames inside a page, so it fits them the
+   same way against a smaller budget: the URL bar, the heading and the caption
+   all sit between the pane's height and the frame's. Their heights are stated
+   here as one constant, the way the rule above states 3.1rem, because a
+   container query reports the pane's box and not its siblings'. */
+.screen-main .hero-browser .hero-frames pre {
+  font-size: clamp(
+    0.45rem,
+    min(
+      calc((100cqw - 3.4rem) / var(--frame-cols, 62) / 0.7),
+      calc((100cqh - 10.5rem) / var(--frame-rows, 13) / 1.5)
+    ),
+    1.15rem
+  );
   line-height: 1.5;
 }
 

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -754,42 +754,6 @@ html {
 }
 
 /* =============================================================================
-   Install-method tabs (hero): curl / brew / npm / hex over one command line.
-   Same recipe as .hero-tab, centered; panes are .ssh-hero copy blocks.
-   ============================================================================= */
-
-.install-tabs__row {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  margin-bottom: 1rem;
-}
-
-.install-tab {
-  appearance: none;
-  background: none;
-  border: none;
-  border-bottom: 2px solid transparent;
-  color: var(--text-dim);
-  font-family: var(--font-mono);
-  font-size: 0.74rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  padding: 0.55rem 1rem;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color var(--duration-fast) var(--ease-smooth),
-              border-color var(--duration-fast) var(--ease-smooth);
-}
-
-.install-tab:hover { color: var(--pearl-cream); }
-
-.install-tab[aria-selected="true"] {
-  color: var(--axol-coral);
-  border-bottom-color: var(--axol-coral);
-}
-
-/* =============================================================================
    Badge
    ============================================================================= */
 
@@ -874,45 +838,10 @@ html {
   color: var(--text-ghost);
 }
 
-/* Feature grid stagger animation */
-.feature-card {
-  animation: fadeInUp 0.5s ease-out both;
-}
-
-.feature-card:nth-child(1) { animation-delay: 0ms; }
-.feature-card:nth-child(2) { animation-delay: 80ms; }
-.feature-card:nth-child(3) { animation-delay: 160ms; }
-.feature-card:nth-child(4) { animation-delay: 240ms; }
-.feature-card:nth-child(5) { animation-delay: 320ms; }
-.feature-card:nth-child(6) { animation-delay: 400ms; }
-.feature-card:nth-child(7) { animation-delay: 480ms; }
-.feature-card:nth-child(8) { animation-delay: 560ms; }
-
-@keyframes fadeInUp {
-  from { opacity: 0; transform: translateY(12px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-/* Category tags */
-.category-tag {
-  padding: 0.25rem 0.75rem;
-  font-family: var(--font-mono);
-  font-size: clamp(0.55rem, 0.5rem + 0.25vw, 0.65rem);
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  color: var(--text-secondary);
-  background: rgba(10, 10, 12, 0.5);
-  border: 1px solid var(--panel-border);
-  border-radius: 4px;
-}
-
-/* Cursor blink */
+/* The blinking cursor every copyable command block ends on. Kept when the dead
+   landing components went: `PlaygroundComponents.ssh_copy_block/1` still asks
+   for it by this exact name. The Tailwind config's `cursor-blink` entry builds
+   `animate-cursor-blink`, a different class, so it is not a substitute. */
 @keyframes cursorBlink {
   0%, 100% { opacity: 1; }
   50% { opacity: 0; }
@@ -920,6 +849,16 @@ html {
 
 .cursor-blink {
   animation: cursorBlink 1s step-end infinite;
+}
+
+/* `.repl-entry` and `.prompt` below animate with this by name. The Tailwind
+   config declares a matching keyframe, but Tailwind only emits keyframes for a
+   utility it actually generates, and no template uses `animate-fade-in` -- so
+   deleting this one stopped both animations rather than falling back to it.
+   `fadeInUp` went with the feature grid that was its only caller. */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 /* =============================================================================
@@ -1071,17 +1010,6 @@ html {
   width: 100%;
   height: 100%;
 }
-
-/* Install-method pane links (only channels that exist are linked). */
-.install-link {
-  color: var(--sky);
-  text-transform: none;
-  letter-spacing: 0.02em;
-  margin-left: 0.4rem;
-  transition: color var(--duration-fast) var(--ease-smooth);
-}
-
-.install-link:hover { color: var(--pearl-cream); }
 
 /* =============================================================================
    Privacy tier ladder (agent payments deep dive)
@@ -1268,106 +1196,6 @@ html {
 }
 
 .token-fact__val { color: var(--pearl-cream); overflow-wrap: anywhere; }
-
-/* =============================================================================
-   FAQ accordion (native <details>)
-   ============================================================================= */
-
-.faq-list {
-  display: flex;
-  flex-direction: column;
-  gap: 0.875rem;
-}
-
-.faq-item {
-  background: rgba(10, 10, 12, 0.4);
-  border: 1px solid var(--panel-border);
-  border-radius: 8px;
-  padding: 1.1rem 1.4rem;
-  transition: border-color var(--duration-normal) var(--ease-smooth);
-}
-
-.faq-item:hover { border-color: var(--panel-border-hover); }
-
-.faq-item summary {
-  cursor: pointer;
-  font-family: var(--font-mono);
-  font-size: clamp(0.85rem, 0.8rem + 0.25vw, 0.95rem);
-  color: var(--pearl-cream);
-  list-style: none;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 1rem;
-}
-
-.faq-item summary::-webkit-details-marker { display: none; }
-.faq-item summary::marker { display: none; content: ''; }
-
-.faq-item summary::after {
-  content: '+';
-  color: var(--axol-coral);
-  font-size: 1.15rem;
-  line-height: 1;
-  transition: transform var(--duration-normal) var(--ease-smooth);
-}
-
-.faq-item[open] summary::after { content: '\2212'; }
-
-.faq-item__body {
-  margin-top: 0.875rem;
-  padding-top: 0.875rem;
-  border-top: 1px solid var(--panel-border);
-  font-family: var(--font-mono);
-  font-size: clamp(0.78rem, 0.73rem + 0.25vw, 0.85rem);
-  line-height: 1.7;
-  color: var(--text-secondary);
-}
-
-/* =============================================================================
-   Feature card numeric index (small label above title)
-   ============================================================================= */
-
-.feature-card__index {
-  font-family: var(--font-mono);
-  font-size: 0.62rem;
-  text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: var(--text-dim);
-  margin-bottom: 0.5rem;
-  display: block;
-}
-
-/* =============================================================================
-   Package card copy button (visible on hover)
-   ============================================================================= */
-
-.pkg-copy-btn {
-  position: absolute;
-  top: 0.75rem;
-  right: 0.75rem;
-  opacity: 0;
-  font-family: var(--font-mono);
-  font-size: 0.6rem;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--text-secondary);
-  background: rgba(10, 10, 12, 0.6);
-  border: 1px solid var(--panel-border);
-  padding: 0.2rem 0.55rem;
-  border-radius: 3px;
-  cursor: pointer;
-  transition: opacity var(--duration-normal) var(--ease-smooth),
-              color var(--duration-normal) var(--ease-smooth),
-              border-color var(--duration-normal) var(--ease-smooth);
-}
-
-.panel:hover .pkg-copy-btn { opacity: 1; }
-.pkg-copy-btn:focus-visible { opacity: 1; }
-.pkg-copy-btn:hover {
-  color: var(--axol-coral);
-  border-color: var(--coral-25);
-}
 
 /* =============================================================================
    Playground Styles (existing, adapted to new tokens)
@@ -2287,6 +2115,22 @@ html {
   margin-left: auto;
   color: var(--text-dim);
   font-variant-numeric: tabular-nums;
+}
+
+/* The base every `.category-tag` carries; `--sm` below only overrides size.
+   Kept when the dead landing components went, because /gallery still uses it
+   for the filter row and the per-demo tags. */
+.category-tag {
+  padding: 0.25rem 0.75rem;
+  font-family: var(--font-mono);
+  font-size: clamp(0.55rem, 0.5rem + 0.25vw, 0.65rem);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-secondary);
+  background: rgba(10, 10, 12, 0.5);
+  border: 1px solid var(--panel-border);
+  border-radius: 4px;
 }
 
 .category-tag--sm {

--- a/web/assets/js/app.js
+++ b/web/assets/js/app.js
@@ -409,26 +409,6 @@ Hooks.MotionPref = {
 // Install-method tabs (hero). All four panes ship server-rendered; this
 // only toggles which is visible, so no server round trip and the curl
 // pane shows before JS loads. Delegated click survives LiveView patches.
-Hooks.InstallTabs = {
-  mounted() {
-    this.onClick = (e) => {
-      const btn = e.target.closest('.install-tab')
-      if (!btn || !this.el.contains(btn)) return
-      const method = btn.dataset.m
-      this.el.querySelectorAll('.install-tab').forEach((tab) => {
-        tab.setAttribute('aria-selected', tab.dataset.m === method ? 'true' : 'false')
-      })
-      this.el.querySelectorAll('.install-pane').forEach((pane) => {
-        pane.hidden = pane.dataset.m !== method
-      })
-    }
-    this.el.addEventListener('click', this.onClick)
-  },
-  destroyed() {
-    this.el.removeEventListener('click', this.onClick)
-  }
-}
-
 // The hero brand mark: the axol face (AxolFace.glyph/3 frames, exported by
 // the server in data-faces) dithered into character cells, framed by a
 // drifting edge texture -- the Halo treatment. Face and halo are two

--- a/web/config/config.exs
+++ b/web/config/config.exs
@@ -3,6 +3,18 @@ import Config
 # Configure the endpoint
 config :raxol_playground, RaxolPlaygroundWeb.Endpoint,
   url: [host: "localhost"],
+  # Compress dynamic responses. `Plug.Static`'s `gzip:` covers pre-compressed
+  # assets on disk and nothing else, so every HTML response left here
+  # uncompressed: the landing page alone is hundreds of kilobytes, most of it
+  # the hero's recorded frames, which are braille and repeated spans and so
+  # compress about fortyfold.
+  #
+  # `compress: true` rather than a hand-written `stream_handlers` list under
+  # `protocol_options`: `Plug.Cowboy` reads both as TOP-LEVEL options and
+  # merges its own defaults last, so a nested list is silently overridden and
+  # the page ships uncompressed anyway. This form also keeps
+  # `cowboy_telemetry_h`, which naming the handlers by hand drops.
+  http: [compress: true],
   render_errors: [
     formats: [html: RaxolPlaygroundWeb.ErrorHTML, json: RaxolPlaygroundWeb.ErrorJSON],
     layout: false

--- a/web/lib/raxol_playground/recorded_frames.ex
+++ b/web/lib/raxol_playground/recorded_frames.ex
@@ -14,8 +14,9 @@ defmodule RaxolPlayground.RecordedFrames do
   surface writes -- one of each per captured frame, so the two panes step
   together. `surface.mcp.json` is the tree the MCP surface serves, projected
   from frame zero: a structure rather than a picture, and the same in every
-  frame. The browser surface needs no artifact of its own, since frame zero is
-  already the LiveView encoding.
+  frame. The browser surface needs no artifact of its own, because
+  `frame_NN.html` IS the LiveView encoding: that pane renders the same sequence
+  the terminal pane steps, inside a page, rather than deriving anything.
 
   `interval_ms` carries the tick the recording was sampled at, which is what
   the page plays it back at.
@@ -125,19 +126,8 @@ defmodule RaxolPlayground.RecordedFrames do
                     {name, interval}
                   end)
 
-  # The browser artifact is frame zero itself, so that pane shows the source
-  # of the markup the terminal pane renders and the two cannot disagree.
   @hero_artifacts Map.new(surface_paths, fn {name, %{ansi: ansi, mcp: mcp}} ->
-                    {name,
-                     %{
-                       browser:
-                         hero_paths
-                         |> Map.fetch!(name)
-                         |> List.first()
-                         |> File.read!(),
-                       ssh: File.read!(ansi),
-                       mcp: File.read!(mcp)
-                     }}
+                    {name, %{ssh: File.read!(ansi), mcp: File.read!(mcp)}}
                   end)
 
   # Derived once: the artifacts are compile-time constants, so the line
@@ -145,13 +135,11 @@ defmodule RaxolPlayground.RecordedFrames do
   @hero_surfaces Map.new(@hero_artifacts, fn {name, artifacts} ->
                    panes =
                      Map.new(artifacts, fn
-                       # SSH is painted, not listed. The other two surfaces
-                       # carry structured text a reader reads line by line, so
-                       # they are broken to a line budget with a marker. This
-                       # one carries a picture, so it keeps its own grid whole
-                       # and the CSS fits the type to it, exactly as the
-                       # terminal pane beside it does. Frame zero only; the
-                       # sequence it belongs to is built below.
+                       # SSH is painted, not listed: it carries a picture, so
+                       # it keeps its own grid whole and the CSS fits the type
+                       # to it, exactly as the terminal pane beside it does.
+                       # Frame zero only; the sequence it belongs to is built
+                       # below.
                        {:ssh, artifact} ->
                          rows = SurfaceSource.ansi_rows(artifact)
 
@@ -161,23 +149,19 @@ defmodule RaxolPlayground.RecordedFrames do
                             grid: SurfaceSource.ansi_grid(rows)
                           }}
 
-                       {surface, artifact} ->
-                         lines =
-                           case surface do
-                             :browser -> SurfaceSource.dom_lines(artifact)
-                             :mcp -> SurfaceSource.json_lines(artifact)
-                           end
-
-                         kind = %{browser: :dom, mcp: :json}[surface]
-
+                       # MCP carries structured text a reader reads line by
+                       # line, so it is broken to a line budget with a marker
+                       # naming what was cut.
+                       {:mcp, artifact} ->
                          clamped =
-                           lines
+                           artifact
+                           |> SurfaceSource.json_lines()
                            |> SurfaceSource.wrap()
                            |> SurfaceSource.clamp(artifact)
 
-                         {surface,
+                         {:mcp,
                           %{
-                            html: SurfaceSource.to_html(clamped, kind),
+                            html: SurfaceSource.to_html(clamped, :json),
                             lines: length(clamped)
                           }}
                      end)
@@ -315,8 +299,13 @@ defmodule RaxolPlayground.RecordedFrames do
     @hero_artifacts |> Map.get(example, %{}) |> Map.get(surface, "")
   end
 
-  @typedoc "A hero surface other than the terminal, which plays frames."
-  @type surface :: :browser | :ssh | :mcp
+  @typedoc """
+  A hero surface with an artifact of its own.
+
+  The terminal and browser panes both play `hero_frames/1` and so appear here
+  under neither name.
+  """
+  @type surface :: :ssh | :mcp
 
   @doc "Rendered preview frame for a catalog demo name, or nil."
   @spec preview(String.t()) :: String.t() | nil

--- a/web/lib/raxol_playground/recorded_frames.ex
+++ b/web/lib/raxol_playground/recorded_frames.ex
@@ -119,8 +119,11 @@ defmodule RaxolPlayground.RecordedFrames do
 
                     interval =
                       case File.read(path) do
-                        {:ok, raw} -> raw |> String.trim() |> String.to_integer()
-                        {:error, _} -> raise "#{path} is missing; rerun gen_landing_frames.exs"
+                        {:ok, raw} ->
+                          raw |> String.trim() |> String.to_integer()
+
+                        {:error, _} ->
+                          raise "#{path} is missing; rerun gen_landing_frames.exs"
                       end
 
                     {name, interval}

--- a/web/lib/raxol_playground/surface_source.ex
+++ b/web/lib/raxol_playground/surface_source.ex
@@ -4,12 +4,12 @@ defmodule RaxolPlayground.SurfaceSource do
 
   Two shapes, because the surfaces carry two kinds of thing.
 
-  The browser and MCP artifacts are structured text, read line by line. The
-  line functions only re-break the stream, so every emitted line is a substring
-  of the artifact; `clamp/2` is the one step that drops anything, and it
-  appends a marker naming what it dropped. Lines are broken rather than wrapped
-  because the height budget is counted in lines: a wrapped line costs two and
-  pushes the marker off the pane.
+  The MCP artifact is structured text, read line by line. `json_lines/1` only
+  re-breaks the stream, so every emitted line is a substring of the artifact;
+  `clamp/2` is the one step that drops anything, and it appends a marker naming
+  what it dropped. Lines are broken rather than wrapped because the height
+  budget is counted in lines: a wrapped line costs two and pushes the marker
+  off the pane.
 
   The SSH artifact is a picture. `ansi_rows/1` decodes its colour instead of
   spelling it out, and nothing is clamped -- the pane reports its grid through
@@ -54,34 +54,6 @@ defmodule RaxolPlayground.SurfaceSource do
       |> Enum.chunk_every(@columns)
       |> Enum.map(&Enum.join/1)
     end
-  end
-
-  @doc """
-  Breaks emitted markup so one element occupies each line.
-
-  Splits before every `<`, then folds each closing tag back onto the line it
-  closes, so a line carries an element and its text rather than a lone
-  `&lt;/span&gt;`.
-  """
-  @spec dom_lines(String.t()) :: [String.t()]
-  def dom_lines(html) do
-    html
-    |> String.replace("<", "\n<")
-    |> String.split("\n")
-    |> Enum.reject(&(&1 == ""))
-    |> fold_onto_previous(&String.starts_with?(&1, "</"))
-  end
-
-  # A line with nothing before it stays put: the stream may open mid-construct.
-  defp fold_onto_previous(lines, continuation?) do
-    lines
-    |> Enum.reduce([], fn line, acc ->
-      case {continuation?.(line), acc} do
-        {true, [prev | rest]} -> [prev <> line | rest]
-        _ -> [line | acc]
-      end
-    end)
-    |> Enum.reverse()
   end
 
   # The SGR colours a recording may ask for, mapped to the class that paints
@@ -302,7 +274,7 @@ defmodule RaxolPlayground.SurfaceSource do
   Colouring runs over the escaped text, so it wraps entities and can never
   re-open markup the artifact contained.
   """
-  @spec to_html([String.t()], :dom | :json) :: String.t()
+  @spec to_html([String.t()], :json) :: String.t()
   def to_html(lines, kind) do
     lines
     |> Enum.map_join("\n", fn line ->
@@ -317,16 +289,6 @@ defmodule RaxolPlayground.SurfaceSource do
     text
     |> Phoenix.HTML.html_escape()
     |> Phoenix.HTML.safe_to_string()
-  end
-
-  # Values first, so one containing a word is not re-marked as a tag.
-  defp colorize(line, :dom) do
-    line
-    |> String.replace(
-      ~r/&quot;([^&]*)&quot;/,
-      ~S(&quot;<span class="hg">\1</span>&quot;)
-    )
-    |> String.replace(~r{&lt;(/?[a-z]+)}, ~S(&lt;<span class="hk">\1</span>))
   end
 
   defp colorize(line, :json) do

--- a/web/lib/raxol_playground_web/components/landing_components.ex
+++ b/web/lib/raxol_playground_web/components/landing_components.ex
@@ -4,10 +4,10 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   the LiveView is just lifecycle (mount, handle_event, handle_info, render
   orchestration) and the markup lives here.
 
-  The counter and agent code samples are owned by this module: it stores
-  them as `~S\"""...\"""` literals, runs them through Makeup at compile time,
-  and exposes the highlighted HTML through Components that don't take any
-  attributes. Callers don't need to know either source exists.
+  The code samples are owned by this module: it stores them as `~S\"""...\"""`
+  literals, runs them through Makeup at compile time, and exposes the
+  highlighted HTML through Components that don't take any attributes. Callers
+  don't need to know the sources exist.
 
   Components that take attributes (nav_bar, screen_hero) receive only
   LiveView-driven state (mobile_menu_open, raxol_version, terminal_html).
@@ -21,33 +21,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   import Phoenix.HTML, only: [raw: 1]
 
   import RaxolPlaygroundWeb.PlaygroundComponents,
-    only: [copyable_command: 1, terminal_chrome: 1, ssh_copy_block: 1]
-
-  @counter_source ~S"""
-  defmodule Counter do
-    use Raxol.Core.Runtime.Application
-
-    @impl true
-    def init(_ctx), do: %{count: 0}
-
-    @impl true
-    def update(:increment, model), do: {%{model | count: model.count + 1}, []}
-    def update(:decrement, model), do: {%{model | count: model.count - 1}, []}
-    def update(_, model), do: {model, []}
-
-    @impl true
-    def view(model) do
-      column style: %{padding: 1, gap: 1} do
-        [
-          text("Count: #{model.count}", style: [:bold]),
-          row style: %{gap: 1} do
-            [button("+", on_click: :increment), button("-", on_click: :decrement)]
-          end
-        ]
-      end
-    end
-  end
-  """
+    only: [copyable_command: 1, terminal_chrome: 1]
 
   @agent_source ~S"""
   defmodule Researcher do
@@ -156,7 +130,6 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
                      }}
                   end)
 
-  @counter_code Makeup.highlight_inner_html(@counter_source)
   @agent_code Makeup.highlight_inner_html(@agent_source)
   # Counted from the registry `Xochi.Capabilities.fallback/0` derives from, so
   # the headline cannot claim a corridor the solver does not have. Tron is
@@ -168,8 +141,6 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   @repo_url "https://github.com/DROOdotFOO/raxol"
 
   @install_command "curl -fsSL https://raxol.io/install | bash"
-  @brew_command "brew install droodotfoo/tap/raxol"
-  @npm_command "npm i -g raxol"
 
   # The hero halo's face cycles the coding agent's REAL status glyphs:
   # AxolFace.glyph/3 is the single source of truth every surface renders,
@@ -184,48 +155,6 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
                   }
                 end
               )
-
-  # Version claims derive from Capabilities.packages() so the FAQ can never
-  # drift from the package table the capability endpoints serve.
-  @faq_versions Capabilities.packages()
-                |> Enum.group_by(& &1.version, & &1.name)
-                |> Enum.sort_by(fn {version, _names} -> version end, :desc)
-                |> Enum.map_join("; ", fn {version, names} ->
-                  "#{Enum.join(names, ", ")} at #{String.replace(version, "~> ", "v")}"
-                end)
-
-  @faqs [
-    %{
-      q: "What is Raxol?",
-      a:
-        "An OTP-native runtime for building TUIs, AI agents, and live web apps from one Elixir module. The same init/update/view shape renders to a terminal, Phoenix LiveView, SSH, and MCP."
-    },
-    %{
-      q: "Do I need Elixir?",
-      a:
-        "Yes. Raxol is an Elixir framework distributed via Hex. If you want to drive a Raxol app from another stack, you can talk to it over MCP (JSON-RPC)."
-    },
-    %{
-      q: "Where do AI agents run?",
-      a:
-        "In your BEAM, supervised. Same app, same node. Bring your own API key (Anthropic, OpenAI, OpenRouter, Ollama, Lumo, Kimi) or run mock for development. The framework streams tokens and routes inter-agent messages over a Registry."
-    },
-    %{
-      q: "Can I drop Raxol into an existing Phoenix app?",
-      a:
-        "Yes. Add :raxol_liveview, mount your TEA module via TEALive or TerminalComponent. The terminal renders as an HTML <pre> diffed by LiveView."
-    },
-    %{
-      q: "Is this production-ready?",
-      a:
-        "On Hex: #{@faq_versions}. raxol_earn and raxol_symphony are pre-alpha. raxol.io itself runs on Fly."
-    },
-    %{
-      q: "What does the SSH demo give me?",
-      a:
-        "Raxol's SSH surface gives every connection a supervised channel with its own crash boundary. The hosted playground is currently browser-only; run `mix raxol.playground --ssh` to try the SSH surface locally."
-    }
-  ]
 
   # ---------------------------------------------------------------------------
   # The one-screen landing: header / hero / footer, sized to the viewport.
@@ -282,7 +211,11 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
   def screen_hero(assigns) do
     assigns =
-      assign(assigns, halo_faces: @halo_faces, network_count: @network_count)
+      assign(assigns,
+        halo_faces: @halo_faces,
+        network_count: @network_count,
+        install_command: @install_command
+      )
 
     ~H"""
     <%!-- The brand mark beside the claim rather than above it: an upright box
@@ -313,11 +246,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         </p>
 
         <div class="screen-install">
-          <.copyable_command
-            id="screen-install-cmd"
-            command="curl -fsSL https://raxol.io/install | bash"
-            tone={:coral}
-          />
+          <.copyable_command id="screen-install-cmd" command={@install_command} tone={:coral} />
         </div>
       </div>
     </div>
@@ -539,62 +468,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   end
 
   # ---------------------------------------------------------------------------
-  # 1a. Install tabs: four methods over one command line
-  #
-  # All four panes ship in the dead render; the InstallTabs hook only
-  # toggles `hidden`/aria-selected, so the block works (showing curl)
-  # before JS and never round-trips the server.
-  # ---------------------------------------------------------------------------
-
-  def install_tabs(assigns) do
-    assigns =
-      assign(assigns,
-        curl_cmd: @install_command,
-        brew_cmd: @brew_command,
-        npm_cmd: @npm_command,
-        hex_dep: Capabilities.dep("raxol")
-      )
-
-    ~H"""
-    <div id="install-tabs" phx-hook="InstallTabs" class="install-tabs mx-auto">
-      <div class="install-tabs__row" role="tablist" aria-label="Install method">
-        <button type="button" class="install-tab" role="tab" aria-selected="true" data-m="curl">curl</button>
-        <button type="button" class="install-tab" role="tab" aria-selected="false" data-m="brew">brew</button>
-        <button type="button" class="install-tab" role="tab" aria-selected="false" data-m="npm">npm</button>
-        <button type="button" class="install-tab" role="tab" aria-selected="false" data-m="hex">hex</button>
-      </div>
-
-      <%!-- Only channels that exist get a link: the script this site
-           serves, and the published Hex package. brew/npm links land
-           when the tap repo and npm package publish. --%>
-      <div class="install-pane" data-m="curl">
-        <.ssh_copy_block id="install-copy-curl" cmd={@curl_cmd} />
-        <p class="label-text mt-3">
-          Self-contained binary. macOS and Linux. Click to copy.
-          <a href="/install" class="install-link">read the script</a>
-        </p>
-      </div>
-      <div class="install-pane" data-m="brew" hidden>
-        <.ssh_copy_block id="install-copy-brew" cmd={@brew_cmd} />
-        <p class="label-text mt-3">Homebrew tap. macOS and Linux.</p>
-      </div>
-      <div class="install-pane" data-m="npm" hidden>
-        <.ssh_copy_block id="install-copy-npm" cmd={@npm_cmd} />
-        <p class="label-text mt-3">One wrapper, one per-platform binary. Needs Node.</p>
-      </div>
-      <div class="install-pane" data-m="hex" hidden>
-        <.ssh_copy_block id="install-copy-hex" cmd={@hex_dep} prompt={nil} />
-        <p class="label-text mt-3">
-          Add to mix.exs in an existing Elixir app.
-          <a href="https://hex.pm/packages/raxol" class="install-link">view on Hex</a>
-        </p>
-      </div>
-    </div>
-    """
-  end
-
-  # ---------------------------------------------------------------------------
-  # 1b. Hero demo: one module, four surfaces
+  # 1. Hero demo: one module, four surfaces
   #
   # The four panes are four encodings of ONE render, all projected from the
   # same `Raxol.Headless` session, the way `Raxol.Harness.Surface.Parity`
@@ -751,23 +625,30 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   def hero_example_names, do: Enum.map(@hero_examples, &elem(&1, 0))
 
   defp example_title(name) do
-    Enum.find_value(@hero_examples, name, fn {n, t, _m, _c, _l} -> n == name && t end)
+    Enum.find_value(@hero_examples, name, fn {n, t, _m, _c, _l} ->
+      n == name && t
+    end)
   end
 
   @doc "The module an example defines, as its own source spells it."
   def example_module(name) do
-    Enum.find_value(@hero_examples, name, fn {n, _t, m, _c, _l} -> n == name && m end)
+    Enum.find_value(@hero_examples, name, fn {n, _t, m, _c, _l} ->
+      n == name && m
+    end)
   end
 
   @doc "Line and column counts of one example's source, as the pane sizes from."
   def example_grid(name) do
-    Enum.find_value(@hero_examples, %{lines: 1, cols: 1}, fn {n, _t, _m, _c, grid} ->
+    Enum.find_value(@hero_examples, %{lines: 1, cols: 1}, fn {n, _t, _m, _c,
+                                                              grid} ->
       n == name && grid
     end)
   end
 
   defp example_code(name) do
-    Enum.find_value(@hero_examples, "", fn {n, _t, _m, c, _l} -> n == name && c end)
+    Enum.find_value(@hero_examples, "", fn {n, _t, _m, c, _l} ->
+      n == name && c
+    end)
   end
 
   defp next_example(name) do
@@ -777,38 +658,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   end
 
   # ---------------------------------------------------------------------------
-  # 2. Proof: counter example
-  # ---------------------------------------------------------------------------
-
-  def code_example_section(assigns) do
-    assigns = assign(assigns, :counter_code, @counter_code)
-
-    ~H"""
-    <section class="landing-section py-12 md:py-20 measure" aria-labelledby="code-title">
-      <h2 id="code-title" class="heading-2xl mb-3">Hello World</h2>
-      <p class="body-text mb-8 max-w-2xl">
-        Every Raxol app follows The Elm Architecture:
-        <span class="text-axol-coral">init</span>,
-        <span class="text-axol-coral">update</span>,
-        <span class="text-axol-coral">view</span>.
-      </p>
-
-      <div class="terminal-chrome mb-8 ch-snap">
-        <.terminal_chrome title="counter.exs" />
-        <div class="terminal-chrome-body">
-          <pre class="code-block"><code class="syntax-elixir"><%= Phoenix.HTML.raw(@counter_code) %></code></pre>
-        </div>
-      </div>
-
-      <p class="body-text-dim max-w-2xl">
-        That counter works in a terminal, Phoenix LiveView, and over SSH. One codebase.
-      </p>
-    </section>
-    """
-  end
-
-  # ---------------------------------------------------------------------------
-  # 3a. Deep dive 01: Surfaces
+  # 2a. Deep dive 01: Surfaces
   # ---------------------------------------------------------------------------
 
   def surfaces_deep_dive(assigns) do
@@ -877,7 +727,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   end
 
   # ---------------------------------------------------------------------------
-  # 3b. Deep dive 02: SSH zero-install
+  # 2b. Deep dive 02: SSH zero-install
   # ---------------------------------------------------------------------------
 
   def ssh_deep_dive(assigns) do
@@ -909,7 +759,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   end
 
   # ---------------------------------------------------------------------------
-  # 3c. Deep dive 03: Agent runtime
+  # 2c. Deep dive 03: Agent runtime
   # ---------------------------------------------------------------------------
 
   def agent_deep_dive(assigns) do
@@ -947,7 +797,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   end
 
   # ---------------------------------------------------------------------------
-  # 3d. Deep dive 04: Coding agent + ACP
+  # 2d. Deep dive 04: Coding agent + ACP
   # ---------------------------------------------------------------------------
 
   def coding_agent_deep_dive(assigns) do
@@ -982,7 +832,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   end
 
   # ---------------------------------------------------------------------------
-  # 3e. Deep dive 05: Agent payments (privacy ladder + solver reach matrix)
+  # 2e. Deep dive 05: Agent payments (privacy ladder + solver reach matrix)
   #
   # The reach matrix renders server-side from the PAYMENTS solver's
   # capability endpoint (Raxol.Payments.Xochi.Capabilities) -- unrelated to
@@ -1236,141 +1086,6 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   # The top tier is open-ended, so it reads as a threshold rather than a band.
   defp score_band(%{min_score: min, max_score: nil}), do: "#{min} and above"
   defp score_band(%{min_score: min, max_score: max}), do: "#{min}-#{max}"
-
-  # ---------------------------------------------------------------------------
-  # 4. Features grid (numbered)
-  # ---------------------------------------------------------------------------
-
-  def features_section(assigns) do
-    ~H"""
-    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="features-title">
-      <span class="section-eyebrow">More capabilities</span>
-      <h2 id="features-title" class="heading-2xl mb-10">What OTP gives you.</h2>
-
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-        <.feature_card index="01" title="Crash Isolation" description="Components crash and restart independently. Your UI keeps running." />
-        <.feature_card index="02" title="Hot Code Reload" description="Change view/1, save. The running app updates without restart." />
-        <.feature_card index="03" title="MCP Tools" description="Widgets auto-derive MCP tools. Agents interact with real UI programmatically." />
-        <.feature_card index="04" title="Time-Travel Debug" description="Snapshot every update/2 cycle. Step back, forward, jump, restore." />
-        <.feature_card index="05" title="Distributed Swarm" description="CRDTs, elections, discovery via gossip, DNS, or Tailscale." />
-        <.feature_card index="06" title="Agent Payments" description="x402 micropayments, Xochi cross-chain, stealth addresses. Autonomous commerce." />
-        <.feature_card index="07" title="Adaptive UI" description="Behavior tracking, layout recommendations, feedback loop. Self-evolving interfaces." />
-        <.feature_card index="08" title="Session Replay" description="Asciinema v2 recording. Replay any session, scrub the timeline, ship as evidence." />
-      </div>
-    </section>
-    """
-  end
-
-  attr(:index, :string, required: true)
-  attr(:title, :string, required: true)
-  attr(:description, :string, required: true)
-
-  defp feature_card(assigns) do
-    ~H"""
-    <div class="panel panel--glow feature-card p-6">
-      <span class="feature-card__index"><%= @index %></span>
-      <h2 class="name-coral mb-2"><%= @title %></h2>
-      <p class="detail-text leading-relaxed"><%= @description %></p>
-    </div>
-    """
-  end
-
-  # ---------------------------------------------------------------------------
-  # 5. Packages
-  # ---------------------------------------------------------------------------
-
-  def packages_section(assigns) do
-    ~H"""
-    <section class="landing-section py-12 md:py-20 measure" aria-labelledby="packages-title">
-      <h2 id="packages-title" class="heading-2xl mb-3">Pick what you need</h2>
-      <p class="body-text mb-10 max-w-2xl">Full framework or just the parts that matter.</p>
-
-      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        <.package_card id="raxol" name="raxol" dep={Capabilities.dep("raxol")} description="Full framework: TEA runtime, rendering, widgets, effects" accent={true} />
-        <.package_card id="agent" name="raxol_agent" dep={Capabilities.dep("raxol_agent")} description="AI agents, teams, strategies, LLM streaming" />
-        <.package_card id="mcp" name="raxol_mcp" dep={Capabilities.dep("raxol_mcp")} description="MCP server, tool derivation from widgets" />
-        <.package_card id="payments" name="raxol_payments" dep={Capabilities.dep("raxol_payments")} description="x402, MPP, Xochi cross-chain, spending controls" />
-        <.package_card id="liveview" name="raxol_liveview" dep={Capabilities.dep("raxol_liveview")} description="Render TEA apps in Phoenix LiveView" />
-        <.package_card id="sensor" name="raxol_sensor" dep={Capabilities.dep("raxol_sensor")} description="Sensor fusion. Zero dependencies." />
-      </div>
-    </section>
-    """
-  end
-
-  attr(:id, :string, required: true)
-  attr(:name, :string, required: true)
-  attr(:dep, :string, required: true)
-  attr(:description, :string, required: true)
-  attr(:accent, :boolean, default: false)
-
-  defp package_card(assigns) do
-    ~H"""
-    <div class="panel panel--glow p-5 relative">
-      <h3 class={["name-sky-sm mb-1", if(@accent, do: "text-axol-coral", else: "text-sky")]}>
-        <%= @name %>
-      </h3>
-      <code class="caption-text"><%= @dep %></code>
-      <p class="detail-text mt-2"><%= @description %></p>
-      <button
-        id={"pkg-copy-#{@id}"}
-        phx-hook="CopyToClipboard"
-        data-copy={@dep}
-        class="pkg-copy-btn"
-        aria-label={"Copy #{@name} dependency"}
-      >copy</button>
-    </div>
-    """
-  end
-
-  # ---------------------------------------------------------------------------
-  # 6. FAQ
-  # ---------------------------------------------------------------------------
-
-  def faq_section(assigns) do
-    assigns = assign(assigns, :faqs, @faqs)
-
-    ~H"""
-    <section class="landing-section py-14 md:py-24 measure" aria-labelledby="faq-title">
-      <span class="section-eyebrow">FAQ</span>
-      <h2 id="faq-title" class="heading-2xl mb-10">Questions, answered.</h2>
-      <div class="faq-list max-w-3xl">
-        <%= for {%{q: q, a: a}, i} <- Enum.with_index(@faqs) do %>
-          <details class="faq-item" id={"faq-#{i}"}>
-            <summary><%= q %></summary>
-            <div class="faq-item__body"><%= a %></div>
-          </details>
-        <% end %>
-      </div>
-    </section>
-    """
-  end
-
-  # ---------------------------------------------------------------------------
-  # 7. CTA
-  # ---------------------------------------------------------------------------
-
-  def try_section(assigns) do
-    assigns = assign(assigns, :install_command, @install_command)
-
-    ~H"""
-    <section class="landing-section py-12 md:py-20 measure" aria-labelledby="try-title">
-      <h2 id="try-title" class="heading-2xl mb-3">One module away from every surface.</h2>
-      <p class="body-text mb-10 max-w-2xl">Starting is genuinely four commands.</p>
-
-      <div class="space-y-3 mb-10 ch-snap">
-        <.copyable_command id="copy-install" command={@install_command} comment="self-contained binary" tone={:coral} />
-        <.copyable_command id="copy-npm" command="npm i -g raxol" comment="Node users" tone={:sky} />
-        <.copyable_command id="copy-playground" command="mix raxol.playground" comment="interactive demos" tone={:sky} />
-        <.copyable_command id="copy-demo" command="mix run examples/demo.exs" comment="BEAM dashboard" tone={:sky} />
-      </div>
-
-      <div class="flex gap-4 flex-wrap">
-        <a href="/playground" class="btn-primary">Open Playground</a>
-        <a href="/gallery" class="btn-secondary">Browse Gallery</a>
-      </div>
-    </section>
-    """
-  end
 
   # ---------------------------------------------------------------------------
   # Footer

--- a/web/lib/raxol_playground_web/components/landing_components.ex
+++ b/web/lib/raxol_playground_web/components/landing_components.ex
@@ -136,13 +136,20 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   # wraps every line in markup, so counting there measures the highlighter. The
   # pane sizes its type from both, so the module fits whole on either axis
   # rather than running off the right edge behind a hidden scrollbar.
+  #
+  # The module name is read out of the source for the same reason. The browser
+  # pane heads its embedded page with it, and a name typed a second time here
+  # would be free to stop matching the `defmodule` line the pane beside it
+  # shows.
   @hero_examples (for {name, file, source} <- [
                         {"pulse", "pulse.ex", @pulse_source},
                         {"halo", "halo.ex", @halo_source}
                       ] do
                     lines = source |> String.trim() |> String.split("\n")
 
-                    {name, file, Makeup.highlight_inner_html(source),
+                    [_, module] = Regex.run(~r/defmodule (\w+)/, source)
+
+                    {name, file, module, Makeup.highlight_inner_html(source),
                      %{
                        lines: length(lines),
                        cols: lines |> Enum.map(&String.length/1) |> Enum.max()
@@ -590,11 +597,13 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   # 1b. Hero demo: one module, four surfaces
   #
   # The four panes are four encodings of ONE render, all projected from the
-  # frame-zero buffer of the same `Raxol.Headless` session, the way
-  # `Raxol.Harness.Surface.Parity` projects a fixture onto cells, LiveView
-  # DOM, SSH ANSI and MCP JSON. None is authored: the browser pane is the
-  # source of the markup the terminal pane renders, and the other two come
-  # from committed artifacts (see `RaxolPlayground.SurfaceSource`).
+  # same `Raxol.Headless` session, the way `Raxol.Harness.Surface.Parity`
+  # projects a fixture onto cells, LiveView DOM, SSH ANSI and MCP JSON. Every
+  # picture and every listing comes from a committed artifact (see
+  # `RaxolPlayground.SurfaceSource`); what a pane puts AROUND one is chrome, in
+  # the same sense the `$ mix run` line and the window dots above it are. The
+  # browser pane's URL bar and page furniture are that chrome, and the frame
+  # inside them is the recording.
   #
   # No ACP tab. ACP is the coding agent's editor protocol, not a surface a
   # TEA module renders to, so a pane captioned "pulse, driven over ACP" would
@@ -619,11 +628,9 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         frame_grid: RecordedFrames.hero_frame_grid(assigns.example),
         frame_ms: RecordedFrames.hero_frame_interval(assigns.example),
         next: next_example(assigns.example),
-        out_browser: RecordedFrames.hero_surface(assigns.example, :browser),
+        module: example_module(assigns.example),
         ssh_frames: RecordedFrames.hero_ssh_frames(assigns.example),
         out_mcp: RecordedFrames.hero_surface(assigns.example, :mcp),
-        browser_lines:
-          RecordedFrames.hero_surface_lines(assigns.example, :browser),
         ssh_grid: RecordedFrames.hero_ssh_grid(assigns.example),
         mcp_lines: RecordedFrames.hero_surface_lines(assigns.example, :mcp)
       )
@@ -659,7 +666,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
       <div class="hero-tabs" role="tablist" aria-label="Render surface">
         <button type="button" class="hero-tab" role="tab" aria-selected="true" data-i="0" data-title={"#{@title} -- rendering to the terminal"} data-label="Rendered to the terminal">Terminal</button>
-        <button type="button" class="hero-tab" role="tab" aria-selected="false" data-i="1" data-title={"#{@title} -- rendering to Phoenix LiveView"} data-label="The DOM LiveView patches">Browser</button>
+        <button type="button" class="hero-tab" role="tab" aria-selected="false" data-i="1" data-title={"#{@title} -- rendering to Phoenix LiveView"} data-label="Embedded in a page">Browser</button>
         <button type="button" class="hero-tab" role="tab" aria-selected="false" data-i="2" data-title={"#{@title} -- served over SSH"} data-label="The same frame, painted down a channel">SSH</button>
         <button type="button" class="hero-tab" role="tab" aria-selected="false" data-i="3" data-title={"#{@title} -- exposed as MCP tools"} data-label="The tree an agent reads">Agent / MCP</button>
       </div>
@@ -683,11 +690,33 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
             </div>
           </div>
 
-          <%!-- The same frame, re-encoded three ways: the head of a committed
-               artifact, clamped with a marker naming what was cut. --%>
+          <%!-- The browser pane shows the app sitting in a page, because that
+               is what the surface is. It used to print `TerminalBridge`'s
+               markup as text -- fifteen lines of escaped spans over braille --
+               and markup shown as text says the library formats strings. What
+               `raxol_liveview` actually hands you is a component: the frame
+               below is the same recording the terminal pane steps, in a page
+               that has a URL and a heading around it. --%>
           <div class="hero-out" data-surface="1" hidden>
             <pre class="hero-pre hero-cmd" aria-hidden="true"><span class="hc">$ mix phx.server</span></pre>
-            <pre class="hero-pre hero-src" style={"--src-lines: #{@browser_lines}"}>{raw(@out_browser)}</pre>
+
+            <div class="hero-browser">
+              <div class="hero-browser__bar" aria-hidden="true">
+                <span class="hero-browser__dot"></span>
+                <span class="hero-browser__url">localhost:4000/{@example}</span>
+              </div>
+
+              <div class="hero-browser__page">
+                <p class="hero-browser__heading">{@module}</p>
+                <div class="hero-frames raxol-terminal bg-synthwave-bg" data-theme="synthwave84" aria-hidden="true" style={"--frame-rows: #{@frame_grid.rows}; --frame-cols: #{@frame_grid.cols}"}>
+                  <div :for={{frame, i} <- Enum.with_index(@frames)} class="hero-frame" data-frame={i} hidden={i != 0}>{raw(frame)}</div>
+                </div>
+                <p class="hero-browser__caption">
+                  One TerminalComponent on an ordinary page. Keydown goes back
+                  through InputAdapter into update/2.
+                </p>
+              </div>
+            </div>
           </div>
 
           <%!-- SSH is the one non-terminal surface that delivers a picture
@@ -704,6 +733,9 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
             </div>
           </div>
 
+          <%!-- The one pane that is listed rather than painted, because what
+               an agent reads is a structure and not a picture: the head of a
+               committed artifact, clamped with a marker naming what was cut. --%>
           <div class="hero-out" data-surface="3" hidden>
             <pre class="hero-pre hero-cmd" aria-hidden="true"><span class="hc">$ mix mcp.server</span></pre>
             <pre class="hero-pre hero-src" style={"--src-lines: #{@mcp_lines}"}>{raw(@out_mcp)}</pre>
@@ -719,20 +751,23 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   def hero_example_names, do: Enum.map(@hero_examples, &elem(&1, 0))
 
   defp example_title(name) do
-    Enum.find_value(@hero_examples, name, fn {n, t, _c, _l} ->
-      n == name && t
-    end)
+    Enum.find_value(@hero_examples, name, fn {n, t, _m, _c, _l} -> n == name && t end)
+  end
+
+  @doc "The module an example defines, as its own source spells it."
+  def example_module(name) do
+    Enum.find_value(@hero_examples, name, fn {n, _t, m, _c, _l} -> n == name && m end)
   end
 
   @doc "Line and column counts of one example's source, as the pane sizes from."
   def example_grid(name) do
-    Enum.find_value(@hero_examples, %{lines: 1, cols: 1}, fn {n, _t, _c, grid} ->
+    Enum.find_value(@hero_examples, %{lines: 1, cols: 1}, fn {n, _t, _m, _c, grid} ->
       n == name && grid
     end)
   end
 
   defp example_code(name) do
-    Enum.find_value(@hero_examples, "", fn {n, _t, c, _l} -> n == name && c end)
+    Enum.find_value(@hero_examples, "", fn {n, _t, _m, c, _l} -> n == name && c end)
   end
 
   defp next_example(name) do

--- a/web/test/raxol_playground_web/landing_components_test.exs
+++ b/web/test/raxol_playground_web/landing_components_test.exs
@@ -66,10 +66,10 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
   end
 
   # The hero claims one module reaches four surfaces, each pane an encoding of
-  # one recorded render. These two tests stop a pane reverting to authored text.
-  test "every listed hero pane is a recorded artifact, line for line" do
+  # one recorded render. These tests stop a pane reverting to authored text.
+  test "the listed hero pane is a recorded artifact, line for line" do
     for name <- LandingComponents.hero_example_names(),
-        surface <- [:browser, :mcp] do
+        surface <- [:mcp] do
       artifact = RecordedFrames.hero_artifact(name, surface)
       pane = RecordedFrames.hero_surface(name, surface)
 
@@ -95,6 +95,41 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
         assert body == full,
                "#{name}/#{surface} shows #{length(body)} of #{length(full)} lines and says nothing"
       end
+    end
+  end
+
+  # The browser pane renders the recording rather than listing the markup of
+  # it, so it gets the same shape of invariant the SSH pane does.
+  test "the browser pane renders the recording inside a page" do
+    for name <- LandingComponents.hero_example_names() do
+      hero = render_component(&LandingComponents.screen_hero/1, example: name)
+      pane = surface_pane(hero, 1)
+      frames = RecordedFrames.hero_frames(name)
+
+      # The regression this pane exists to not have. Markup shown as text is
+      # what made the surface that renders to a browser read as a library that
+      # formats strings.
+      refute pane =~ "&lt;span",
+             "#{name}/browser is listing its markup as text again"
+
+      refute pane =~ "more lines,",
+             "#{name}/browser is clamping a listing instead of rendering a frame"
+
+      # Every recorded frame, and only those: one element each, contents
+      # verbatim, so the pane cannot drift from the recording beside it.
+      assert count(pane, ~s(class="hero-frame")) == length(frames)
+
+      for {frame, i} <- Enum.with_index(frames) do
+        assert pane =~ ~s(data-frame="#{i}")
+        assert String.contains?(pane, frame), "#{name}/browser dropped frame #{i}"
+      end
+
+      # The page around the frame is what distinguishes this tab from the
+      # terminal tab, which shows the same recording bare.
+      assert pane =~ "localhost:4000/#{name}"
+
+      assert pane =~ ~r/hero-browser__heading">\s*#{LandingComponents.example_module(name)}\s*</,
+             "#{name}/browser does not head its page with the module the source defines"
     end
   end
 
@@ -550,10 +585,22 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     refute row =~ ~s(title=")
   end
 
-  defp break_lines(artifact, :browser), do: SurfaceSource.dom_lines(artifact)
   defp break_lines(artifact, :mcp), do: SurfaceSource.json_lines(artifact)
 
   defp strip_ansi(text), do: String.replace(text, ~r/\e\[[0-9;?]*[A-Za-z]/, "")
+
+  defp count(haystack, needle), do: length(String.split(haystack, needle)) - 1
+
+  # A rendered hero carries every surface at once, so a pane is the run between
+  # its own marker and the next one. The last pane has no next marker, which is
+  # why the tail is taken rather than a second split asserted.
+  defp surface_pane(hero, index) do
+    [_, rest] = String.split(hero, ~s(data-surface="#{index}"), parts: 2)
+
+    rest
+    |> String.split(~r/data-surface="\d+"/, parts: 2)
+    |> List.first()
+  end
 
   # Undoes SurfaceSource's colour spans and escaping, leaving the lines as its
   # line-breaking produced them.

--- a/web/test/raxol_playground_web/landing_components_test.exs
+++ b/web/test/raxol_playground_web/landing_components_test.exs
@@ -20,16 +20,15 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       )
 
     deep_dive = render_component(&LandingComponents.ssh_deep_dive/1, %{})
-    try_section = render_component(&LandingComponents.try_section/1, %{})
 
-    # The one-screen hero carries ONE install path -- the curl script this
-    # site serves. The four-method tabs live in `install_tabs`, tested below.
+    # The one-screen hero carries ONE install path: the curl script this site
+    # serves. The four-method install tabs are gone, along with every other
+    # component that rendered on no route.
     assert hero =~ "curl -fsSL https://raxol.io/install | bash"
     assert deep_dive =~ "Hosted SSH is temporarily offline"
     assert deep_dive =~ ~s(href="/playground")
-    assert try_section =~ "npm i -g raxol"
 
-    refute Enum.join([hero, deep_dive, try_section]) =~ "playground@raxol.io"
+    refute Enum.join([hero, deep_dive]) =~ "playground@raxol.io"
   end
 
   # The landing is one screen. These are the two properties that keeps: it
@@ -121,14 +120,17 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
 
       for {frame, i} <- Enum.with_index(frames) do
         assert pane =~ ~s(data-frame="#{i}")
-        assert String.contains?(pane, frame), "#{name}/browser dropped frame #{i}"
+
+        assert String.contains?(pane, frame),
+               "#{name}/browser dropped frame #{i}"
       end
 
       # The page around the frame is what distinguishes this tab from the
       # terminal tab, which shows the same recording bare.
       assert pane =~ "localhost:4000/#{name}"
 
-      assert pane =~ ~r/hero-browser__heading">\s*#{LandingComponents.example_module(name)}\s*</,
+      assert pane =~
+               ~r/hero-browser__heading">\s*#{LandingComponents.example_module(name)}\s*</,
              "#{name}/browser does not head its page with the module the source defines"
     end
   end
@@ -186,7 +188,8 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       assert Enum.uniq(ssh) == ssh, "#{name}/ssh recorded identical frames"
 
       for frame <- ssh do
-        refute frame =~ "ESC[", "#{name}/ssh is showing escape codes as text again"
+        refute frame =~ "ESC[",
+               "#{name}/ssh is showing escape codes as text again"
       end
     end
   end
@@ -198,7 +201,9 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       interval = RecordedFrames.hero_frame_interval(name)
 
       assert interval > 0
-      assert interval <= 200, "#{name} plays back at #{interval}ms, which is a slideshow"
+
+      assert interval <= 200,
+             "#{name} plays back at #{interval}ms, which is a slideshow"
 
       hero = render_component(&LandingComponents.screen_hero/1, example: name)
       assert hero =~ ~s(data-frame-ms="#{interval}")
@@ -447,9 +452,9 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     end
   end
 
-  # npm and the Homebrew tap are built but unpublished and human-gated. The row
-  # names channels that exist today. `install_tabs` still advertises both and
-  # is rendered by nothing; that wart must not spread to a live component.
+  # npm and the Homebrew tap are built but unpublished and human-gated, so the
+  # row names channels that exist today. The install tabs that advertised both
+  # while rendering on no route are gone.
   test "the integrations row names no unpublished install channel" do
     row = render_component(&LandingComponents.screen_integrations/1, %{})
 
@@ -621,28 +626,6 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     |> String.replace("&amp;", "&")
   end
 
-  test "install tabs carry all four methods with curl visible by default" do
-    tabs = render_component(&LandingComponents.install_tabs/1, %{})
-
-    assert tabs =~ ~s(aria-label="Install method")
-    assert tabs =~ "curl -fsSL https://raxol.io/install | bash"
-    assert tabs =~ "brew install droodotfoo/tap/raxol"
-    assert tabs =~ "npm i -g raxol"
-    assert tabs =~ "{:raxol,"
-
-    # The curl pane is the one visible before JS runs (dead render).
-    assert tabs =~ ~s(aria-selected="true" data-m="curl")
-    refute tabs =~ ~s(<div class="install-pane" data-m="curl" hidden>)
-    assert tabs =~ ~s(<div class="install-pane" data-m="brew" hidden>)
-
-    # Only channels that exist are linked: the script this site serves and
-    # the published Hex package. brew/npm stay unlinked until they publish.
-    assert tabs =~ ~s(href="/install")
-    assert tabs =~ ~s(href="https://hex.pm/packages/raxol")
-    refute tabs =~ "npmjs.com"
-    refute tabs =~ "homebrew-tap"
-  end
-
   test "the hero halo exports the coding agent's real face frames" do
     hero =
       render_component(&LandingComponents.screen_hero/1,
@@ -669,14 +652,6 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     assert surfaces =~ "termbox2 NIF"
     assert surfaces =~ "Phoenix LiveView"
     assert surfaces =~ "JSON-RPC over stdio"
-  end
-
-  test "the closing section leads with a claim, proven by the commands beneath" do
-    try_section = render_component(&LandingComponents.try_section/1, %{})
-
-    assert try_section =~ "One module away from every surface."
-    assert try_section =~ "four commands"
-    assert try_section =~ "curl -fsSL https://raxol.io/install | bash"
   end
 
   test "nav links the components entry on desktop and mobile" do
@@ -857,7 +832,10 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
   # settlement invited the reading its own copy then had to deny, so the
   # payments page must not carry it back.
   test "the payments page carries no token" do
-    payments = render_component(&LandingComponents.payments_deep_dive/1, matrix: @live_matrix)
+    payments =
+      render_component(&LandingComponents.payments_deep_dive/1,
+        matrix: @live_matrix
+      )
 
     refute payments =~ "$RAXOL"
     refute payments =~ "0xf44702b17d9abD53815F703e772F35E9c71A53af"


### PR DESCRIPTION
Recovers the work stranded on the local-only `web/browser-pane-embed`,
rebased onto the current #942 tip, plus a dead-component sweep that was
sitting uncommitted in that worktree.

## Browser surface as a page

Two commits carried over unchanged in intent. `.hero-browser` gives the
browser pane real chrome — a URL bar and page text around the frame —
because the terminal tab shows the same recording bare, and without the
chrome the two tabs were one picture twice. `@hero_examples` grows a
module name read out of the source, so the pane's heading cannot drift
from the `defmodule` line beside it. Plus gzip/brotli on the HTML the
site already serves.

Rebasing meant resolving four conflicts against the reconciled #942:
`colorize(line, :dom)` and the `browser:` artifact key are deleted by
these commits and nothing else referenced them; the `.ansi-*` bold and
bright classes from #942's decoder are kept whole alongside the new
`.hero-browser` block.

## Drop the components that render on no route

`install_tabs`, `code_example_section`, `features_section`,
`packages_section`, `faq_section`, `try_section`, plus `feature_card`,
`package_card`, the `InstallTabs` hook and the CSS for all of it. The
landing became one screen and the deep dives moved to `TopicLive`; these
were left behind, rendered by nothing, and still had to be kept honest —
`install_tabs` advertised brew and npm channels that have not published.

I checked every removed component against the templates: nothing
references them.

## Three CSS rules the sweep took that are still in use

The component removal is clean. The CSS removal was not, and these are
kept:

| Rule | Still used by |
| --- | --- |
| `.category-tag` | `gallery_live.ex`, 4 call sites |
| `.cursor-blink` | `playground_components.ex:26` |
| `@keyframes fadeIn` | `.repl-entry` and `.prompt` |

`.category-tag--sm` survived the cut but is a size override — the base
carried the colour, border, radius, uppercase and letter-spacing, so the
gallery's filter row and demo tags would have lost their chrome.

The other two look covered by `tailwind.config.js` and are not.
`cursor-blink` there builds the utility `animate-cursor-blink`, a
different class from the bare `cursor-blink` the template asks for. And
Tailwind only emits keyframes for a utility it actually generates — no
template uses `animate-fade-in`, so `@keyframes fadeIn` would not have
been emitted at all and both animations would have stopped.

None of the three breaks a build or a test. Deleting CSS that a template
still names fails silently, which is why the check has to be selectors
against templates rather than against the suite.

`fadeInUp` went with the feature grid that was its only caller, and the
moduledoc no longer claims a counter sample that is gone.

## Testing

- `mix compile --warnings-as-errors` clean
- `mix test` in `web/` — 55 passing (down from 57: the two removed tests
  covered `install_tabs` and `try_section`)
- `mix format --check-formatted` clean at the root

## Manual testing

- [ ] `/gallery` — category filter row and per-demo tags still have their
      border, background and uppercase treatment
- [ ] `/repl` — history entries fade in
- [ ] Any copyable command block — the trailing cursor blinks
- [ ] Landing hero — browser tab shows the page chrome with the module
      name as its heading
