### PR TITLE
Fix the marquee where it actually breaks

### DIFF
--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -1852,6 +1852,15 @@ html {
    Hero surface-tabbed demo (one module, four surfaces)
    ============================================================================= */
 
+/* No box of its own. The shell exists only to give `main`'s middle child a
+   stable id, so the demo's per-example id cannot displace the integrations row
+   that follows it and restart its marquee. `display: contents` keeps
+   `.hero-demo` a direct flex child of `.screen-main`, so the demo's own layout
+   is unchanged. */
+.hero-demo-shell {
+  display: contents;
+}
+
 .hero-demo {
   background: rgba(10, 10, 12, 0.75);
   border: 1px solid var(--panel-border);

--- a/web/lib/raxol_playground_web/components/landing_components.ex
+++ b/web/lib/raxol_playground_web/components/landing_components.ex
@@ -427,14 +427,21 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
     <%!-- Two identical runs, so translating the track by half its width loops
          seamlessly. The copy is aria-hidden -- it exists for the animation,
          and a screen reader reading the list twice would be a defect. --%>
-    <%!-- Keyed and pinned because the row is a SIBLING of the hero, and the
-         hero re-renders on every "next example". Without an id, morphdom has
-         nothing to match this div by and re-inserts it while realigning
-         `main`'s children; re-insertion restarts the CSS animation, so the
-         track jumped back to its first frame on every click. Nothing here
-         depends on an assign -- the groups come from the capability registries
-         and are identical on every render -- so there is no update to lose. --%>
-    <div id="screen-integrations" phx-update="ignore" class="screen-integrations">
+    <%!-- Deliberately unkeyed. The track used to jump back to its first frame
+         on every "next example", and the row looks like the thing to pin: it is
+         the sibling that follows the hero, so morphdom detaches and reattaches
+         it whenever the hero is rekeyed, and reattaching an element restarts its
+         CSS animation. But nothing done here can prevent that -- it is not this
+         element being rekeyed, and `phx-update="ignore"` governs a subtree's
+         contents, not whether the subtree is moved. Measured: with an id and
+         `phx-update="ignore"` on this div the row was still detached on every
+         click and the animation still reset.
+
+         The fix belongs where the rekeying happens, so it lives on the hero's
+         stable `.hero-demo-shell`. Left plain here on purpose: an id and an
+         ignore that did nothing would read as the thing holding the row still,
+         and the next person to touch the hero would trust it. --%>
+    <div class="screen-integrations">
       <div class="integrations-track">
         <div
           :for={dup? <- [false, true]}
@@ -646,15 +653,27 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
       )
 
     ~H"""
-    <%!-- The id carries the example so switching remounts the hook: the frame
-         player caches its frame nodes, and patching them underneath it would
-         leave it stepping elements that no longer exist. --%>
-    <div
-      id={"hero-demo-#{@example}"}
-      phx-hook="HeroDemo"
-      class="hero-demo mx-auto text-left"
-      data-frame-ms={@frame_ms}
-    >
+    <%!-- A stable id for the child `main` actually holds, because the demo's own
+         id deliberately changes per example (below) and morphdom keys `main`'s
+         children by id. A rekeyed hero is an insert, and inserting it displaces
+         the sibling that follows -- the integrations row -- which detaches and
+         reattaches it. Reattaching an element restarts its CSS animation, so the
+         marquee jumped back to its first frame on every "next example".
+
+         The shell contains the churn: `main`'s three children now keep the same
+         identity across a switch, and only the hero's own subtree is rekeyed.
+         `.hero-demo-shell` is `display: contents`, so it generates no box and
+         `.hero-demo` remains a direct flex child of `.screen-main`. --%>
+    <div id="hero-demo-shell" class="hero-demo-shell">
+      <%!-- The id carries the example so switching remounts the hook: the frame
+           player caches its frame nodes, and patching them underneath it would
+           leave it stepping elements that no longer exist. --%>
+      <div
+        id={"hero-demo-#{@example}"}
+        phx-hook="HeroDemo"
+        class="hero-demo mx-auto text-left"
+        data-frame-ms={@frame_ms}
+      >
       <%!-- The player's controls live in the title bar, where a window's
            controls belong and where nothing can clip them. They used to sit in
            a footer below the panes: the demo box is height-capped, so on any
@@ -852,6 +871,7 @@ defmodule RaxolPlaygroundWeb.LandingComponents do
         </div>
       </div>
 
+      </div>
     </div>
     """
   end

--- a/web/test/raxol_playground_web/landing_components_test.exs
+++ b/web/test/raxol_playground_web/landing_components_test.exs
@@ -707,17 +707,57 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
     end
   end
 
-  # Being a sibling of the hero is what made the marquee fragile: the hero
-  # re-renders on every "next example", and an id-less div gives morphdom
-  # nothing to match on, so it re-inserted this one while realigning main's
-  # children and the CSS animation restarted from its first frame. The id and
-  # phx-update="ignore" are the fix, and neither is visible in the rendered
-  # output's appearance, so nothing else would catch their removal.
-  test "the integrations row is pinned so a hero re-render cannot restart it" do
+  describe "the hero's outer id is stable across examples" do
+    # What kept the marquee still. morphdom keys main's children by id, so a
+    # hero whose own id changes per example is an insert, and inserting it
+    # displaces the sibling after it: the integrations row is detached and
+    # reattached, and reattaching an element restarts its CSS animation. The
+    # shell holds the outer id constant so main's children keep their identity.
+    #
+    # Measured in a browser against a live LiveView, since none of it is visible
+    # in rendered markup: before, a MutationObserver on main recorded the row
+    # removed and re-added on every click and the track's animation currentTime
+    # fell from 24637ms to 1180ms. After, no mutations and a monotonic timeline.
+    test "every example renders the same outer element id" do
+      ids =
+        Enum.map(LandingComponents.hero_example_names(), fn name ->
+          hero =
+            render_component(&LandingComponents.screen_hero/1, example: name)
+
+          outer_hero_shell_id(hero)
+        end)
+
+      assert length(ids) > 1, "needs at least two examples to be meaningful"
+      assert Enum.uniq(ids) == ["hero-demo-shell"]
+    end
+
+    # The other half, and the reason the shell exists rather than the outer id
+    # simply being made stable. The hook element's id has to keep carrying the
+    # example: the frame player caches its frame nodes, and it is the id change
+    # that remounts it. Holding both means neither can be "fixed" into the other.
+    test "the hook element's id still changes per example" do
+      ids =
+        Enum.map(LandingComponents.hero_example_names(), fn name ->
+          hero =
+            render_component(&LandingComponents.screen_hero/1, example: name)
+
+          hook_element_id(hero)
+        end)
+
+      assert Enum.uniq(ids) == ids
+      assert Enum.all?(ids, &String.starts_with?(&1, "hero-demo-"))
+      refute "hero-demo-shell" in ids
+    end
+  end
+
+  # The row is deliberately not pinned: an id and phx-update="ignore" on it were
+  # measured to change nothing, because it is not the element being rekeyed.
+  # Pinned here so the ineffective fix does not come back looking like one.
+  test "the integrations row carries no id or ignore of its own" do
     row = render_component(&LandingComponents.screen_integrations/1, %{})
 
-    assert row =~ ~s(id="screen-integrations")
-    assert row =~ ~s(phx-update="ignore")
+    refute row =~ ~s(id="screen-integrations")
+    refute row =~ ~s(phx-update="ignore")
   end
 
   # A mark decorates a derived entry, it never replaces one. The row still
@@ -1237,6 +1277,26 @@ defmodule RaxolPlaygroundWeb.LandingComponentsTest do
       after
         System.delete_env("RAXOL_SSH_PLAYGROUND")
       end
+    end
+  end
+
+  # --- helpers ---------------------------------------------------------------
+
+  # Matched on the tag rather than on an exact attribute order, so reordering
+  # the shell's attributes is not a test failure. There is no HTML parser in
+  # this app's test deps and one dependency is not worth two selectors.
+  defp outer_hero_shell_id(html) do
+    capture(html, ~r/<div[^>]*\bid="([^"]*)"[^>]*class="[^"]*hero-demo-shell/)
+  end
+
+  defp hook_element_id(html) do
+    capture(html, ~r/<div[^>]*\bid="([^"]*)"[^>]*phx-hook="HeroDemo"/)
+  end
+
+  defp capture(html, regex) do
+    case Regex.run(regex, html) do
+      [_, value] -> value
+      _no_match -> nil
     end
   end
 end


