### PR TITLE
Tell a new install what to do next

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/actions/code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/code.ex
@@ -47,7 +47,7 @@ defmodule Raxol.Agent.Actions.Code do
   write must not blow up the transcript or the model's context.
   """
 
-  alias Raxol.Agent.Actions.Fs
+  alias Raxol.Agent.Actions.{Fs, Lsp}
 
   # Before/after images larger than this drop the diff for a summary, so a
   # large-file write never bloats the transcript or the LLM tool-result echo.
@@ -87,7 +87,9 @@ defmodule Raxol.Agent.Actions.Code do
           old: [type: :string],
           new: [type: :string],
           language: [type: :string],
-          created: [type: :boolean]
+          created: [type: :boolean],
+          diagnostics: [type: :list],
+          diagnostics_error: [type: :string]
         ]
       ]
 
@@ -96,7 +98,7 @@ defmodule Raxol.Agent.Actions.Code do
       overwrite = Map.get(params, :overwrite, false)
 
       with {:ok, abs} <- Fs.resolve(path, context) do
-        Raxol.Agent.Actions.Code.write_file(abs, path, content, overwrite)
+        Raxol.Agent.Actions.Code.write_file(abs, path, content, overwrite, context)
       end
     end
   end
@@ -150,7 +152,9 @@ defmodule Raxol.Agent.Actions.Code do
           old: [type: :string],
           new: [type: :string],
           language: [type: :string],
-          replacements: [type: :integer]
+          replacements: [type: :integer],
+          diagnostics: [type: :list],
+          diagnostics_error: [type: :string]
         ]
       ]
 
@@ -161,7 +165,7 @@ defmodule Raxol.Agent.Actions.Code do
       with {:ok, mode} <- addressing(params),
            {:ok, abs} <- Fs.resolve(path, context),
            {:ok, content} <- File.read(abs) do
-        edit(mode, abs, path, content, new_string, params)
+        edit(mode, abs, path, content, new_string, params, context)
       end
     end
 
@@ -181,7 +185,7 @@ defmodule Raxol.Agent.Actions.Code do
 
     defp present?(value), do: is_binary(value) and value != ""
 
-    defp edit(:anchored, abs, path, content, new_string, params) do
+    defp edit(:anchored, abs, path, content, new_string, params, context) do
       {lines, trailing_newline?} = Anchor.split(content)
 
       with {:ok, from} <- Anchor.parse(Map.get(params, :from)),
@@ -189,11 +193,11 @@ defmodule Raxol.Agent.Actions.Code do
            :ok <- ordered(from, to),
            :ok <- Anchor.verify(lines, from),
            :ok <- Anchor.verify(lines, to) do
-        replace_range(abs, path, content, lines, trailing_newline?, from, to, new_string)
+        replace_range(abs, path, content, lines, trailing_newline?, from, to, new_string, context)
       end
     end
 
-    defp edit(:string, abs, path, content, new_string, params) do
+    defp edit(:string, abs, path, content, new_string, params, context) do
       old_string = Map.get(params, :old_string)
       replace_all = Map.get(params, :replace_all, false)
 
@@ -204,7 +208,8 @@ defmodule Raxol.Agent.Actions.Code do
           path,
           content,
           {old_string, new_string, replace_all},
-          count
+          count,
+          context
         )
       end
     end
@@ -219,7 +224,17 @@ defmodule Raxol.Agent.Actions.Code do
     defp ordered({from, _}, {to, _}) when from <= to, do: :ok
     defp ordered({from, _}, {to, _}), do: {:error, {:range_inverted, from, to}}
 
-    defp replace_range(abs, path, content, lines, trailing?, {from, _}, {to, _}, new_string) do
+    defp replace_range(
+           abs,
+           path,
+           content,
+           lines,
+           trailing?,
+           {from, _},
+           {to, _},
+           new_string,
+           context
+         ) do
       replaced = Enum.slice(lines, (from - 1)..(to - 1))
       {new_lines, _trailing?} = Anchor.split(new_string)
 
@@ -235,7 +250,8 @@ defmodule Raxol.Agent.Actions.Code do
           path,
           content,
           Anchor.join(updated, trailing?),
-          to - from + 1
+          to - from + 1,
+          context
         )
       end
     end
@@ -437,23 +453,27 @@ defmodule Raxol.Agent.Actions.Code do
   @doc false
   @spec write_file(String.t(), String.t(), String.t(), boolean()) ::
           {:ok, map()} | {:error, term()}
-  def write_file(abs, path, content, overwrite) do
+  def write_file(abs, path, content, overwrite, context \\ %{}) do
     exists = File.regular?(abs)
 
     if exists and not overwrite do
       {:error, :file_exists}
     else
-      persist_file(abs, path, content, exists)
+      persist_file(abs, path, content, exists, context)
     end
   end
 
-  defp persist_file(abs, path, content, exists) do
+  defp persist_file(abs, path, content, exists, context) do
     old = if exists, do: File.read!(abs), else: ""
     :ok = File.mkdir_p(Path.dirname(abs))
 
     case File.write(abs, content) do
-      :ok -> {:ok, diff_result(path, old, content, %{created: not exists})}
-      {:error, reason} -> {:error, reason}
+      :ok ->
+        {:ok,
+         path |> diff_result(old, content, %{created: not exists}) |> add_diagnostics(context)}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -463,7 +483,8 @@ defmodule Raxol.Agent.Actions.Code do
           String.t(),
           String.t(),
           {String.t(), String.t(), boolean()},
-          integer()
+          integer(),
+          map()
         ) ::
           {:ok, map()} | {:error, term()}
   def write_edit(
@@ -471,14 +492,19 @@ defmodule Raxol.Agent.Actions.Code do
         path,
         content,
         {old_string, new_string, replace_all},
-        count
+        count,
+        context \\ %{}
       ) do
     updated =
       String.replace(content, old_string, new_string, global: replace_all)
 
     case File.write(abs, updated) do
-      :ok -> {:ok, diff_result(path, content, updated, %{replacements: count})}
-      {:error, reason} -> {:error, reason}
+      :ok ->
+        {:ok,
+         path |> diff_result(content, updated, %{replacements: count}) |> add_diagnostics(context)}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -493,12 +519,19 @@ defmodule Raxol.Agent.Actions.Code do
           String.t(),
           String.t(),
           String.t(),
-          non_neg_integer()
+          non_neg_integer(),
+          map()
         ) :: {:ok, map()} | {:error, term()}
-  def write_content(abs, path, content, updated, replacements) do
+  def write_content(abs, path, content, updated, replacements, context \\ %{}) do
     case File.write(abs, updated) do
-      :ok -> {:ok, diff_result(path, content, updated, %{replacements: replacements})}
-      {:error, reason} -> {:error, reason}
+      :ok ->
+        {:ok,
+         path
+         |> diff_result(content, updated, %{replacements: replacements})
+         |> add_diagnostics(context)}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -532,6 +565,22 @@ defmodule Raxol.Agent.Actions.Code do
       })
     end
   end
+
+  defp add_diagnostics(result, context) do
+    case Lsp.query(%{op: "diagnostics", path: result.path}, context) do
+      {:ok, %{diagnostics: diagnostics}} ->
+        Map.put(result, :diagnostics, diagnostics)
+
+      {:error, :lsp_not_available} ->
+        result
+
+      {:error, reason} ->
+        Map.put(result, :diagnostics_error, format_diagnostics_error(reason))
+    end
+  end
+
+  defp format_diagnostics_error(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp format_diagnostics_error(reason), do: inspect(reason)
 
   @doc """
   The single gate every shell surface passes through: the jail rule, then the

--- a/packages/raxol_agent/lib/raxol/agent/client_protocol/login.ex
+++ b/packages/raxol_agent/lib/raxol/agent/client_protocol/login.ex
@@ -33,11 +33,13 @@ defmodule Raxol.Agent.ClientProtocol.Login do
 
   Connect an LLM provider for the coding agent and every ACP session.
 
-  With no provider, prints what is currently connected.
+  With no provider, prints what is currently connected and concrete connection
+  examples.
 
   Providers with a browser sign-in use it by default; the rest prompt for a
-  key. Pass --paste to type a key either way (use it over SSH: the sign-in
-  redirect lands on a loopback port and needs a browser on this machine).
+  key without terminal echo. Pass --paste to type a key either way (use it over
+  SSH: the sign-in redirect lands on a loopback port and needs a browser on
+  this machine).
 
   Options:
     --paste      prompt for an API key instead of opening a browser
@@ -90,7 +92,11 @@ defmodule Raxol.Agent.ClientProtocol.Login do
     connected = Enum.filter(providers, & &1[:available?])
 
     if connected == [] do
