### PR TITLE
Tighten landing page IA

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,9 +138,15 @@ Unix/macOS backend uses a termbox2 NIF; Windows uses a pure Elixir driver (usabl
 
 ## Documentation
 
-Start with the [documentation index](docs/README.md), or jump to the
-[Quickstart](docs/getting-started/QUICKSTART.md), [feature catalog](docs/features/README.md),
-[package map](docs/PACKAGES.md), or [API docs](https://hexdocs.pm/raxol).
+Start with the [documentation index](docs/README.md), or jump to:
+
+- [Quickstart](docs/getting-started/QUICKSTART.md)
+- [Components](docs/getting-started/COMPONENT_GALLERY.md)
+- [Surfaces](docs/guides/SURFACES.md)
+- [Coding Agent](docs/features/CODING_AGENT.md)
+- [Payments](docs/features/AGENTIC_COMMERCE.md)
+- [$RAXOL token facts](https://raxol.io/token)
+- [API docs](https://hexdocs.pm/raxol)
 
 ## Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,16 +17,18 @@ Raxol is a multi-surface application runtime for Elixir. One TEA module renders 
 - [LiveView Integration](cookbook/LIVEVIEW_INTEGRATION.md): embed terminals in Phoenix
 - [Performance](cookbook/PERFORMANCE_OPTIMIZATION.md): 60fps rendering, diffing, caching
 
+## Product areas
+
+- [Components](getting-started/COMPONENT_GALLERY.md): browse the component catalog and demos
+- [Surfaces](guides/SURFACES.md): render one TEA app to terminal, LiveView, SSH, and MCP
+- [Coding Agent](features/CODING_AGENT.md): run `raxol code`, `raxol -p`, SSH, ACP, and MCP agent surfaces
+- [Payments](features/AGENTIC_COMMERCE.md): wallets, spend gates, HTTP 402, Xochi, and settlement receipts
+- [$RAXOL token facts](https://raxol.io/token): contract addresses and pair link
+
 ## Features
 
 See the [feature catalog](features/README.md) for agents, MCP, commerce,
 distributed systems, developer tools, and alternate surfaces.
-
-## Guides
-
-- [Surfaces](guides/SURFACES.md): write once, render to every surface
-- [Skill Authoring](guides/SKILL_AUTHORING.md): write a reusable `SKILL.md`
-- [Custom Components](cookbook/CUSTOM_COMPONENTS.md)
 
 ## Design
 

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -1137,6 +1137,7 @@ html {
 
 @media (max-width: 700px) {
   .rung { grid-template-columns: 1fr 1fr; gap: 0.15rem 1rem; }
+  .rung--head span:nth-child(n + 3) { display: none; }
 }
 
 /* Two columns, for the ladders that are a label and one value: the routing
@@ -1286,7 +1287,7 @@ html {
 
 .reach-scroll::-webkit-scrollbar { display: none; }
 
-.reach-grid { min-width: 500px; }
+.reach-grid { min-width: 0; }
 
 .reach-row {
   display: grid;
@@ -1315,6 +1316,15 @@ html {
 .reach-row--future .reach-row__note { color: var(--text-muted); font-size: 0.72rem; }
 
 .reach-toks { display: flex; gap: 0.28rem; flex-wrap: wrap; }
+
+@media (max-width: 700px) {
+  .reach-row {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.25rem;
+  }
+
+  .reach-toks { margin-top: 0.25rem; }
+}
 
 .tok {
   padding: 0.06em 0.38em;
@@ -2633,6 +2643,7 @@ input[type="range"]::-moz-range-thumb {
   text-wrap: pretty;
 }
 
+
 /* The demo is the centerpiece, but it no longer takes ALL the height the text
    does not: capped, so the room freed by folding the install command into the
    intro reads as whitespace under the demo rather than as empty panes. That
@@ -2833,26 +2844,11 @@ input[type="range"]::-moz-range-thumb {
 
 .screen-footer .screen-bar {
   flex-wrap: wrap;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 0.75rem 1.5rem;
 }
 
-.screen-topics { display: flex; flex-wrap: wrap; gap: 1.1rem; }
 
-.topic-link {
-  color: var(--text-muted);
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
-}
-
-.topic-link:hover, .topic-link:focus-visible {
-  color: var(--axol-coral);
-  border-bottom-color: currentColor;
-}
-
-/* The gap does the separating the middle dots used to. Wider between the
-   destinations than inside the Hex/GitHub pair, so the row reads as grouped
-   navigation rather than a run-on sentence. */
 .screen-meta {
   color: var(--text-dim);
   display: inline-flex;

--- a/web/config/dev.exs
+++ b/web/config/dev.exs
@@ -13,9 +13,11 @@ config :raxol_playground, RaxolPlaygroundWeb.Endpoint,
   check_origin: false,
   code_reloader: true,
   debug_errors: true,
-  secret_key_base: "development-secret-key-base-at-least-64-characters-long-for-security-purposes",
+  secret_key_base:
+    "development-secret-key-base-at-least-64-characters-long-for-security-purposes",
   watchers: [
-    esbuild: {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
+    esbuild:
+      {Esbuild, :install_and_run, [:default, ~w(--sourcemap=inline --watch)]},
     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
   ]
 
@@ -54,6 +56,8 @@ config :raxol_playground, RaxolPlaygroundWeb.Endpoint,
 
 # Enable dev routes for dashboard and mailbox
 config :raxol_playground, dev_routes: true
+
+config :raxol, :skip_endpoint, true
 
 # Do not include metadata nor timestamps in development logs
 config :logger, :console, format: "[$level] $message\n"

--- a/web/lib/raxol_playground_web/components/landing_components.ex
+++ b/web/lib/raxol_playground_web/components/landing_components.ex
@@ -215,22 +215,18 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
   # `settle.ex` cannot be expected to infer which noun it is answering, so each
   # example says so in the title bar.
   @hero_examples (for {name, file, blurb, source} <- [
-                        {"settle", "settle.ex",
-                         "gate, EIP-712, solver, explorers", @settle_source},
-                        {"pulse", "pulse.exs", "one module, four surfaces",
-                         @pulse_source},
-                        {"halo", "halo.exs", "the mark, as a program",
-                         @halo_source},
+                        {"settle", "settle.ex", "gate, EIP-712, solver, explorers",
+                         @settle_source},
+                        {"pulse", "pulse.exs", "one module, four surfaces", @pulse_source},
+                        {"halo", "halo.exs", "the mark, as a program", @halo_source},
                         {"harness", "harness.ex",
-                         "a Virtuals ACP job, worked by the coding agent",
-                         @harness_source}
+                         "a Virtuals ACP job, worked by the coding agent", @harness_source}
                       ] do
                     [_, module] = Regex.run(~r/defmodule (\w+)/, source)
 
                     lines = source |> String.trim() |> String.split("\n")
 
-                    {name, file, module, blurb,
-                     Makeup.highlight_inner_html(source),
+                    {name, file, module, blurb, Makeup.highlight_inner_html(source),
                      %{
                        lines: length(lines),
                        cols: lines |> Enum.map(&String.length/1) |> Enum.max()
@@ -304,7 +300,6 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         aria-label="Main navigation"
       >
         <a :for={{href, label} <- nav_links()} href={href} class="nav-link">{label}</a>
-        <a :for={{path, label} <- topic_links()} href={path} class="nav-link">{label}</a>
       </nav>
     </header>
     """
@@ -314,10 +309,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
   def screen_hero(assigns) do
     assigns =
-      assign(assigns,
-        halo_faces: @halo_faces,
-        install_command: @install_command
-      )
+      assign(assigns, halo_faces: @halo_faces, install_command: @install_command)
 
     ~H"""
     <%!-- The brand mark beside the claim rather than above it: an upright box
@@ -343,15 +335,15 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         <h1 class="screen-title">
           One Elixir module.
           <span class="screen-title__claim text-axol-coral">
-            Seven surfaces, one runtime.
+            Every surface, one runtime.
           </span>
         </h1>
 
         <p class="screen-sub">
-          Write the app once. Raxol projects it to terminal, LiveView, SSH, MCP,
-          Telegram, Watch, and Speech. <span class="text-axol-coral">raxol_payments</span>
-          gates the signature path.
+          Runtime, agent harness, and payment rails run on OTP. Render to terminal,
+          LiveView, SSH, MCP, Telegram, Watch, and Speech.
         </p>
+
 
 
         <div class="screen-install">
@@ -498,12 +490,9 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     ~H"""
     <footer class="screen-footer" role="contentinfo">
       <div class="screen-bar">
-        <nav class="screen-topics" aria-label="Deep dives">
-          <a :for={{path, label} <- primary_topic_links()} href={path} class="topic-link">{label}</a>
-        </nav>
-
         <span class="screen-meta">
           <a href="https://hex.pm/packages/raxol" class="subtle-link">Hex</a>
+          <a href="/token" class="subtle-link">$RAXOL</a>
           <.github_mark />
         </span>
       </div>
@@ -534,31 +523,8 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     """
   end
 
-  # The deep-dive pages, in one place so the header and footer cannot list
-  # different ones. `TopicLive` owns the paths; this only borrows them.
-  defp topic_links, do: RaxolPlaygroundWeb.TopicLive.links()
-
-  @primary_topic_paths ["/surfaces", "/coding-agent", "/payments", "/token"]
-  defp primary_topic_links do
-    Enum.filter(topic_links(), fn {path, _label} ->
-      path in @primary_topic_paths
-    end)
-  end
-
-  # One list for both site headers. The landing carried four links and the
-  # topic pages six, so the navigation changed shape when a reader crossed
-  # between them and neither list knew the other existed.
-  # Two, because two is what the site actually has to offer a first-time
-  # reader: somewhere to watch it run, and somewhere to read the API.
-  #
-  # It carried six. Playground, Gallery and Demos were three labels for one
-  # job, and no visitor could tell them apart from the words -- Demos was a
-  # strictly smaller copy of Gallery over the same catalog, and is gone;
-  # Playground is one link inside Components, where someone who wants the
-  # fuller tool is already standing. Skill and GitHub are reference material
-  # for a reader who has already decided, so they moved to the footer, GitHub
-  # as its mark. Nothing here was padded back to a round number: a third item
-  # added to reach one would be the same defect in a smaller font.
+  # One list for both site headers: run it, or read the API. Product pages live
+  # in the hero/demo path and in the docs, not as a second table of contents.
   @nav_links [
     {"/gallery", "Components"},
     {"https://hexdocs.pm/raxol", "Docs"}
@@ -982,8 +948,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
 
   @doc "Line and column counts of one example's source, as the pane sizes from."
   def example_grid(name) do
-    Enum.find_value(@hero_examples, %{lines: 1, cols: 1}, fn {n, _t, _m, _b, _c,
-                                                              grid} ->
+    Enum.find_value(@hero_examples, %{lines: 1, cols: 1}, fn {n, _t, _m, _b, _c, grid} ->
       n == name && grid
     end)
   end
@@ -1432,8 +1397,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         routes: routes(),
         payment_actions: payment_actions(),
         action_groups: action_groups(),
-        show_future_svm:
-          not Enum.any?(assigns.matrix.chains, &(&1.vm_type == :svm)),
+        show_future_svm: not Enum.any?(assigns.matrix.chains, &(&1.vm_type == :svm)),
         live?: assigns.matrix.source == :live
       )
 
@@ -1441,13 +1405,15 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     <section class="landing-section payments-deep py-14 md:py-24 measure" aria-labelledby="payments-title">
       <div class="mb-8">
         <h1 id="payments-title" class="heading-2xl mb-3">
-          Spend gate, signed intent, solver receipt.
+          Agents that pay invoices.
         </h1>
         <p class="body-text max-w-2xl">
-          <code>Raxol.Payments.Router.select/1</code> picks x402,
-          <a href="https://xochi.fi" rel="noopener" class="text-sky">Xochi</a>,
-          or relay. Fees come from <code>Raxol.Payments.FeeSchedule</code>.
-          Payments: <%= @payments_version %>; core: 2.6.
+          Agents can pay HTTP 402 invoices under ledger-enforced spend gates.
+          Raxol chooses the rail, signs the intent, and records the receipt.
+        </p>
+        <p class="caption-text mt-3">
+          Payments package: <%= @payments_version %>; core: 2.6.
+          Stablecoin fees run 10-22 bps by trust tier; volatile assets run 22-40 bps.
         </p>
       </div>
 
@@ -1632,8 +1598,9 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
       </div>
 
       <p class="body-text-dim max-w-2xl mb-4">
-        Project token on <%= @token.chain_name %>. Payments settle in
-        stablecoins, not $<%= @token.symbol %>.
+        ${@token.symbol} is the project token, not the payment rail. Agents pay
+        invoices in stablecoins; payment corridors quote, route, and settle in
+        those assets.
       </p>
 
       <div class="reach reach--compact">

--- a/web/lib/raxol_playground_web/components/layouts/root.html.heex
+++ b/web/lib/raxol_playground_web/components/layouts/root.html.heex
@@ -5,26 +5,27 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#0a0a0c" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <meta name="description" content="Write one app. Render it to a terminal, a browser, or an agent. Multi-surface runtime for Elixir on OTP." />
-    <meta property="og:title" content="Raxol: multi-surface application runtime for Elixir" />
-    <meta property="og:description" content="One TEA module renders to terminal, browser (LiveView), SSH, and MCP (agents). Crash isolation, hot reload, agentic commerce, distributed swarm." />
+    <% page_description = assigns[:page_description] || "Write one app. Render it to a terminal, a browser, or an agent. Multi-surface runtime for Elixir on OTP." %>
+    <% og_title = assigns[:og_title] || "Raxol: multi-surface application runtime for Elixir" %>
+    <% canonical_url = assigns[:canonical_url] || "https://raxol.io/" %>
+    <meta name="description" content={page_description} />
+    <meta property="og:title" content={og_title} />
+    <meta property="og:description" content={page_description} />
     <meta property="og:image" content="https://raxol.io/images/social-preview.png" />
-    <meta property="og:url" content="https://raxol.io" />
+    <meta property="og:url" content={canonical_url} />
     <meta property="og:type" content="website" />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Raxol: multi-surface application runtime for Elixir" />
-    <meta name="twitter:description" content="One TEA module renders to terminal, browser (LiveView), SSH, and MCP (agents). Crash isolation, hot reload, agentic commerce, distributed swarm." />
+    <meta name="twitter:title" content={og_title} />
+    <meta name="twitter:description" content={page_description} />
     <meta name="twitter:image" content="https://raxol.io/images/social-preview.png" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
-    <link rel="canonical" href="https://raxol.io" />
+    <link rel="canonical" href={canonical_url} />
     <%!-- Self-hosted Monaspace variable fonts. Preload the mono cut (used everywhere)
          so first-paint doesn't fall back to Fira Code. Neon/Xenon load lazily on use. --%>
     <link rel="preload" href={~p"/fonts/MonaspaceArgon-Var.woff2"} as="font" type="font/woff2" crossorigin="anonymous" />
-    <link rel="preload" href={~p"/fonts/MonaspaceNeon-Var.woff2"} as="font" type="font/woff2" crossorigin="anonymous" />
-    <link rel="preload" href={~p"/fonts/MonaspaceXenon-Var.woff2"} as="font" type="font/woff2" crossorigin="anonymous" />
     <.live_title suffix=" · Raxol">
       <%= assigns[:page_title] || "Raxol Playground" %>
     </.live_title>

--- a/web/lib/raxol_playground_web/live/gallery_live.ex
+++ b/web/lib/raxol_playground_web/live/gallery_live.ex
@@ -20,6 +20,12 @@ defmodule RaxolPlaygroundWeb.GalleryLive do
     socket =
       socket
       |> assign(:page_title, "Gallery")
+      |> assign(
+        :page_description,
+        "Browse 41 terminal-first Raxol UI components for Elixir apps: inputs, overlays, layouts, charts, agent harness views, and effects."
+      )
+      |> assign(:og_title, "Raxol component gallery")
+      |> assign(:canonical_url, "https://raxol.io/gallery")
       |> assign(:components, components)
       |> assign(:total_count, length(components))
       |> assign(:categories, Catalog.list_categories())
@@ -66,10 +72,7 @@ defmodule RaxolPlaygroundWeb.GalleryLive do
   end
 
   def handle_event("filter_category", %{"category" => category}, socket) do
-    {:noreply,
-     refilter(
-       assign(socket, :active_category, String.to_existing_atom(category))
-     )}
+    {:noreply, refilter(assign(socket, :active_category, String.to_existing_atom(category)))}
   rescue
     ArgumentError -> {:noreply, socket}
   end
@@ -87,10 +90,7 @@ defmodule RaxolPlaygroundWeb.GalleryLive do
   end
 
   def handle_event("filter_complexity", %{"level" => level}, socket) do
-    {:noreply,
-     refilter(
-       assign(socket, :complexity_filter, String.to_existing_atom(level))
-     )}
+    {:noreply, refilter(assign(socket, :complexity_filter, String.to_existing_atom(level)))}
   rescue
     ArgumentError -> {:noreply, socket}
   end
@@ -229,9 +229,9 @@ defmodule RaxolPlaygroundWeb.GalleryLive do
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <%= if @view_mode == "grid" && @grouped do %>
           <section :if={@featured != []} class="mb-10" aria-labelledby="featured-heading">
-            <h2 id="featured-heading" class="font-mono font-semibold text-pearl mb-1">Start here</h2>
+            <h2 id="featured-heading" class="font-mono font-semibold text-pearl mb-1">Core demos</h2>
             <p class="font-mono detail-text mb-3">
-              Five that show the range: a stateful component, a rich text surface, a live chart, an overlay, and the agent harness.
+              Table, modal, markdown, chart, and harness components.
             </p>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
               <%= for comp <- @featured do %>
@@ -297,6 +297,7 @@ defmodule RaxolPlaygroundWeb.GalleryLive do
         data-theme="synthwave84"
         aria-hidden="true"
         tabindex="-1"
+        inert
         phx-hook={if length(@preview.frames) > 1, do: "CardLoop"}
         data-frame-ms={@preview.interval_ms}
       ><%= if length(@preview.frames) > 1 do %><div

--- a/web/lib/raxol_playground_web/live/landing_live.ex
+++ b/web/lib/raxol_playground_web/live/landing_live.ex
@@ -31,15 +31,17 @@ defmodule RaxolPlaygroundWeb.LandingLive do
        # The layout appends " · Raxol", so the brand alone rendered as
        # "Raxol · Raxol". The claim reads better in a tab and in a search result.
        page_title: "One module, every surface",
+       page_description:
+         "Raxol renders one Elixir module to terminal, LiveView, SSH, MCP, Telegram, Watch, and Speech, with an agent harness and payment rails on OTP.",
+       og_title: "Raxol: one Elixir module, every surface",
+       canonical_url: "https://raxol.io/",
        mobile_menu_open: false,
        example: List.first(hero_example_names()),
        # ETS-cached with a 300s TTL; nil config (dev/test, or prod without
        # XOCHI_CAPABILITIES_BASE_URL) skips the network entirely and serves
        # the static fallback, which renders as a "cached" badge.
        xochi_matrix:
-         XochiCapabilities.get(
-           Application.get_env(:raxol_playground, :xochi_capabilities)
-         )
+         XochiCapabilities.get(Application.get_env(:raxol_playground, :xochi_capabilities))
      )}
   end
 
@@ -52,8 +54,7 @@ defmodule RaxolPlaygroundWeb.LandingLive do
     names = hero_example_names()
     idx = Enum.find_index(names, &(&1 == socket.assigns.example)) || 0
 
-    {:noreply,
-     assign(socket, :example, Enum.at(names, rem(idx + 1, length(names))))}
+    {:noreply, assign(socket, :example, Enum.at(names, rem(idx + 1, length(names))))}
   end
 
   def handle_event(_event, _params, socket), do: {:noreply, socket}

--- a/web/lib/raxol_playground_web/live/topic_live.ex
+++ b/web/lib/raxol_playground_web/live/topic_live.ex
@@ -21,14 +21,26 @@ defmodule RaxolPlaygroundWeb.TopicLive do
 
   # The router names each topic as a `live_action`, so the URL and the atom
   # this module matches on are declared in one place (the router) and cannot
-  # drift apart. `{path, page title, nav label}`.
+  # drift apart. `{path, page title, nav label, description}`.
   @topics %{
-    surfaces: {"/surfaces", "Surfaces", "Surfaces"},
-    ssh: {"/ssh", "SSH", "SSH"},
-    agent: {"/agents", "Agents", "Agents"},
-    coding_agent: {"/coding-agent", "raxol code", "raxol code"},
-    payments: {"/payments", "Agent payments", "Payments"},
-    token: {"/token", "$RAXOL", "$RAXOL"}
+    surfaces:
+      {"/surfaces", "Surfaces", "Surfaces",
+       "See how one Raxol app projects to terminal, LiveView, SSH, MCP, Telegram, Watch, and Speech from one Elixir module."},
+    ssh:
+      {"/ssh", "SSH", "SSH",
+       "Run a Raxol app over SSH with an Erlang daemon, supervised channels, tenant directories, and explicit resource caps."},
+    agent:
+      {"/agents", "Agents", "Agents",
+       "Build Raxol agents with a terminal UI, tool calls, MCP projection, and OTP process isolation."},
+    coding_agent:
+      {"/coding-agent", "raxol code", "raxol code",
+       "Use raxol code as an interactive coding-agent TUI or headless command with JSON events and MCP tools."},
+    payments:
+      {"/payments", "Agent payments", "Payments",
+       "See how Raxol agents pay HTTP 402 invoices with ledger-enforced spend gates, signed intents, solver receipts, and stablecoin settlement."},
+    token:
+      {"/token", "$RAXOL", "$RAXOL",
+       "Read the project-token facts for Raxol and how the token differs from the stablecoin payment rails agents use."}
   }
 
   @order [:surfaces, :ssh, :agent, :coding_agent, :payments, :token]
@@ -36,20 +48,23 @@ defmodule RaxolPlaygroundWeb.TopicLive do
   @doc "Every topic as `{path, label}`, in nav order."
   def links do
     Enum.map(@order, fn topic ->
-      {path, _title, label} = @topics[topic]
+      {path, _title, label, _description} = @topics[topic]
       {path, label}
     end)
   end
 
   @impl true
   def mount(_params, _session, socket) do
-    {_path, title, _label} = Map.fetch!(@topics, socket.assigns.live_action)
+    {path, title, _label, description} = Map.fetch!(@topics, socket.assigns.live_action)
 
     {:ok,
      assign(socket,
        # The layout already appends " · Raxol", so naming the brand here put it
        # in the tab twice.
        page_title: title,
+       page_description: description,
+       og_title: "Raxol #{String.downcase(title)}",
+       canonical_url: "https://raxol.io#{path}",
        title: title,
        mobile_menu_open: false,
        xochi_matrix: xochi_matrix(socket.assigns.live_action)
@@ -61,9 +76,7 @@ defmodule RaxolPlaygroundWeb.TopicLive do
   # mount total put four unrelated pages behind a third-party endpoint's
   # availability; the branch is cheaper than that coupling.
   defp xochi_matrix(:payments) do
-    XochiCapabilities.get(
-      Application.get_env(:raxol_playground, :xochi_capabilities)
-    )
+    XochiCapabilities.get(Application.get_env(:raxol_playground, :xochi_capabilities))
   end
 
   defp xochi_matrix(_topic), do: nil

--- a/web/test/raxol_playground_web/demo_live_test.exs
+++ b/web/test/raxol_playground_web/demo_live_test.exs
@@ -17,6 +17,21 @@ defmodule RaxolPlaygroundWeb.DemoLiveTest do
     assert redirected_to(conn, 301) == "/gallery"
   end
 
+  test "major pages render route-specific metadata" do
+    for {path, title, canonical} <- [
+          {"/", "Raxol: one Elixir module, every surface", "https://raxol.io/"},
+          {"/gallery", "Raxol component gallery", "https://raxol.io/gallery"},
+          {"/surfaces", "Raxol surfaces", "https://raxol.io/surfaces"},
+          {"/payments", "Raxol agent payments", "https://raxol.io/payments"}
+        ] do
+      html = get_page(path) |> html_response(200)
+
+      assert html =~ ~s(<meta property="og:title" content="#{title}")
+      assert html =~ ~s(<link rel="canonical" href="#{canonical}")
+      assert html =~ ~s(<meta property="og:url" content="#{canonical}")
+    end
+  end
+
   test "GET /demos/:demo serves a known demo" do
     [component | _] = Raxol.Playground.Catalog.list_components()
 

--- a/web/test/raxol_playground_web/landing_components_test.exs
+++ b/web/test/raxol_playground_web/landing_components_test.exs
@@ -28,9 +28,7 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
   # this covers all four of it.
   test "each hero program matches the one the frames record" do
     script =
-      File.read!(
-        Path.expand("../../../scripts/gen_landing_frames.exs", __DIR__)
-      )
+      File.read!(Path.expand("../../../scripts/gen_landing_frames.exs", __DIR__))
 
     for name <- LandingComponents.hero_example_names() do
       shown = String.trim(LandingComponents.example_source(name))
@@ -86,9 +84,8 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
 
     deep_dive = render_component(&LandingComponents.ssh_deep_dive/1, %{})
 
-    # The one-screen hero carries ONE install path: the curl script this site
-    # serves. The four-method install tabs are gone, along with every other
-    # component that rendered on no route.
+    # The one-screen hero carries one install path: the curl script this site
+    # serves.
     assert hero =~ "curl -fsSL https://raxol.io/install | bash"
 
     # The SSH section still says the hosted endpoint is down -- that is the
@@ -595,9 +592,7 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       )
 
     [sub] =
-      Regex.run(~r/<p class="screen-sub">(.*?)<\/p>/s, hero,
-        capture: :all_but_first
-      )
+      Regex.run(~r/<p class="screen-sub">(.*?)<\/p>/s, hero, capture: :all_but_first)
 
     for chain <- [
           "Ethereum",
@@ -896,26 +891,22 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     assert open =~ ~s(href="/gallery")
   end
 
-  # The navigation is the thing this page kept getting wrong: six labels for
-  # four destinations, three of them ("Playground", "Gallery", "Demos") naming
-  # one job. The count is the property worth holding, because the failure mode
-  # is adding "just one more" link until it is six again.
-  test "the header offers two destinations and no more" do
+  test "the header offers only components and docs" do
     assert LandingComponents.nav_links() == [
              {"/gallery", "Components"},
              {"https://hexdocs.pm/raxol", "Docs"}
            ]
   end
 
-  # Reference material moved to the footer rather than being deleted: every
-  # destination the header dropped is still one click away.
-  test "the landing footer keeps only primary destinations" do
+  test "the landing footer keeps package, token, and source links" do
     footer = render_component(&LandingComponents.screen_footer/1, %{})
 
-    assert footer =~ ~s(href="/coding-agent")
-    assert footer =~ "raxol code"
     assert footer =~ ~s(href="https://hex.pm/packages/raxol")
+    assert footer =~ ~s(href="/token")
+    assert footer =~ "$RAXOL"
+    refute footer =~ "$RAXOL verified"
     assert footer =~ "github.com/DROOdotFOO/raxol"
+    refute footer =~ ~s(href="/coding-agent")
     refute footer =~ ~s(href="/skill.md")
     refute footer =~ ~r/>\s*\d+\s+packages\s*</
   end
@@ -1017,10 +1008,13 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
         matrix: @live_matrix
       )
 
-    # Maturity is labeled; dated launch proof belongs off this tight page.
     assert payments =~ "0.2"
-    assert payments =~ "xochi.fi"
-    assert payments =~ ~s(href="https://xochi.fi")
+    assert payments =~ "HTTP 402 invoices"
+    assert payments =~ "Stablecoin fees run 10-22 bps"
+    refute payments =~ "2026-06-28"
+    refute payments =~ "2026-07-20"
+    refute payments =~ "fee table below"
+    refute payments =~ "over claims"
 
     # Fees come from FeeSchedule, the pinned mirror of the solver's published
     # schedule -- every tier, both asset classes, at the rates it actually
@@ -1132,12 +1126,13 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
 
   # `$RAXOL` reaches the footer through `TopicLive.links/0` like every other
   # deep dive, so the page and the link to it cannot drift apart.
-  test "the token page is a topic the footer lists" do
+  test "the token page remains available from the footer link" do
     assert {"/token", "$RAXOL"} in RaxolPlaygroundWeb.TopicLive.links()
 
     footer = render_component(&LandingComponents.screen_footer/1, %{})
     assert footer =~ ~s(href="/token")
     assert footer =~ "$RAXOL"
+    refute footer =~ "$RAXOL verified"
   end
 
   test "coding agent section claims ACP membership and prints the four surfaces" do


### PR DESCRIPTION
## Summary
- reduce landing header/footer navigation to primary paths
- move product-area links into README/docs index
- add route-specific metadata and mobile overflow fixes
- remove AI-ish payments metanarration and keep the token link as 

## Verification
- cd web && mix test test/raxol_playground_web/landing_components_test.exs test/raxol_playground_web/demo_live_test.exs
- browser smoke on localhost:4000 for reduced nav/footer and mobile width