### PR TITLE
Pin the integrations marquee and link payments from the header

### DIFF
--- a/web/lib/raxol_playground_web/components/landing_components.ex
+++ b/web/lib/raxol_playground_web/components/landing_components.ex
@@ -427,7 +427,14 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     <%!-- Two identical runs, so translating the track by half its width loops
          seamlessly. The copy is aria-hidden -- it exists for the animation,
          and a screen reader reading the list twice would be a defect. --%>
-    <div class="screen-integrations">
+    <%!-- Keyed and pinned because the row is a SIBLING of the hero, and the
+         hero re-renders on every "next example". Without an id, morphdom has
+         nothing to match this div by and re-inserts it while realigning
+         `main`'s children; re-insertion restarts the CSS animation, so the
+         track jumped back to its first frame on every click. Nothing here
+         depends on an assign -- the groups come from the capability registries
+         and are identical on every render -- so there is no update to lose. --%>
+    <div id="screen-integrations" phx-update="ignore" class="screen-integrations">
       <div class="integrations-track">
         <div
           :for={dup? <- [false, true]}

--- a/web/lib/raxol_playground_web/components/landing_components.ex
+++ b/web/lib/raxol_playground_web/components/landing_components.ex
@@ -530,10 +530,18 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     """
   end
 
-  # One list for both site headers: run it, or read the API. Product pages live
-  # in the hero/demo path and in the docs, not as a second table of contents.
+  # One list for both site headers: run it, read the rail, or read the API.
+  #
+  # The other topic pages sit on the hero and demo path, so listing them here
+  # would restate that path rather than add to it. /payments is the exception.
+  # Its only inbound link was the line at the foot of /token, and /token is
+  # itself only reachable from the landing footer's $RAXOL mark, which left the
+  # payment rails two hops deep behind the token page -- the one adjacency the
+  # copy on both pages exists to deny. The header slot is the fix; /token keeps
+  # pointing here, now as a cross-reference rather than the only way in.
   @nav_links [
     {"/gallery", "Components"},
+    {"/payments", "Payments"},
     {"https://hexdocs.pm/raxol", "Docs"}
   ]
 

--- a/web/test/raxol_playground_web/landing_components_test.exs
+++ b/web/test/raxol_playground_web/landing_components_test.exs
@@ -707,6 +707,19 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     end
   end
 
+  # Being a sibling of the hero is what made the marquee fragile: the hero
+  # re-renders on every "next example", and an id-less div gives morphdom
+  # nothing to match on, so it re-inserted this one while realigning main's
+  # children and the CSS animation restarted from its first frame. The id and
+  # phx-update="ignore" are the fix, and neither is visible in the rendered
+  # output's appearance, so nothing else would catch their removal.
+  test "the integrations row is pinned so a hero re-render cannot restart it" do
+    row = render_component(&LandingComponents.screen_integrations/1, %{})
+
+    assert row =~ ~s(id="screen-integrations")
+    assert row =~ ~s(phx-update="ignore")
+  end
+
   # A mark decorates a derived entry, it never replaces one. The row still
   # lists what the registry lists, and an entry whose brand has no mark shows
   # its name. Both directions are held: a mark left behind for something no

--- a/web/test/raxol_playground_web/landing_components_test.exs
+++ b/web/test/raxol_playground_web/landing_components_test.exs
@@ -904,9 +904,15 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     assert open =~ ~s(href="/gallery")
   end
 
-  test "the header offers only components and docs" do
+  # Pinned as an exact list on purpose. The header is a short, argued-for set,
+  # and the point of holding it here is that a fourth entry has to be justified
+  # rather than appended. Payments earned its slot because /payments was
+  # otherwise reachable only from the foot of /token, which is itself only
+  # reachable from the landing footer's $RAXOL mark.
+  test "the header offers components, payments, and docs" do
     assert LandingComponents.nav_links() == [
              {"/gallery", "Components"},
+             {"/payments", "Payments"},
              {"https://hexdocs.pm/raxol", "Docs"}
            ]
   end


### PR DESCRIPTION
## Summary

Two independent landing-page fixes, one commit each.

### Pin the integrations row against hero re-renders

The integrations marquee is a **sibling** of the hero, and the hero re-renders on every "next example". With no `id`, morphdom had nothing to match the div by, so it re-inserted the row while realigning `main`'s children. Re-insertion restarts the CSS animation, so the track jumped back to its first frame on every click.

An `id` plus `phx-update="ignore"` fixes it. Nothing in the row depends on an assign: the groups come from the capability registries and render identically every time, so ignoring updates loses nothing.

Neither attribute affects how the row looks, so nothing else would have caught their removal. A regression test holds both.

### Link payments from the site header

`/payments` had exactly one inbound link: a line at the foot of `/token`. `/token` is itself only reachable from the landing footer's `$RAXOL` mark, which left the payment rails two hops deep behind the token page -- the exact adjacency the copy on both pages exists to deny.

The header slot is the fix. `/token` keeps pointing here, now as a cross-reference rather than the only way in. The other topic pages stay out: they sit on the hero and demo path, so listing them would restate that path rather than add to it.

The existing header test already pinned the list exactly; it is updated rather than loosened, so a fourth entry still has to be argued for.

## Manual testing

- [x] `cd web && MIX_ENV=test mix test` -- 76 passed (74 before, plus the two this adds)
- [x] `MIX_ENV=test mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] each commit is green on its own, so a bisect through this pair stays clean
- [x] confirmed `/payments` resolves: `live("/payments", TopicLive, :payments)` in the router