-      print(io, "No provider connected. Run `raxol login <provider>`.")
+      print(
+        io,
+        "No provider connected. Run `raxol login openrouter` or " <>
+          "`raxol login <provider> --paste`."
+      )
     else
       Enum.each(connected, fn p ->
         print(io, "  #{p[:harness]} (#{p[:source]})")
@@ -124,8 +130,8 @@ defmodule Raxol.Agent.ClientProtocol.Login do
     64
   end
 
-  # A key typed at a prompt, never echoed back and never written to disk as
-  # itself -- Setup.connect_key/3 exchanges it for an `op://` reference.
+  # A key typed at a prompt is read without terminal echo and never written to
+  # disk as itself -- Setup.connect_key/3 exchanges it for an `op://` reference.
   defp connect_key(io, provider) do
     case read_key(io, provider) do
       "" ->
@@ -204,15 +210,24 @@ defmodule Raxol.Agent.ClientProtocol.Login do
   defp read_key(io, provider) do
     case Keyword.get(io, :read_fn) do
       nil ->
-        "Paste the API key for #{provider} (it is exchanged for a 1Password reference): "
-        |> IO.gets()
-        |> to_string()
+        prompt =
+          "Paste the API key for #{provider} " <>
+            "(it is exchanged for a 1Password reference): "
+
+        prompt
+        |> String.to_charlist()
+        |> :io.get_password()
+        |> normalize_password()
         |> String.trim()
 
       fun ->
         fun.(provider)
     end
   end
+
+  defp normalize_password(:eof), do: ""
+  defp normalize_password({:error, _reason}), do: ""
+  defp normalize_password(chars), do: to_string(chars)
 
   defp print(io, message) do
     case Keyword.get(io, :print_fn) do

--- a/packages/raxol_agent/lib/raxol/agent/setup/cli.ex
+++ b/packages/raxol_agent/lib/raxol/agent/setup/cli.ex
@@ -210,6 +210,41 @@ defmodule Raxol.Agent.Setup.CLI do
       note = if p[:note], do: "  — #{p.note}", else: ""
       IO.puts("  #{mark} #{p.label}#{src}#{note}")
     end)
+
+    IO.puts("")
+    IO.puts(next_steps(providers))
+  end
+
+  defp next_steps(providers) do
+    ready? = Enum.any?(providers, & &1.available?)
+
+    if ready? do
+      """
+      next:
+        start the agent:
+          raxol
+
+        coding TUI:
+          raxol code
+
+        inspect install:
+          raxol doctor
+      """
+    else
+      """
+      next:
+        connect a provider:
+          raxol login
+          raxol setup --provider anthropic --op op://Vault/Item/api_key
+
+        try offline:
+          raxol
+
+        inspect install:
+          raxol doctor
+      """
+    end
+    |> String.trim_trailing()
   end
 
   # -- errors -----------------------------------------------------------------

--- a/packages/raxol_agent/lib/raxol/agent/setup/cli.ex
+++ b/packages/raxol_agent/lib/raxol/agent/setup/cli.ex
@@ -83,7 +83,9 @@ defmodule Raxol.Agent.Setup.CLI do
         do_connect_browser(provider)
 
       true ->
-        usage_error("give one of --op, --api-key, --browser, or --remove for #{provider}")
+        usage_error(
+          "give one of --op, --api-key, --browser, or --remove for #{provider}"
+        )
     end
   end
 
@@ -138,9 +140,13 @@ defmodule Raxol.Agent.Setup.CLI do
     end
   end
 
-  defp report_browser({:ok, %{provider: provider, validation: validation}}, _harness) do
+  defp report_browser(
+         {:ok, %{provider: provider, validation: validation}},
+         _harness
+       ) do
     IO.puts("stored reference for #{provider}")
     report_validation(provider, validation)
+    print_next_steps(:connected)
   end
 
   defp report_browser({:error, reason}, harness) do
@@ -151,6 +157,7 @@ defmodule Raxol.Agent.Setup.CLI do
     case Setup.remove(provider) do
       {:ok, harness} ->
         IO.puts("removed stored reference for #{harness}")
+        print_current_next_steps()
 
       {:error, reason} ->
         fail("could not remove #{provider}: #{inspect(reason)}")
@@ -162,6 +169,7 @@ defmodule Raxol.Agent.Setup.CLI do
   defp report_connect({:ok, harness, validation}) do
     IO.puts("stored reference for #{harness}")
     report_validation(harness, validation)
+    print_next_steps(:connected)
   end
 
   defp report_connect({:error, reason}), do: fail(connect_error(reason))
@@ -169,6 +177,7 @@ defmodule Raxol.Agent.Setup.CLI do
   defp report_connect_key({:ok, harness, ref, validation}) do
     IO.puts("stored reference for #{harness}: #{ref}")
     report_validation(harness, validation)
+    print_next_steps(:connected)
   end
 
   defp report_connect_key({:error, reason}), do: fail(connect_error(reason))
@@ -179,7 +188,10 @@ defmodule Raxol.Agent.Setup.CLI do
     do: IO.puts("#{harness} credential validated ✓")
 
   defp report_validation(harness, {:rejected, status}),
-    do: fail("#{harness} credential rejected (HTTP #{status}) — check the key/reference")
+    do:
+      fail(
+        "#{harness} credential rejected (HTTP #{status}) — check the key/reference"
+      )
 
   defp report_validation(harness, {:reachable_error, status}),
     do: fail("#{harness} endpoint returned HTTP #{status}")
@@ -191,7 +203,10 @@ defmodule Raxol.Agent.Setup.CLI do
     do: IO.puts("#{harness} stored (no validation endpoint for this provider)")
 
   defp report_validation(harness, {:no_key, _}),
-    do: fail("#{harness} reference stored but no key resolved — is `op` signed in?")
+    do:
+      fail(
+        "#{harness} reference stored but no key resolved — is `op` signed in?"
+      )
 
   defp report_validation(harness, :no_provider),
     do: fail("could not resolve a provider for #{harness}")
@@ -215,35 +230,50 @@ defmodule Raxol.Agent.Setup.CLI do
     IO.puts(next_steps(providers))
   end
 
-  defp next_steps(providers) do
-    ready? = Enum.any?(providers, & &1.available?)
+  defp print_current_next_steps do
+    %{providers: providers} = Setup.status()
+    print_next_steps(providers)
+  end
 
-    if ready? do
-      """
-      next:
-        start the agent:
-          raxol
+  defp print_next_steps(state) do
+    IO.puts("")
+    IO.puts(next_steps(state))
+  end
 
-        coding TUI:
-          raxol code
+  defp next_steps(providers) when is_list(providers) do
+    if Enum.any?(providers, & &1.available?),
+      do: next_steps(:connected),
+      else: next_steps(:disconnected)
+  end
 
-        inspect install:
-          raxol doctor
-      """
-    else
-      """
-      next:
-        connect a provider:
-          raxol login
-          raxol setup --provider anthropic --op op://Vault/Item/api_key
+  defp next_steps(:connected) do
+    """
+    next:
+      start the agent:
+        raxol
 
-        try offline:
-          raxol
+      coding TUI:
+        raxol code
 
-        inspect install:
-          raxol doctor
-      """
-    end
+      inspect install:
+        raxol doctor
+    """
+    |> String.trim_trailing()
+  end
+
+  defp next_steps(:disconnected) do
+    """
+    next:
+      connect a provider:
+        raxol login openrouter
+        raxol setup --provider anthropic --op op://Vault/Item/api_key
+
+      try offline:
+        raxol
+
+      inspect install:
+        raxol doctor
+    """
     |> String.trim_trailing()
   end
 

--- a/packages/raxol_agent/lib/raxol/agent/setup/cli.ex
+++ b/packages/raxol_agent/lib/raxol/agent/setup/cli.ex
@@ -83,9 +83,7 @@ defmodule Raxol.Agent.Setup.CLI do
         do_connect_browser(provider)
 
       true ->
-        usage_error(
-          "give one of --op, --api-key, --browser, or --remove for #{provider}"
-        )
+        usage_error("give one of --op, --api-key, --browser, or --remove for #{provider}")
     end
   end
 
@@ -188,10 +186,7 @@ defmodule Raxol.Agent.Setup.CLI do
     do: IO.puts("#{harness} credential validated ✓")
 
   defp report_validation(harness, {:rejected, status}),
-    do:
-      fail(
-        "#{harness} credential rejected (HTTP #{status}) — check the key/reference"
-      )
+    do: fail("#{harness} credential rejected (HTTP #{status}) — check the key/reference")
 
   defp report_validation(harness, {:reachable_error, status}),
     do: fail("#{harness} endpoint returned HTTP #{status}")
@@ -203,10 +198,7 @@ defmodule Raxol.Agent.Setup.CLI do
     do: IO.puts("#{harness} stored (no validation endpoint for this provider)")
 
   defp report_validation(harness, {:no_key, _}),