### PR DESCRIPTION
Follow-up to #963, which merged while this was being measured. The marquee fix
in that PR does not work, and this replaces it with one that does.

## The previous fix does not work

Measured in a browser against a live LiveView on the merged code. With
`id="screen-integrations"` and `phx-update="ignore"` on the row, a
MutationObserver on `main.screen-main` still recorded the row removed and
re-added on every "next example", and the track's animation `currentTime` still
reset:

```
mutations:  ROW REMOVED, ROW ADDED  (x3, one per click)
animation:  13842 -> 1354 -> 1417 -> 1444 ms
```

`phx-update="ignore"` governs a subtree's contents. It does not govern whether
the subtree is moved.

## What actually happens

#963's mechanism was right; its element was wrong. `main.screen-main` has three
children, and morphdom keys them by id:

```
div.screen-intro          (no id)
div.hero-demo             id="hero-demo-harness"  ->  id="hero-demo-settle"
div.screen-integrations
```

The hero's id deliberately carries the example, because that is what remounts
the frame-player hook. A rekeyed hero is an insert, and inserting it displaces
the sibling after it: the row is detached and reattached, and reattaching an
element restarts its CSS animation. Nothing done to the row can stop it being
moved.

## The fix

A stable `#hero-demo-shell` around the demo, `display: contents` so it generates
no box and `.hero-demo` stays a direct flex child of `.screen-main`. The
per-example id moves inside it, so the hook still remounts on a switch while
`main`'s three children keep their identity.

The row's `id` and `phx-update` are removed rather than left in as harmless. An
ineffective fix that reads like the load-bearing one is worse than no fix, and
the next person to touch the hero would trust it.

## Measured after

Same instrumentation, same three clicks:

```
mutations:  (none, row never detached)
animation:  13992 -> 15499 -> 16999 -> 18499 ms   (monotonic)
hero box:   992x567, unchanged
examples:   halo -> settle -> pulse -> harness, hook id changing each time
```

## Tests

The old test asserted the two attributes were present in the rendered string,
which is a change detector for an implementation that did not work. Replaced
with three that pin the real invariant, both halves of it:

- every example renders the same outer element id (`hero-demo-shell`)
- the hook element's id still changes per example, so neither can be "fixed"
  into the other
- the row carries no id or ignore of its own, so the ineffective fix cannot come
  back looking like one

## Manual testing

- [x] `cd web && MIX_ENV=test mix test` -- 78 passed (76 on master, plus net two)
- [x] `MIX_ENV=test mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] browser: reproduced the bug on master, confirmed the previous fix leaves it
      unchanged, confirmed this one fixes it, all three by MutationObserver and
      `getAnimations()[0].currentTime` rather than by eye
- [x] screenshot after the change: hero and row render unchanged, marquee scrolls