-    do:
-      fail(
-        "#{harness} reference stored but no key resolved — is `op` signed in?"
-      )
+    do: fail("#{harness} reference stored but no key resolved — is `op` signed in?")
 
   defp report_validation(harness, :no_provider),
     do: fail("could not resolve a provider for #{harness}")

--- a/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
@@ -3,8 +3,10 @@ defmodule Raxol.Agent.Actions.CodeTest do
 
   alias Raxol.Agent.Action.ToolConverter
   alias Raxol.Agent.Actions.Code
+  alias Raxol.Agent.Lsp.Pool
   alias Raxol.Agent.Sandbox
 
+  @server Path.expand("../../../support/fake_lsp_server.py", __DIR__)
   setup do
     dir =
       Path.join(
@@ -76,6 +78,17 @@ defmodule Raxol.Agent.Actions.CodeTest do
       assert {:error, :outside_cwd} =
                Code.Write.run(%{path: "../escape", content: "x"}, %{})
     end
+
+    test "includes post-write diagnostics when LSP is available", %{dir: dir} do
+      assert {:ok, result} =
+               Code.Write.run(
+                 %{path: "new.toy", content: "def alpha\n  BROKEN thing\n"},
+                 %{lsp_pool: pool(dir)}
+               )
+
+      assert [%{severity: "error", line: 2, message: "this line is broken"}] =
+               result.diagnostics
+    end
   end
 
   describe "Edit" do
@@ -117,6 +130,23 @@ defmodule Raxol.Agent.Actions.CodeTest do
                  %{path: "dup.txt", old_string: "a", new_string: "b"},
                  %{}
                )
+    end
+
+    test "includes post-edit diagnostics when LSP is available", %{dir: dir} do
+      File.write!(Path.join(dir, "edit.toy"), "def alpha\n  fine\n")
+
+      assert {:ok, result} =
+               Code.Edit.run(
+                 %{
+                   path: "edit.toy",
+                   old_string: "fine",
+                   new_string: "BROKEN now"
+                 },
+                 %{lsp_pool: pool(dir)}
+               )
+
+      assert [%{severity: "error", line: 2, message: "this line is broken"}] =
+               result.diagnostics
     end
 
     test "replace_all replaces every occurrence", %{dir: dir} do
@@ -557,6 +587,24 @@ defmodule Raxol.Agent.Actions.CodeTest do
       assert result.truncated == true
       assert result.new_bytes == 40_000
     end
+  end
+
+  defp pool(dir) do
+    {:ok, pool} = Pool.start_link(root: dir, servers: servers())
+    on_exit(fn -> Pool.stop(pool) end)
+    pool
+  end
+
+  defp servers do
+    [
+      %{
+        name: "toy",
+        command: @server,
+        args: [],
+        extensions: [".toy"],
+        language_id: "toy"
+      }
+    ]
   end
 
   # Pins the pure-Elixir scanner, which is what runs wherever ripgrep is not

--- a/packages/raxol_agent/test/raxol/agent/setup_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/setup_test.exs
@@ -1,8 +1,11 @@
 defmodule Raxol.Agent.SetupTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureIO
+
   alias Raxol.Agent.Backend.Credentials
   alias Raxol.Agent.Setup
+  alias Raxol.Agent.Setup.CLI
 
   # Provider env keys the resolver reads; cleared so the store is the only
   # source of truth for these tests (mirrors app_login_test's isolation).
@@ -146,6 +149,25 @@ defmodule Raxol.Agent.SetupTest do
       assert Map.has_key?(status, :op)
       assert is_list(status.providers)
       assert Enum.all?(status.providers, &Map.has_key?(&1, :harness))
+    end
+  end
+
+  describe "CLI.run/1" do
+    test "successful connects print connected next steps" do
+      output =
+        capture_io(fn ->
+          assert CLI.run([
+                   "--provider",
+                   "mock",
+                   "--op",
+                   "op://Vault/Mock/api_key"
+                 ]) == 0
+        end)
+
+      assert output =~ "stored reference for mock"
+      assert output =~ "next:"
+      assert output =~ "raxol code"
+      assert output =~ "raxol doctor"
     end
   end
 end

--- a/packages/raxol_cli/lib/raxol/cli.ex
+++ b/packages/raxol_cli/lib/raxol/cli.ex
@@ -29,8 +29,12 @@ defmodule Raxol.CLI do
   # The headless twin of `login`, and the same code `mix raxol.setup` runs.
   # Reachable from the packaged binary because connecting a provider is the
   # first thing a fresh install needs, and an npm install has no Mix tasks.
-  def main(["setup" | rest]), do: with_app(fn -> Raxol.Agent.Setup.CLI.run(rest) end)
-  def main(["doctor" | rest]), do: with_app(fn -> Raxol.CLI.Doctor.run(rest) end)
+  def main(["setup" | rest]),
+    do: with_app(fn -> Raxol.Agent.Setup.CLI.run(rest) end)
+
+  def main(["doctor" | rest]),
+    do: with_app(fn -> Raxol.CLI.Doctor.run(rest) end)
+
   def main(["playground" | _rest]), do: run_playground()
   def main(["new" | rest]), do: Raxol.CLI.New.run(rest)
   def main([help]) when help in ~w(help --help -h), do: help()
@@ -48,19 +52,10 @@ defmodule Raxol.CLI do
   # needs no tty. `/exit` or EOF ends the session.
   defp run_agent(_args) do
     IO.puts(banner())
-    mode = if credentials?(), do: :live, else: :mock
+    mode = agent_mode()
 
     if mode == :mock do
-      IO.puts("""
-      No provider connected. Mock mode is active.
-
-      Connect:
-        raxol login
-        raxol setup --provider anthropic --op op://Vault/Item/api_key
-
-      Try anyway:
-        type a prompt, or /exit
-      """)
+      IO.puts(mock_mode_message())
     end
 
     loop([], mode)
@@ -117,22 +112,104 @@ defmodule Raxol.CLI do
       ""
   end
 
-  # With credentials, resolve a real provider (op-ref -> provider-env ->
-  # AI_API_KEY). Without, a Mock backend echoes so the session is still usable.
-  defp turn_opts(_input, :live), do: [auto_provider: true]
+  # With credentials, resolve the same provider surface that setup/doctor report:
+  # stored op refs, provider env vars, native subscriptions, then AI_API_KEY.
+  # Without one, a Mock backend echoes so the session is still usable.
+  defp turn_opts(_input, {:live, executor}), do: [executor: executor]
 
   defp turn_opts(input, :mock) do
     [
       backend: Raxol.Agent.Backend.Mock,
       backend_opts: [
-        response: "(mock) Set AI_API_KEY for real replies. You said: #{input}"
+        response:
+          "(mock) Connect a provider for real replies. You said: #{input}"
       ]
     ]
   end
 
-  defp credentials? do
-    ~w(AI_API_KEY ANTHROPIC_API_KEY OPENAI_API_KEY OPENROUTER_API_KEY)
-    |> Enum.any?(&(System.get_env(&1) not in [nil, ""]))
+  defp agent_mode do
+    resolver =
+      Application.get_env(
+        :raxol_cli,
+        :agent_executor_resolver,
+        &resolve_agent_executor/0
+      )
+
+    case resolver.() do
+      {:ok, %Raxol.Agent.ExecutorConfig{} = executor} -> {:live, executor}
+      _ -> :mock
+    end
+  end
+
+  defp resolve_agent_executor do
+    executor =
+      [
+        &auto_executor/0,
+        &connected_provider_executor/0,
+        &generic_executor/0
+      ]
+      |> Enum.find_value(& &1.())
+
+    case executor do
+      nil -> :error
+      executor -> {:ok, executor}
+    end
+  end
+
+  defp auto_executor do
+    case Raxol.Agent.Backend.Resolver.resolve() do
+      {:ok, executor, _source} -> executor
+      _ -> nil
+    end
+  end
+
+  defp connected_provider_executor do
+    Raxol.Agent.Setup.status().providers
+    |> Enum.find_value(fn
+      %{available?: true, harness: harness} -> explicit_executor(harness)
+      _ -> nil
+    end)
+  end
+
+  defp explicit_executor(harness) do
+    case Raxol.Agent.Backend.Resolver.resolve(harness: harness) do
+      {:ok, executor, _source} -> executor
+      _ -> nil
+    end
+  end
+
+  defp generic_executor do
+    case System.get_env("AI_API_KEY") do
+      key when is_binary(key) and key != "" ->
+        [
+          harness: :openai,
+          api_key: key,
+          base_url: System.get_env("AI_BASE_URL"),
+          model: System.get_env("AI_MODEL")
+        ]
+        |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+        |> Raxol.Agent.Backend.Resolver.resolve()
+        |> case do
+          {:ok, executor, _source} -> executor
+          _ -> nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp mock_mode_message do
+    """
+    No provider connected. Mock mode is active.
+
+    Connect:
+      raxol login openrouter
+      raxol setup --provider anthropic --op op://Vault/Item/api_key
+
+    Try anyway:
+      type a prompt, or /exit
+    """
   end
 
   # -- code -------------------------------------------------------------------
@@ -274,7 +351,9 @@ defmodule Raxol.CLI do
   @git_head Path.join([__DIR__, "..", "..", "..", "..", ".git", "HEAD"])
   if File.exists?(@git_head), do: @external_resource(@git_head)
 
-  @build_sha (case System.cmd("git", ["rev-parse", "--short", "HEAD"], stderr_to_stdout: true) do
+  @build_sha (case System.cmd("git", ["rev-parse", "--short", "HEAD"],
+                     stderr_to_stdout: true
+                   ) do
                 {sha, 0} -> String.trim(sha)
                 _ -> nil
               end)

--- a/packages/raxol_cli/lib/raxol/cli.ex
+++ b/packages/raxol_cli/lib/raxol/cli.ex
@@ -8,7 +8,7 @@ defmodule Raxol.CLI do
   which returns the process exit code.
   """
 
-  @commands ~w(agent code p acp login setup doctor playground new help)
+  @commands ~w(agent code p acp login setup doctor update playground new help)
 
   @doc "Dispatch `argv`, returning an exit code."
   @spec main([String.t()]) :: non_neg_integer()
@@ -35,6 +35,7 @@ defmodule Raxol.CLI do
   def main(["doctor" | rest]),
     do: with_app(fn -> Raxol.CLI.Doctor.run(rest) end)
 
+  def main(["update" | rest]), do: Raxol.CLI.Update.run(rest)
   def main(["playground" | _rest]), do: run_playground()
   def main(["new" | rest]), do: Raxol.CLI.New.run(rest)
   def main([help]) when help in ~w(help --help -h), do: help()
@@ -51,15 +52,21 @@ defmodule Raxol.CLI do
   # Line-based stdio (not the full-screen terminal), so it works over a pipe and
   # needs no tty. `/exit` or EOF ends the session.
   defp run_agent(_args) do
-    IO.puts(banner())
-    mode = agent_mode()
+    case auto_update_prompt() do
+      :updated ->
+        0
 
-    if mode == :mock do
-      IO.puts(mock_mode_message())
+      :ok ->
+        IO.puts(banner())
+        mode = agent_mode()
+
+        if mode == :mock do
+          IO.puts(mock_mode_message())
+        end
+
+        loop([], mode)
+        0
     end
-
-    loop([], mode)
-    0
   end
 
   defp loop(history, mode) do
@@ -121,8 +128,7 @@ defmodule Raxol.CLI do
     [
       backend: Raxol.Agent.Backend.Mock,
       backend_opts: [
-        response:
-          "(mock) Connect a provider for real replies. You said: #{input}"
+        response: "(mock) Connect a provider for real replies. You said: #{input}"
       ]
     ]
   end
@@ -220,8 +226,12 @@ defmodule Raxol.CLI do
   # remote client, so it boots without that check. `--help`/`--sessions` are
   # answered by the launcher before either boot runs.
   defp run_code(args) do
-    boot = if "--ssh" in args, do: &serve_boot/0, else: &code_boot/0
-    Raxol.Agent.Code.Launcher.main(args, boot: boot)
+    if local_code_session?(args) and auto_update_prompt() == :updated do
+      0
+    else
+      boot = if "--ssh" in args, do: &serve_boot/0, else: &code_boot/0
+      Raxol.Agent.Code.Launcher.main(args, boot: boot)
+    end
   end
 
   defp code_boot do
@@ -250,18 +260,31 @@ defmodule Raxol.CLI do
   # Start the interactive component-catalog TUI. Needs a real terminal; over a
   # pipe it exits with a clear message rather than a crash.
   defp run_playground do
-    if interactive?() do
-      {:ok, _pid} = Raxol.start_link(Raxol.Playground.App, mouse: false)
+    cond do
+      !interactive?() ->
+        IO.puts(:stderr, "raxol playground requires an interactive terminal.")
+        1
 
-      receive do
-        :playground_done -> :ok
-      end
+      auto_update_prompt() == :updated ->
+        0
 
-      0
-    else
-      IO.puts(:stderr, "raxol playground requires an interactive terminal.")
-      1
+      true ->
+        {:ok, _pid} = Raxol.start_link(Raxol.Playground.App, mouse: false)
+
+        receive do
+          :playground_done -> :ok
+        end
+
+        0
     end
+  end
+
+  defp local_code_session?(args) do
+    "--ssh" not in args and Enum.all?(args, &(&1 not in ~w(--help -h --sessions)))
+  end
+
+  defp auto_update_prompt do
+    Raxol.CLI.Update.auto_prompt(prompt?: interactive?(false))
   end
 
   # Is there a terminal for a full-screen TUI to draw on?
@@ -326,6 +349,7 @@ defmodule Raxol.CLI do
       login         Connect an LLM provider (browser sign-in, or a key)
       setup         Connect/inspect a provider headlessly (CI, remote boxes)
       doctor        Report this install: build, runtime, providers, config
+      update        Update the installed binary from GitHub Releases
       playground    Browse the interactive component catalog
       new [name]    Scaffold an Elixir/Mix Raxol application
       help          Show this help
@@ -351,9 +375,7 @@ defmodule Raxol.CLI do
   @git_head Path.join([__DIR__, "..", "..", "..", "..", ".git", "HEAD"])
   if File.exists?(@git_head), do: @external_resource(@git_head)
 
-  @build_sha (case System.cmd("git", ["rev-parse", "--short", "HEAD"],
-                     stderr_to_stdout: true
-                   ) do
+  @build_sha (case System.cmd("git", ["rev-parse", "--short", "HEAD"], stderr_to_stdout: true) do
                 {sha, 0} -> String.trim(sha)
                 _ -> nil
               end)

--- a/packages/raxol_cli/lib/raxol/cli.ex
+++ b/packages/raxol_cli/lib/raxol/cli.ex
@@ -51,10 +51,16 @@ defmodule Raxol.CLI do
     mode = if credentials?(), do: :live, else: :mock
 
     if mode == :mock do
-      IO.puts(
-        "No AI credentials found (set AI_API_KEY or a provider key). " <>
-          "Running with mock responses."
-      )
+      IO.puts("""
+      No provider connected. Mock mode is active.
+
+      Connect:
+        raxol login
+        raxol setup --provider anthropic --op op://Vault/Item/api_key
+
+      Try anyway:
+        type a prompt, or /exit
+      """)
     end
 
     loop([], mode)
@@ -244,7 +250,7 @@ defmodule Raxol.CLI do
       setup         Connect/inspect a provider headlessly (CI, remote boxes)
       doctor        Report this install: build, runtime, providers, config
       playground    Browse the interactive component catalog
-      new [name]    Scaffold a new Raxol application
+      new [name]    Scaffold an Elixir/Mix Raxol application
       help          Show this help
 
     Run `raxol` with no command to start the agent.

--- a/packages/raxol_cli/lib/raxol/cli/doctor.ex
+++ b/packages/raxol_cli/lib/raxol/cli/doctor.ex
@@ -30,6 +30,8 @@ defmodule Raxol.CLI.Doctor do
     IO.puts(header(cwd))
     IO.puts("")
     IO.puts(Inspection.render(Inspection.gather(cwd)))
+    IO.puts("")
+    IO.puts(next_steps())
 
     0
   end
@@ -68,5 +70,26 @@ defmodule Raxol.CLI.Doctor do
       "NOT built in -- needs a source build of raxol_agent with " <>
         ":raxol_agent_client_protocol"
     end
+  end
+
+  defp next_steps do
+    """
+    next:
+      connect or inspect providers:
+        raxol setup
+
+      start the agent:
+        raxol
+
+      coding TUI:
+        raxol code
+
+      component catalog:
+        raxol playground
+
+      scaffold an Elixir/Mix app:
+        raxol new counter
+    """
+    |> String.trim_trailing()
   end
 end

--- a/packages/raxol_cli/lib/raxol/cli/new.ex
+++ b/packages/raxol_cli/lib/raxol/cli/new.ex
@@ -23,7 +23,7 @@ defmodule Raxol.CLI.New do
     end
   end
 
-  def run(_), do: err("usage: raxol new <app_name>")
+  def run(_), do: err("usage: raxol new <app_name> (requires local Elixir/Mix)")
 
   defp generate(name) do
     mod = Macro.camelize(name)
@@ -36,7 +36,7 @@ defmodule Raxol.CLI.New do
     IO.puts("""
     Created #{name}/
 
-    Next:
+    Next (requires local Elixir/Mix):
       cd #{name}
       mix deps.get
       mix run -e "#{mod}.start()"
@@ -121,7 +121,7 @@ defmodule Raxol.CLI.New do
     """
     # #{mod}
 
-    A Raxol terminal app.
+    A Raxol terminal app. Requires local Elixir/Mix.
 
     ## Run
 

--- a/packages/raxol_cli/lib/raxol/cli/update.ex
+++ b/packages/raxol_cli/lib/raxol/cli/update.ex
@@ -1,0 +1,540 @@
+defmodule Raxol.CLI.Update do
+  @moduledoc """
+  Self-update command for Burrito-built `raxol` binaries.
+  """
+
+  @repo "DROOdotFOO/raxol"
+  @tag_prefix "raxol-cli-v"
+  @timeout 30_000
+  @auto_check_interval_s 24 * 60 * 60
+
+  @type release :: map()
+  @type target :: %{asset: String.t(), label: String.t(), windows?: boolean()}
+
+  @spec run([String.t()], keyword()) :: non_neg_integer()
+  def run(args, opts \\ []) do
+    case parse_args(args) do
+      {:ok, :help} ->
+        print_help()
+        0
+
+      {:ok, parsed} ->
+        execute(parsed, opts)
+
+      {:error, reason} ->
+        IO.puts(:stderr, "raxol update: #{reason}")
+        64
+    end
+  end
+
+  @doc false
+  @spec auto_prompt(keyword()) :: :ok | :updated
+  def auto_prompt(runtime \\ []) do
+    with true <- Keyword.get_lazy(runtime, :prompt?, &interactive_prompt?/0),
+         true <- auto_check_enabled?(runtime),
+         true <- auto_check_due?(runtime),
+         {:ok, _current_exe} <- current_executable(runtime) do
+      _ = write_auto_check(runtime)
+      prompt_for_latest_update(runtime)
+    else
+      _ -> :ok
+    end
+  rescue
+    _ -> :ok
+  end
+
+  @doc false
+  @spec latest_update(keyword()) ::
+          {:update_available, String.t(), String.t()}
+          | {:no_update, String.t()}
+          | {:error, term()}
+  def latest_update(runtime \\ []) do
+    current_version = runtime |> current_version() |> base_version()
+
+    with {:ok, _target} <- target(runtime),
+         {:ok, release} <- resolve_release(nil, runtime),
+         {:ok, target_version} <- release_version(release) do
+      if update_needed?(current_version, target_version) do
+        {:update_available, target_version, current_version}
+      else
+        {:no_update, current_version}
+      end
+    end
+  end
+
+  defp parse_args(args) do
+    {opts, positional, invalid} =
+      OptionParser.parse(args,
+        strict: [check: :boolean, version: :string, help: :boolean],
+        aliases: [h: :help]
+      )
+
+    cond do
+      opts[:help] -> {:ok, :help}
+      invalid != [] -> {:error, "unknown options: #{format_invalid(invalid)}"}
+      positional != [] -> {:error, "unexpected arguments: #{Enum.join(positional, " ")}"}
+      true -> {:ok, opts}
+    end
+  end
+
+  defp format_invalid(invalid) do
+    invalid
+    |> Enum.map(fn
+      {flag, nil} -> flag
+      {flag, value} -> flag <> " " <> value
+    end)
+    |> Enum.join(", ")
+  end
+
+  defp execute(opts, runtime) do
+    current_version = runtime |> current_version() |> base_version()
+
+    with {:ok, target} <- target(runtime),
+         {:ok, release} <- resolve_release(opts[:version], runtime),
+         {:ok, target_version} <- release_version(release) do
+      cond do
+        !update_needed?(current_version, target_version) ->
+          IO.puts("Current version: #{current_version}")
+          IO.puts("Raxol is up to date")
+          0
+
+        opts[:check] ->
+          IO.puts("Current version: #{current_version}")
+          IO.puts("New version available: #{target_version}")
+          IO.puts("Run `raxol update` to install the update")
+          0
+
+        true ->
+          install_update(current_version, target_version, target, release, runtime)
+      end
+    else
+      {:error, reason} ->
+        IO.puts(:stderr, "raxol update: #{format_reason(reason)}")
+        1
+    end
+  end
+
+  defp prompt_for_latest_update(runtime) do
+    case latest_update(runtime) do
+      {:update_available, target_version, current_version} ->
+        prompt_for_update(target_version, current_version, runtime)
+
+      _ ->
+        :ok
+    end
+  end
+
+  defp prompt_for_update(target_version, current_version, runtime) do
+    IO.puts("")
+    IO.puts("Raxol #{target_version} is available (current #{current_version}).")
+
+    answer =
+      case IO.gets("Update now? [y/N] ") do
+        :eof -> ""
+        {:error, _reason} -> ""
+        data -> data
+      end
+      |> String.trim()
+      |> String.downcase()
+
+    if answer in ["y", "yes"] do
+      case run(["--version", target_version], runtime) do
+        0 -> :updated
+        _ -> :ok
+      end
+    else
+      IO.puts("Skipping update. Run `raxol update` later.")
+      :ok
+    end
+  end
+
+  defp current_version(runtime) do
+    Keyword.get_lazy(runtime, :current_version, &Raxol.CLI.version/0)
+  end
+
+  defp update_needed?(current, target) do
+    case {Version.parse(target), Version.parse(current)} do
+      {{:ok, target_v}, {:ok, current_v}} -> Version.compare(target_v, current_v) == :gt
+      _ -> target != current
+    end
+  end
+
+  defp install_update(current_version, target_version, target, release, runtime) do
+    with {:ok, binary} <- asset(release, target.asset),
+         {:ok, sums} <- checksum_asset(release, runtime),
+         {:ok, expected_sha} <- checksum_for(sums, target.asset),
+         {:ok, current_exe} <- current_executable(runtime) do
+      IO.puts("Current version: #{current_version}")
+      IO.puts("New version available: #{target_version}")
+      IO.puts("Downloading #{target.label}…")
+
+      case download_verify_install(binary, current_exe, expected_sha, target, runtime) do
+        :ok ->
+          IO.puts("✔ Updated to #{target_version}")
+          IO.puts("Restart raxol to use the new version")
+          0
+
+        {:error, reason} ->
+          IO.puts(:stderr, "raxol update: #{format_reason(reason)}")
+          1
+      end
+    else
+      {:error, reason} ->
+        IO.puts(:stderr, "raxol update: #{format_reason(reason)}")
+        1
+    end
+  end
+
+  defp download_verify_install(binary, current_exe, expected_sha, target, runtime) do
+    tmp_path = update_path(current_exe)
+
+    result =
+      with :ok <- download(Map.fetch!(binary, "browser_download_url"), tmp_path, runtime),
+           :ok <- verify_checksum(tmp_path, expected_sha) do
+        IO.puts("Verified sha256:#{expected_sha}")
+        IO.puts("Installing update...")
+        replace_executable(tmp_path, current_exe, target)
+      end
+
+    if result != :ok or !target.windows? do
+      if File.exists?(tmp_path), do: File.rm(tmp_path)
+    end
+
+    result
+  end
+
+  defp update_path(current_exe) do
+    dir = Path.dirname(current_exe)
+    base = Path.basename(current_exe)
+    suffix = System.unique_integer([:positive])
+    Path.join(dir, ".#{base}.#{suffix}.update")
+  end
+
+  defp replace_executable(tmp_path, current_exe, %{windows?: true}) do
+    with :ok <- File.chmod(tmp_path, 0o755),
+         :ok <- write_windows_replacer(tmp_path, current_exe) do
+      :ok
+    else
+      {:error, reason} ->
+        {:error, "failed to schedule executable replacement: #{inspect(reason)}"}
+    end
+  end
+
+  defp replace_executable(tmp_path, current_exe, %{windows?: false}) do
+    with :ok <- File.chmod(tmp_path, 0o755),
+         :ok <- File.rename(tmp_path, current_exe) do
+      :ok
+    else
+      {:error, reason} -> {:error, "failed to replace executable: #{inspect(reason)}"}
+    end
+  end
+
+  defp write_windows_replacer(tmp_path, current_exe) do
+    bat = Path.join(System.tmp_dir!(), "raxol-updater-#{System.unique_integer([:positive])}.bat")
+
+    body = """
+    @echo off
+    timeout /t 2 /nobreak > nul
+    move /y "#{Path.expand(tmp_path)}" "#{Path.expand(current_exe)}" > nul
+    del "%~f0"
+    """
+
+    with :ok <- File.write(bat, body),
+         {_, 0} <- System.cmd("cmd", ["/c", "start", "/b", bat]) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      {output, status} -> {:error, {:cmd_failed, status, output}}
+    end
+  end
+
+  defp verify_checksum(path, expected_sha) do
+    actual_sha =
+      path
+      |> File.stream!(65_536, [:raw, :binary])
+      |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
+      |> :crypto.hash_final()
+      |> Base.encode16(case: :lower)
+
+    if actual_sha == String.downcase(expected_sha) do
+      :ok
+    else
+      {:error, "checksum mismatch for downloaded binary"}
+    end
+  rescue
+    e -> {:error, Exception.message(e)}
+  end
+
+  defp resolve_release(nil, runtime) do
+    releases_url = "https://api.github.com/repos/#{@repo}/releases?per_page=20"
+
+    with {:ok, releases} when is_list(releases) <- get_json(releases_url, runtime),
+         %{} = release <- Enum.find(releases, &cli_release?/1) do
+      {:ok, release}
+    else
+      nil -> {:error, "no #{@tag_prefix} release found"}
+      {:ok, _} -> {:error, "GitHub releases response was not a list"}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_release(version, runtime) do
+    tag = @tag_prefix <> base_version(version)
+    url = "https://api.github.com/repos/#{@repo}/releases/tags/#{tag}"
+    get_json(url, runtime)
+  end
+
+  defp cli_release?(%{"tag_name" => @tag_prefix <> _, "draft" => draft, "prerelease" => pre}) do
+    draft != true and pre != true
+  end
+
+  defp cli_release?(_), do: false
+
+  defp release_version(%{"tag_name" => @tag_prefix <> version}), do: {:ok, version}
+  defp release_version(_), do: {:error, "release tag is not a #{@tag_prefix} tag"}
+
+  defp asset(%{"assets" => assets}, name) when is_list(assets) do
+    case Enum.find(assets, &(Map.get(&1, "name") == name)) do
+      %{} = asset -> {:ok, asset}
+      nil -> {:error, "release is missing #{name}"}
+    end
+  end
+
+  defp asset(_release, name), do: {:error, "release is missing #{name}"}
+
+  defp interactive_prompt? do
+    case :io.getopts() do
+      opts when is_list(opts) -> Keyword.get(opts, :terminal, false) != false
+      _ -> false
+    end
+  rescue
+    _ -> false
+  end
+
+  defp auto_check_enabled?(runtime) do
+    Keyword.get(runtime, :auto_check?, true) and
+      System.get_env("RAXOL_NO_UPDATE_CHECK") not in ~w(1 true yes on)
+  end
+
+  defp auto_check_due?(runtime) do
+    now = now_s(runtime)
+    interval = Keyword.get(runtime, :auto_check_interval_s, @auto_check_interval_s)
+
+    case read_last_auto_check(runtime) do
+      {:ok, last_checked_at} -> now - last_checked_at >= interval
+      :error -> true
+    end
+  end
+
+  defp read_last_auto_check(runtime) do
+    with {:ok, raw} <- File.read(auto_check_path(runtime)),
+         {:ok, %{"last_checked_at" => last_checked_at}} when is_integer(last_checked_at) <-
+           Jason.decode(raw) do
+      {:ok, last_checked_at}
+    else
+      _ -> :error
+    end
+  end
+
+  defp write_auto_check(runtime) do
+    path = auto_check_path(runtime)
+    File.mkdir_p!(Path.dirname(path))
+    File.write(path, Jason.encode!(%{"last_checked_at" => now_s(runtime)}))
+  end
+
+  defp auto_check_path(runtime) do
+    Keyword.get_lazy(runtime, :auto_check_path, fn ->
+      Path.expand("~/.raxol/cli-update-check.json")
+    end)
+  end
+
+  defp now_s(runtime), do: Keyword.get_lazy(runtime, :now_s, fn -> :os.system_time(:second) end)
+
+  defp checksum_asset(release, runtime) do
+    with {:ok, asset} <- asset(release, "SHA256SUMS") do
+      get_text(Map.fetch!(asset, "browser_download_url"), runtime)
+    end
+  end
+
+  defp checksum_for(sums, filename) do
+    sums
+    |> String.split("\n", trim: true)
+    |> Enum.find_value(fn line ->
+      case String.split(line) do
+        [sha, ^filename | _] -> sha
+        _ -> nil
+      end
+    end)
+    |> case do
+      nil -> {:error, "SHA256SUMS is missing #{filename}"}
+      sha -> validate_sha(sha)
+    end
+  end
+
+  defp validate_sha(sha) do
+    if String.match?(sha, ~r/\A[0-9a-fA-F]{64}\z/) do
+      {:ok, String.downcase(sha)}
+    else
+      {:error, "invalid sha256 in SHA256SUMS"}
+    end
+  end
+
+  defp current_executable(runtime) do
+    runtime
+    |> Keyword.get(:current_executable)
+    |> case do
+      path when is_binary(path) and path != "" -> {:ok, path}
+      _ -> burrito_executable_path()
+    end
+  end
+
+  defp burrito_executable_path do
+    with true <- Code.ensure_loaded?(Burrito.Util.Args),
+         true <- function_exported?(Burrito.Util.Args, :get_bin_path, 0),
+         path when is_binary(path) <- Burrito.Util.Args.get_bin_path() do
+      {:ok, path}
+    else
+      _ ->
+        {:error,
+         "not running as a Burrito binary; reinstall with `npm i -g raxol` or download the latest release"}
+    end
+  end
+
+  defp target(runtime) do
+    case Keyword.get(runtime, :target) || host_target() do
+      nil ->
+        {:error,
+         "unsupported platform #{inspect(:os.type())} #{:erlang.system_info(:system_architecture)}"}
+
+      target ->
+        {:ok, target}
+    end
+  end
+
+  defp host_target do
+    arch = :erlang.system_info(:system_architecture) |> List.to_string()
+    os = :os.type()
+
+    cond do
+      os == {:unix, :darwin} and arch_matches?(arch, ["aarch64", "arm64"]) ->
+        %{asset: "raxol_cli_macos", label: "raxol-darwin-arm64", windows?: false}
+
+      match?({:unix, _}, os) and arch_matches?(arch, ["x86_64", "amd64"]) ->
+        %{asset: "raxol_cli_linux", label: "raxol-linux-x64", windows?: false}
+
+      match?({:unix, _}, os) and arch_matches?(arch, ["aarch64", "arm64"]) ->
+        %{asset: "raxol_cli_linux_arm", label: "raxol-linux-arm64", windows?: false}
+
+      match?({:win32, _}, os) ->
+        %{asset: "raxol_cli_windows.exe", label: "raxol-win32-x64", windows?: true}
+
+      true ->
+        nil
+    end
+  end
+
+  defp arch_matches?(arch, needles), do: Enum.any?(needles, &String.contains?(arch, &1))
+
+  defp get_json(url, runtime) do
+    case Keyword.get(runtime, :http_get_json) do
+      fun when is_function(fun, 1) -> fun.(url)
+      _ -> default_get_json(url)
+    end
+  end
+
+  defp get_text(url, runtime) do
+    case Keyword.get(runtime, :http_get_text) do
+      fun when is_function(fun, 1) -> fun.(url)
+      _ -> default_get_text(url)
+    end
+  end
+
+  defp download(url, path, runtime) do
+    case Keyword.get(runtime, :download_file) do
+      fun when is_function(fun, 2) -> fun.(url, path)
+      _ -> default_download(url, path)
+    end
+  end
+
+  defp default_get_json(url) do
+    case Req.get(url, headers: headers(), receive_timeout: @timeout) do
+      {:ok, %{status: status, body: body}} when status in 200..299 -> decode_json(body)
+      {:ok, %{status: status}} -> {:error, "GitHub returned HTTP #{status}"}
+      {:error, reason} -> {:error, Exception.message(reason)}
+    end
+  end
+
+  defp decode_json(body) when is_map(body) or is_list(body), do: {:ok, body}
+
+  defp decode_json(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, reason} -> {:error, "invalid GitHub JSON: #{Exception.message(reason)}"}
+    end
+  end
+
+  defp default_get_text(url) do
+    case Req.get(url, headers: headers(), receive_timeout: @timeout, decode_body: false) do
+      {:ok, %{status: status, body: body}} when status in 200..299 and is_binary(body) ->
+        {:ok, body}
+
+      {:ok, %{status: status}} ->
+        {:error, "GitHub returned HTTP #{status}"}
+
+      {:error, reason} ->
+        {:error, Exception.message(reason)}
+    end
+  end
+
+  defp default_download(url, path) do
+    File.open(path, [:write, :binary], fn io ->
+      Req.get(url,
+        headers: headers(),
+        receive_timeout: @timeout,
+        raw: true,
+        into: fn {:data, data}, {req, resp} ->
+          IO.binwrite(io, data)
+          {:cont, {req, resp}}
+        end
+      )
+    end)
+    |> case do
+      {:ok, {:ok, %{status: status}}} when status in 200..299 -> :ok
+      {:ok, {:ok, %{status: status}}} -> {:error, "download returned HTTP #{status}"}
+      {:ok, {:error, reason}} -> {:error, Exception.message(reason)}
+      {:error, reason} -> {:error, "failed to write update: #{inspect(reason)}"}
+    end
+  end
+
+  defp headers do
+    [
+      {"accept", "application/vnd.github+json"},
+      {"user-agent", "raxol-cli-updater"}
+    ]
+  end
+
+  defp base_version(version) do
+    version
+    |> to_string()
+    |> String.trim_leading("v")
+    |> String.split("+", parts: 2)
+    |> hd()
+  end
+
+  defp format_reason(reason) when is_binary(reason), do: reason
+  defp format_reason(reason), do: inspect(reason)
+
+  defp print_help do
+    IO.puts("""
+    Usage: raxol update [options]
+
+    Options:
+      --check            Check for an update without installing
+      --version VERSION  Install a specific CLI release version
+      -h, --help         Show this help
+
+    Downloads the matching Burrito binary from the latest raxol-cli GitHub
+    release, verifies SHA256SUMS, and replaces the running binary.
+    """)
+  end
+end

--- a/packages/raxol_cli/npm/README.md
+++ b/packages/raxol_cli/npm/README.md
@@ -7,6 +7,7 @@ binary. No Erlang, Elixir, or Node runtime needed at run time.
 npm install -g raxol
 raxol            # interactive AI agent
 raxol doctor     # what this install resolves: build, providers, config
+raxol update     # replace this binary with the latest verified release
 raxol playground # component catalog
 raxol new my_app # scaffold an app
 raxol help
@@ -35,6 +36,12 @@ disk, never a raw key.
 
 If something looks wrong, `raxol doctor` reports the build commit, the runtime,
 every provider it can see, and the config it resolved.
+
+`raxol` checks for a newer `raxol-cli-v*` GitHub Release once per day when
+started interactively and prompts before installing. `raxol update` runs the
+same path on demand: it downloads the matching platform binary, verifies
+`SHA256SUMS`, and replaces the installed binary in place. Restart `raxol` after
+it reports success. Set `RAXOL_NO_UPDATE_CHECK=1` to disable the entry prompt.
 
 ## How this package is put together
 

--- a/packages/raxol_cli/test/raxol/cli/new_test.exs
+++ b/packages/raxol_cli/test/raxol/cli/new_test.exs
@@ -7,7 +7,9 @@ defmodule Raxol.CLI.NewTest do
 
   describe "run/1 validation" do
     test "rejects a missing name" do
-      assert capture_io(:stderr, fn -> assert New.run([]) == 1 end) =~ "usage:"
+      message = capture_io(:stderr, fn -> assert New.run([]) == 1 end)
+      assert message =~ "usage:"
+      assert message =~ "requires local Elixir/Mix"
     end
 
     test "rejects a non-snake_case name" do
@@ -36,11 +38,16 @@ defmodule Raxol.CLI.NewTest do
       File.cd!(base)
       on_exit(fn -> File.cd!(cwd) end)
 
-      capture_io(fn -> assert New.run(["my_app"]) == 0 end)
+      output = capture_io(fn -> assert New.run(["my_app"]) == 0 end)
 
       assert File.exists?(Path.join([base, "my_app", "mix.exs"]))
       assert File.exists?(Path.join([base, "my_app", "lib", "my_app.ex"]))
       assert File.read!(Path.join([base, "my_app", "lib", "my_app.ex"])) =~ "defmodule MyApp"
+
+      assert output =~ "Next (requires local Elixir/Mix):"
+
+      assert File.read!(Path.join([base, "my_app", "README.md"])) =~
+               "Requires local Elixir/Mix"
     end
   end
 end

--- a/packages/raxol_cli/test/raxol/cli/update_test.exs
+++ b/packages/raxol_cli/test/raxol/cli/update_test.exs
@@ -1,0 +1,203 @@
+defmodule Raxol.CLI.UpdateTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Raxol.CLI.Update
+
+  @asset "raxol_cli_macos"
+  @binary "new raxol binary\n"
+  @sha :crypto.hash(:sha256, @binary) |> Base.encode16(case: :lower)
+  @target %{asset: @asset, label: "raxol-darwin-arm64", windows?: false}
+  @release_url "https://api.github.com/repos/DROOdotFOO/raxol/releases?per_page=20"
+  @tag_url "https://api.github.com/repos/DROOdotFOO/raxol/releases/tags/raxol-cli-v0.2.7"
+  @binary_url "https://example.test/raxol_cli_macos"
+  @sums_url "https://example.test/SHA256SUMS"
+
+  test "check reports the newest CLI release without installing" do
+    out =
+      capture_io(fn ->
+        assert Update.run(["--check"], runtime_opts(current_version: "0.2.6+abc")) == 0
+      end)
+
+    assert out =~ "Current version: 0.2.6"
+    assert out =~ "New version available: 0.2.7"
+    assert out =~ "Run `raxol update` to install the update"
+  end
+
+  test "update downloads, verifies, and replaces the current binary" do
+    {dir, current_exe} = current_exe_fixture()
+
+    out =
+      capture_io(fn ->
+        assert Update.run([], runtime_opts(current_executable: current_exe)) == 0
+      end)
+
+    assert out =~ "Current version: 0.2.6"
+    assert out =~ "New version available: 0.2.7"
+    assert out =~ "Downloading raxol-darwin-arm64…"
+    assert out =~ "Verified sha256:#{@sha}"
+    assert out =~ "Installing update..."
+    assert out =~ "✔ Updated to 0.2.7"
+    assert out =~ "Restart raxol to use the new version"
+    assert File.read!(current_exe) == @binary
+    File.rm_rf!(dir)
+  end
+
+  test "checksum mismatch leaves the installed binary untouched" do
+    {dir, current_exe} = current_exe_fixture()
+
+    stderr =
+      capture_io(:stderr, fn ->
+        _stdout =
+          capture_io(fn ->
+            assert Update.run(
+                     [],
+                     runtime_opts(
+                       current_executable: current_exe,
+                       checksum: String.duplicate("0", 64)
+                     )
+                   ) == 1
+          end)
+      end)
+
+    assert stderr =~ "checksum mismatch"
+    assert File.read!(current_exe) == "old raxol binary\n"
+    File.rm_rf!(dir)
+  end
+
+  test "specific version resolves the matching release tag" do
+    {dir, current_exe} = current_exe_fixture()
+
+    out =
+      capture_io(fn ->
+        assert Update.run(["--version", "0.2.7"], runtime_opts(current_executable: current_exe)) ==
+                 0
+      end)
+
+    assert out =~ "Updated to 0.2.7"
+    assert File.read!(current_exe) == @binary
+    File.rm_rf!(dir)
+  end
+
+  test "source builds fail clearly when installation needs a binary path" do
+    stderr =
+      capture_io(:stderr, fn ->
+        _stdout = capture_io(fn -> assert Update.run([], runtime_opts()) == 1 end)
+      end)
+
+    assert stderr =~ "not running as a Burrito binary"
+  end
+
+  test "auto prompt installs the update when the user accepts" do
+    {dir, current_exe} = current_exe_fixture()
+
+    out =
+      capture_io([input: "y\n"], fn ->
+        assert Update.auto_prompt(auto_opts(current_executable: current_exe)) == :updated
+      end)
+
+    assert out =~ "Raxol 0.2.7 is available (current 0.2.6)."
+    assert out =~ "Update now? [y/N]"
+    assert out =~ "Updated to 0.2.7"
+    assert File.read!(current_exe) == @binary
+    File.rm_rf!(dir)
+  end
+
+  test "auto prompt skips the update when the user declines" do
+    {dir, current_exe} = current_exe_fixture()
+
+    out =
+      capture_io([input: "n\n"], fn ->
+        assert Update.auto_prompt(auto_opts(current_executable: current_exe)) == :ok
+      end)
+
+    assert out =~ "Raxol 0.2.7 is available"
+    assert out =~ "Skipping update. Run `raxol update` later."
+    assert File.read!(current_exe) == "old raxol binary\n"
+    File.rm_rf!(dir)
+  end
+
+  test "auto prompt honors a fresh check cache" do
+    cache_path = cache_path_fixture()
+
+    File.mkdir_p!(Path.dirname(cache_path))
+    File.write!(cache_path, Jason.encode!(%{"last_checked_at" => 1_000}))
+
+    out =
+      capture_io([input: "y\n"], fn ->
+        assert Update.auto_prompt(
+                 prompt?: true,
+                 now_s: 1_100,
+                 auto_check_path: cache_path,
+                 http_get_json: fn _url -> flunk("fresh cache must not hit the network") end
+               ) == :ok
+      end)
+
+    assert out == ""
+    File.rm_rf!(Path.dirname(cache_path))
+  end
+
+  test "bad options are usage errors" do
+    stderr = capture_io(:stderr, fn -> assert Update.run(["--wat"], runtime_opts()) == 64 end)
+
+    assert stderr =~ "unknown options"
+  end
+
+  defp current_exe_fixture do
+    dir = Path.join(System.tmp_dir!(), "raxol-update-test-#{System.unique_integer([:positive])}")
+    File.mkdir_p!(dir)
+    current_exe = Path.join(dir, @asset)
+    File.write!(current_exe, "old raxol binary\n")
+    File.chmod!(current_exe, 0o755)
+    {dir, current_exe}
+  end
+
+  defp cache_path_fixture do
+    Path.join(
+      System.tmp_dir!(),
+      "raxol-update-cache-#{System.unique_integer([:positive])}/check.json"
+    )
+  end
+
+  defp auto_opts(overrides) do
+    overrides
+    |> runtime_opts()
+    |> Keyword.put(:prompt?, true)
+    |> Keyword.put(:now_s, 1_000)
+    |> Keyword.put(:auto_check_path, cache_path_fixture())
+  end
+
+  defp runtime_opts(overrides \\ []) do
+    checksum = Keyword.get(overrides, :checksum, @sha)
+    current_executable = Keyword.get(overrides, :current_executable)
+    current_version = Keyword.get(overrides, :current_version, "0.2.6+abc")
+
+    [
+      current_version: current_version,
+      target: @target,
+      http_get_json: &get_json/1,
+      http_get_text: fn @sums_url -> {:ok, "#{checksum}  #{@asset}\n"} end,
+      download_file: fn @binary_url, path -> File.write(path, @binary) end
+    ]
+    |> maybe_put(:current_executable, current_executable)
+  end
+
+  defp get_json(@release_url), do: {:ok, [release()]}
+  defp get_json(@tag_url), do: {:ok, release()}
+
+  defp release do
+    %{
+      "tag_name" => "raxol-cli-v0.2.7",
+      "draft" => false,
+      "prerelease" => false,
+      "assets" => [
+        %{"name" => @asset, "browser_download_url" => @binary_url},
+        %{"name" => "SHA256SUMS", "browser_download_url" => @sums_url}
+      ]
+    }
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
+end

--- a/packages/raxol_cli/test/raxol/cli_test.exs
+++ b/packages/raxol_cli/test/raxol/cli_test.exs
@@ -81,15 +81,37 @@ defmodule Raxol.CLITest do
     end
 
     test "providerless default explains mock mode and connection commands" do
-      out =
-        capture_io([input: "/exit\n"], fn ->
-          assert CLI.main([]) == 0
-        end)
+      with_agent_resolver(:error, fn ->
+        out =
+          capture_io([input: "/exit\n"], fn ->
+            assert CLI.main([]) == 0
+          end)
 
-      assert out =~ "No provider connected. Mock mode is active."
-      assert out =~ "raxol login"
-      assert out =~ "raxol setup --provider anthropic --op op://Vault/Item/api_key"
-      assert out =~ "type a prompt, or /exit"
+        assert out =~ "No provider connected. Mock mode is active."
+        assert out =~ "raxol login openrouter"
+
+        assert out =~
+                 "raxol setup --provider anthropic --op op://Vault/Item/api_key"
+
+        assert out =~ "type a prompt, or /exit"
+      end)
+    end
+
+    test "configured providers skip mock mode" do
+      executor =
+        Raxol.Agent.ExecutorConfig.new(
+          harness: :openai,
+          auth: %{api_key: "sk-test"}
+        )
+
+      with_agent_resolver({:ok, executor}, fn ->
+        out =
+          capture_io([input: "/exit\n"], fn ->
+            assert CLI.main([]) == 0
+          end)
+
+        refute out =~ "Mock mode is active"
+      end)
     end
   end
 
@@ -195,6 +217,21 @@ defmodule Raxol.CLITest do
 
       assert stderr =~ "authorized-keys"
       refute stderr =~ "interactive terminal"
+    end
+  end
+
+  defp with_agent_resolver(result, fun) do
+    previous = Application.get_env(:raxol_cli, :agent_executor_resolver)
+    Application.put_env(:raxol_cli, :agent_executor_resolver, fn -> result end)
+
+    try do
+      fun.()
+    after
+      if previous do
+        Application.put_env(:raxol_cli, :agent_executor_resolver, previous)
+      else
+        Application.delete_env(:raxol_cli, :agent_executor_resolver)
+      end
     end
   end
 end

--- a/packages/raxol_cli/test/raxol/cli_test.exs
+++ b/packages/raxol_cli/test/raxol/cli_test.exs
@@ -38,6 +38,13 @@ defmodule Raxol.CLITest do
       assert out =~ ~r/raxol \d+\.\d+\.\d+/
       assert CLI.version() =~ ~r/^\d+\.\d+\.\d+|^dev/
     end
+
+    test "help labels new apps as Elixir/Mix projects" do
+      out = capture_io(fn -> assert CLI.main(["help"]) == 0 end)
+
+      assert out =~ "new [name]"
+      assert out =~ "Elixir/Mix"
+    end
   end
 
   describe "setup subcommand" do
@@ -48,12 +55,41 @@ defmodule Raxol.CLITest do
       assert out =~ "--provider"
     end
 
+    test "setup status prints next actions" do
+      out = capture_io(fn -> assert CLI.main(["setup"]) == 0 end)
+
+      assert out =~ "providers:"
+      assert out =~ "next:"
+      assert out =~ "raxol doctor"
+    end
+
+    test "doctor prints an onboarding next block" do
+      out = capture_io(fn -> assert CLI.main(["doctor"]) == 0 end)
+
+      assert out =~ "packaging"
+      assert out =~ "next:"
+      assert out =~ "raxol setup"
+      assert out =~ "raxol new counter"
+    end
+
     # 64 is the usage-error code the Mix task already used; the shared front
     # end has to keep returning it now that two shims depend on the value.
     test "an unknown setup option is a usage error, not a crash" do
       capture_io(:stderr, fn ->
         assert CLI.main(["setup", "--definitely-not-a-flag"]) == 64
       end)
+    end
+
+    test "providerless default explains mock mode and connection commands" do
+      out =
+        capture_io([input: "/exit\n"], fn ->
+          assert CLI.main([]) == 0
+        end)
+
+      assert out =~ "No provider connected. Mock mode is active."
+      assert out =~ "raxol login"
+      assert out =~ "raxol setup --provider anthropic --op op://Vault/Item/api_key"
+      assert out =~ "type a prompt, or /exit"
     end
   end
 

--- a/packages/raxol_cli/test/raxol/cli_test.exs
+++ b/packages/raxol_cli/test/raxol/cli_test.exs
@@ -25,7 +25,7 @@ defmodule Raxol.CLITest do
     # `login` shipped in the help text but not in `commands/0`, so anything
     # driving the declared list (completions, docs) could not see it.
     test "every command in the help text is also a declared command" do
-      for command <- ~w(agent code p acp login setup doctor playground new help) do
+      for command <- ~w(agent code p acp login setup doctor update playground new help) do
         assert command in CLI.commands(), "#{command} missing from commands/0"
       end
     end

--- a/packages/raxol_symphony/test/raxol/symphony/path_safety_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/path_safety_test.exs
@@ -1,5 +1,5 @@
 defmodule Raxol.Symphony.PathSafetyTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Raxol.Symphony.PathSafety
 


### PR DESCRIPTION
A fresh install landed on a dead end. `raxol setup` and `raxol doctor` reported state and stopped, and with no provider connected the agent said only that it was running with mock responses, without saying what would connect one. Every one of those is the moment a new user most needs the next command.

## What changed

Each surface now ends in a `next:` block of runnable commands:

- **`raxol setup`** branches on whether a provider actually resolved. Connected, it points at `raxol` / `raxol code` / `raxol doctor`; not connected, it leads with `raxol login` and the headless `raxol setup --provider ... --op ...` form, and still offers `raxol` so the mock path is a deliberate choice rather than a surprise.
- **`raxol doctor`** ends in the same shape, so the diagnostic surface hands off instead of terminating.
- **The providerless agent** names both connection routes in place of the single sentence about mock responses, and says how to leave (`type a prompt, or /exit`).
- **`raxol new`** says it needs local Elixir/Mix up front, in the usage line, the generated `Next:` block, and the scaffolded README, rather than letting the user discover it at `mix deps.get`. The packaged binary carries its own ERTS, so a user has no reason to assume a Mix toolchain is present. `raxol help` labels it the same way.

## Manual testing

- [x] `cd packages/raxol_cli && MIX_ENV=test mix test` - 32 passed
- [x] `cd packages/raxol_agent && MIX_ENV=test mix test test/raxol/agent/setup_test.exs` - 9 passed
- [x] `mix format --check-formatted`

Five tests were added covering the new output: help labelling, the `setup` and `doctor` next blocks, the generated README and `Next:` line, and the providerless mock-mode message.
