### PR TITLE
Confine Symphony agent runs to their per-issue workspace

### DIFF
--- a/packages/raxol_symphony/lib/raxol/symphony/runner.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runner.ex
@@ -27,6 +27,16 @@ defmodule Raxol.Symphony.Runner do
   - `Raxol.Symphony.Runners.Codex` -- Port-based Codex app-server (JSON-RPC
     2.0 over stdio, mirrors upstream Symphony Elixir).
 
+  ## Workspace
+
+  `opts[:workspace_path]` is the per-issue directory the orchestrator allocated
+  under `config.workspace.root`, and it is REQUIRED rather than advisory: a
+  runner that ignores it runs against whatever cwd the orchestrator process
+  happens to have. `Raxol.Symphony.Runners.RaxolAgent` threads it into the
+  agent's tool context as `:cwd`; `Raxol.Symphony.Runners.Codex` passes it as
+  the Codex session root. Both raise when it is absent, so a run is never
+  silently unconfined.
+
   ## Sending updates back
 
   The runner SHOULD forward agent events to the orchestrator via the `:parent`

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
@@ -27,8 +27,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
           base_url: https://api.anthropic.com
           max_tokens: 4096
           system_prompt: "You are a software engineer..."
-          # actions: list of fully-qualified action modules (currently ignored;
-          # tool use lands later together with hook integration)
+          actions: Raxol.Agent.Actions.Code.all()
+          tool_policy: :allow_all
+          shell_sandbox: Raxol.Agent.Sandbox.Shell.allowlist(["git", "mix"])
           pause_detector: {MyApp.PauseDetector, :detect}
           tracker_cache: {Raxol.Agent.Cache.Ets, %{table: :tracker_cache}}
           tracker_cache_ttl_ms: 30_000
@@ -151,6 +152,47 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
   a no-op (and never raises) when unconfigured. Currently wired in the
   workflow-mode path; the simple path is a follow-up.
 
+  ## Tools
+
+  `agent.actions` is a list of `Raxol.Agent.Action` modules exposed to the
+  model as tools. Default `[]` -- no tools, which is the pre-existing
+  behaviour. Entries are module atoms, like `agent.module`, `agent.policies`
+  and `agent.sandboxes`; an entry that is not a loadable Action module fails
+  the run with `{:error, {:invalid_actions, offenders}}` rather than being
+  dropped, since an agent that quietly has no tools is indistinguishable from
+  a model that chose not to call any.
+
+  ### Declaring actions is not the same as enabling writes
+
+  With `actions` set and nothing else, a run gets READ-ONLY tools. The
+  framework's default tool policy
+  (`Raxol.Agent.ToolPolicy.deny_sensitive/0`, applied by
+  `Raxol.Agent.Action.ToolConverter` whenever the context sets no
+  `:tool_authorizer`) denies the Actions marked `sensitive: true` --
+  `write_file`, `edit_file` and `bash` -- and allows `grep`, `glob` and the
+  other read-only ones. A prompt-injected model therefore cannot write to
+  disk or spawn a shell just by emitting a tool call.
+
+  A Symphony run is unattended: there is no operator to approve a call the way
+  `Raxol.Agent.Code.App` prompts one interactively. Enabling writes is
+  therefore a deliberate configuration act, `agent.tool_policy`:
+
+    * unset (default) -- read-only, per above
+    * `:allow_all` -- every declared Action may run. This is what an
+      autonomous coding run needs, and it means the model can write anywhere
+      inside the workspace and run any shell command the sandbox permits
+    * `:deny_all` / `:deny_sensitive` -- explicit forms of the restrictive ends
+    * `{:allowlist, names}` / `{:denylist, names}` -- by tool name
+    * a `(module, params, context) -> :ok | {:deny, reason}` function
+
+  An unrecognized value denies everything rather than falling back to the
+  framework default, so a typo cannot silently widen a run.
+
+  `agent.shell_sandbox` takes a `Raxol.Agent.Sandbox.Shell` that `bash` checks
+  a command against before spawning. Worth setting whenever `tool_policy`
+  admits `bash`: the workspace cwd confines the *fs* tools, but a shell command
+  is not a path -- it can `cd` elsewhere or name an absolute one.
+
   ## Workspace confinement
 
   The orchestrator gives every issue its own workspace under
@@ -201,35 +243,60 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
       not raxol_agent_loaded?() ->
         {:error, :raxol_agent_not_loaded}
 
-      workflow_mode?(config) ->
-        run_via_workflow(issue, config, opts)
-
       true ->
-        do_run(issue, config, opts)
+        # Bad `agent.actions` fails the run rather than silently dropping the
+        # tool: an agent that quietly has no tools looks like a model that
+        # chose not to use them.
+        case validate_actions(config) do
+          {:ok, _actions} -> dispatch(issue, config, opts)
+          {:error, _} = err -> err
+        end
     end
   end
 
-  @doc """
-  Build the agent tool context for a run from the runner `opts`.
+  defp dispatch(%Issue{} = issue, %Config{} = config, opts) do
+    if workflow_mode?(config),
+      do: run_via_workflow(issue, config, opts),
+      else: do_run(issue, config, opts)
+  end
 
-  The context carries `:cwd`, the per-issue workspace the orchestrator
-  allocated. `Raxol.Agent.Actions.Fs.resolve/2` expands every tool path
-  against it and rejects anything that resolves outside it.
+  @doc """
+  Build the agent tool context for a run.
+
+  The context carries:
+
+    * `:cwd` -- the per-issue workspace the orchestrator allocated.
+      `Raxol.Agent.Actions.Fs.resolve/2` expands every tool path against it and
+      rejects anything that resolves outside it.
+    * `:tool_authorizer` -- only when `agent.tool_policy` is set. LEAVING IT
+      UNSET IS THE SAFE DEFAULT: `Raxol.Agent.Action.ToolConverter` then falls
+      back to `Raxol.Agent.ToolPolicy.deny_sensitive/0`, which denies the
+      `sensitive: true` Actions (`write_file`, `edit_file`, `bash`) while
+      letting read-only ones through. Injecting nothing is what keeps an
+      unattended run read-only until an operator opts in.
+    * `:shell_sandbox` -- only when `agent.shell_sandbox` is set. `bash` checks
+      the command against it before any process spawns.
 
   Raises when `opts` carries no `:workspace_path`: there is no safe default
   here, and falling back to the BEAM's cwd would silently un-confine the run.
   """
-  @spec agent_context(keyword()) :: map()
-  def agent_context(opts) do
+  @spec agent_context(keyword(), Config.t()) :: map()
+  def agent_context(opts, %Config{} = config) do
     %{cwd: Keyword.fetch!(opts, :workspace_path)}
+    |> put_unless_nil(:tool_authorizer, agent_tool_authorizer(config))
+    |> put_unless_nil(:shell_sandbox, agent_shell_sandbox(config))
   end
+
+  defp put_unless_nil(map, _key, nil), do: map
+  defp put_unless_nil(map, key, value), do: Map.put(map, key, value)
 
   # The options both run paths hand to `Raxol.Agent.Stream.run/2`.
   #
   # Shared so the two paths cannot drift, and named so a test can pin the
-  # `:context` key: `Stream.run/2` reads it with `Keyword.get(opts, :context,
-  # %{})`, so a misspelled key would not raise -- it would silently fall back
-  # to an empty context and un-confine the run.
+  # `:context` and `:actions` keys: `Stream.run/2` reads both with
+  # `Keyword.get/3` defaults, so a misspelled key would not raise -- it would
+  # silently fall back to an empty context (un-confining the run) or to no
+  # tools at all.
   @doc false
   @spec __stream_opts__(map()) :: keyword()
   def __stream_opts__(state) do
@@ -237,7 +304,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
       backend: Map.fetch!(state, :backend),
       backend_opts: Map.fetch!(state, :backend_opts),
       system_prompt: Map.fetch!(state, :system_prompt),
-      context: Map.fetch!(state, :context)
+      context: Map.fetch!(state, :context),
+      actions: Map.fetch!(state, :actions)
     ]
   end
 
@@ -304,7 +372,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
       backend_opts: backend_opts,
       system_prompt: agent_string(config, :system_prompt),
       pause_detector: agent_pause_detector(config),
-      context: agent_context(opts),
+      context: agent_context(opts, config),
+      actions: raw_actions(config),
       turn: 1,
       max_turns: config.agent.max_turns,
       last_events: [],
@@ -541,7 +610,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
           backend_opts: backend_opts,
           system_prompt: agent_string(config, :system_prompt),
           pause_detector: agent_pause_detector(config),
-          context: agent_context(opts),
+          context: agent_context(opts, config),
+          actions: raw_actions(config),
           turn: 1,
           max_turns: config.agent.max_turns
         }
@@ -883,6 +953,70 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
 
   defp build_thread_id(%Issue{id: id}, attempt) when not is_nil(id) do
     "symphony-agent-" <> to_string(id) <> "-" <> to_string(attempt || 0)
+  end
+
+  # -- Tools ------------------------------------------------------------------
+
+  @doc """
+  The Action modules this run exposes to the model, from `agent.actions`.
+
+  Returns `{:error, {:invalid_actions, offenders}}` when an entry is not a
+  loadable module implementing `Raxol.Agent.Action`. Entries are module atoms,
+  not strings -- the same shape `agent.module`, `agent.policies` and
+  `agent.sandboxes` already take, since `runner.agent` is an Elixir term map.
+  """
+  @spec validate_actions(Config.t()) :: {:ok, [module()]} | {:error, term()}
+  def validate_actions(%Config{} = config) do
+    actions = raw_actions(config)
+
+    case Enum.reject(actions, &action_module?/1) do
+      [] -> {:ok, actions}
+      offenders -> {:error, {:invalid_actions, offenders}}
+    end
+  end
+
+  defp raw_actions(%Config{runner: runner}) do
+    case get_in(runner, [:agent, :actions]) do
+      list when is_list(list) -> list
+      _ -> []
+    end
+  end
+
+  # An Action is a module exporting the behaviour's `run/2` plus the
+  # `__action_meta__/0` that `use Raxol.Agent.Action` injects (the marker the
+  # tool converter reads name and sensitivity from). Checked rather than
+  # assumed: a typo'd module name is an atom like any other, and would
+  # otherwise surface as a crash mid-run.
+  defp action_module?(mod) when is_atom(mod) do
+    Code.ensure_loaded?(mod) and function_exported?(mod, :run, 2) and
+      function_exported?(mod, :__action_meta__, 0)
+  end
+
+  defp action_module?(_), do: false
+
+  # `agent.tool_policy` -> a `:tool_authorizer`, or nil to leave the framework
+  # default (`ToolPolicy.deny_sensitive/0`) in force. See `agent_context/2`.
+  defp agent_tool_authorizer(%Config{runner: runner}) do
+    case get_in(runner, [:agent, :tool_policy]) do
+      nil -> nil
+      fun when is_function(fun, 3) -> fun
+      :deny_sensitive -> Raxol.Agent.ToolPolicy.deny_sensitive()
+      :allow_all -> Raxol.Agent.ToolPolicy.allow_all()
+      :deny_all -> Raxol.Agent.ToolPolicy.deny_all()
+      {:allowlist, names} when is_list(names) -> Raxol.Agent.ToolPolicy.allowlist(names)
+      {:denylist, names} when is_list(names) -> Raxol.Agent.ToolPolicy.denylist(names)
+      # An unrecognized policy must not read as "no policy" -- that would
+      # silently widen the run to the framework default. Deny everything and
+      # let the operator see empty tool results rather than unintended writes.
+      _ -> Raxol.Agent.ToolPolicy.deny_all(:invalid_tool_policy)
+    end
+  end
+
+  defp agent_shell_sandbox(%Config{runner: runner}) do
+    case get_in(runner, [:agent, :shell_sandbox]) do
+      %Raxol.Agent.Sandbox.Shell{} = sandbox -> sandbox
+      _ -> nil
+    end
   end
 
   defp agent_policies(%Config{runner: runner}) do

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
@@ -151,6 +151,31 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
   a no-op (and never raises) when unconfigured. Currently wired in the
   workflow-mode path; the simple path is a follow-up.
 
+  ## Workspace confinement
+
+  The orchestrator gives every issue its own workspace under
+  `config.workspace.root` and passes it as `opts[:workspace_path]`. This runner
+  threads that path into the agent's tool context as `:cwd`, which is what
+  `Raxol.Agent.Actions.Fs.resolve/2` resolves paths against and confines them
+  to. Without it the fs tools resolve against the BEAM's cwd -- the repo the
+  orchestrator was started in -- so the per-issue workspace would be a
+  directory that gets created and then not enforced.
+
+  `:workspace_path` is therefore REQUIRED, the same way
+  `Raxol.Symphony.Runners.Codex` requires it. A missing one raises rather than
+  running unconfined, so the two runners cannot disagree about whether a
+  Symphony run is contained.
+
+  Confinement is pre-wired rather than load-bearing today: this runner passes
+  no `:actions`, so a run currently has no fs tools to confine. Threading the
+  cwd now means tool use lands into an already-enforced workspace instead of
+  needing to remember the boundary later.
+
+  Runs do NOT carry `jail: true`. The jail marker disables the shell tool
+  outright (`Raxol.Agent.Actions.Code.shell_jail_allow/1`), which an autonomous
+  coding run needs; revisit once ADR-0032's `Spawn` backends give a jailed
+  session a working shell.
+
   ## Compile-time optionality
 
   `raxol_agent` is an optional dep. If the consumer app does not include it,
@@ -182,6 +207,38 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
       true ->
         do_run(issue, config, opts)
     end
+  end
+
+  @doc """
+  Build the agent tool context for a run from the runner `opts`.
+
+  The context carries `:cwd`, the per-issue workspace the orchestrator
+  allocated. `Raxol.Agent.Actions.Fs.resolve/2` expands every tool path
+  against it and rejects anything that resolves outside it.
+
+  Raises when `opts` carries no `:workspace_path`: there is no safe default
+  here, and falling back to the BEAM's cwd would silently un-confine the run.
+  """
+  @spec agent_context(keyword()) :: map()
+  def agent_context(opts) do
+    %{cwd: Keyword.fetch!(opts, :workspace_path)}
+  end
+
+  # The options both run paths hand to `Raxol.Agent.Stream.run/2`.
+  #
+  # Shared so the two paths cannot drift, and named so a test can pin the
+  # `:context` key: `Stream.run/2` reads it with `Keyword.get(opts, :context,
+  # %{})`, so a misspelled key would not raise -- it would silently fall back
+  # to an empty context and un-confine the run.
+  @doc false
+  @spec __stream_opts__(map()) :: keyword()
+  def __stream_opts__(state) do
+    [
+      backend: Map.fetch!(state, :backend),
+      backend_opts: Map.fetch!(state, :backend_opts),
+      system_prompt: Map.fetch!(state, :system_prompt),
+      context: Map.fetch!(state, :context)
+    ]
   end
 
   # --- Workflow-envelope path ---
@@ -247,6 +304,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
       backend_opts: backend_opts,
       system_prompt: agent_string(config, :system_prompt),
       pause_detector: agent_pause_detector(config),
+      context: agent_context(opts),
       turn: 1,
       max_turns: config.agent.max_turns,
       last_events: [],
@@ -396,12 +454,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
 
   defp run_authorized_turn(state, prompt, policies, turn_payload) do
     op = fn _params ->
-      stream =
-        stream_module().run(prompt,
-          backend: state.backend,
-          backend_opts: state.backend_opts,
-          system_prompt: state.system_prompt
-        )
+      stream = stream_module().run(prompt, __stream_opts__(state))
 
       {:ok,
        collect_with_detector(
@@ -488,6 +541,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
           backend_opts: backend_opts,
           system_prompt: agent_string(config, :system_prompt),
           pause_detector: agent_pause_detector(config),
+          context: agent_context(opts),
           turn: 1,
           max_turns: config.agent.max_turns
         }
@@ -534,12 +588,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
   end
 
   defp run_one_turn(%Issue{} = issue, %Config{} = config, prompt, ctx) do
-    stream =
-      stream_module().run(prompt,
-        backend: ctx.backend,
-        backend_opts: ctx.backend_opts,
-        system_prompt: ctx.system_prompt
-      )
+    stream = stream_module().run(prompt, __stream_opts__(ctx))
 
     if SelfImprove.configured?(config) do
       {result, events} =

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent_session.ex
@@ -27,7 +27,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
       {:symphony_start, %{
         issue: %Raxol.Symphony.Issue{},
         prompt: rendered_template_string,
-        attempt: integer_or_nil
+        attempt: integer_or_nil,
+        workspace_path: per_issue_workspace_dir
       }}
 
   The agent's `update/2` handles this however it wants. To complete,
@@ -42,6 +43,33 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
   `{:tool_result, _}`, `{:turn_complete, _}` are forwarded to the
   parent as `{:run_event, issue.id, payload}` so the orchestrator
   surfaces them like the Stream-based runner does.
+
+  ## Workspace confinement is the agent module's job here
+
+  `opts[:workspace_path]` is required, as it is for every runner, and it
+  reaches the agent in the seed and resume payloads. Unlike
+  `Raxol.Symphony.Runners.RaxolAgent`, this runner cannot *enforce* it.
+
+  That runner owns the call into `Raxol.Agent.Stream.run/2`, so it builds the
+  tool context and the fs tools are confined whatever the agent does. Here the
+  agent module owns its own tool-execution path: it decides what to invoke on
+  `:symphony_start` and it constructs the context those Actions receive.
+  `Raxol.Agent.Session` builds its Lifecycle options internally and accepts
+  nothing from the caller, so Symphony has no seam to inject a boundary into.
+
+  An agent module used with this runner is therefore responsible for scoping
+  its own tools to the workspace it is handed:
+
+      def update({:agent_message, _, {:symphony_start, payload}}, model) do
+        context = %{cwd: payload.workspace_path}
+        Raxol.Agent.Stream.run(payload.prompt, actions: actions(), context: context)
+        ...
+      end
+
+  Without that, the module's fs Actions resolve against the BEAM's cwd -- the
+  repo the orchestrator was started in -- exactly as if no workspace had been
+  allocated. Enforcing it from Symphony's side would need
+  `Raxol.Agent.Session` to accept caller-supplied lifecycle options.
 
   ## Timeout
 
@@ -68,7 +96,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
 
   On resume the runner sends:
 
-      {:symphony_resume, %{resume_value: rv, session_id: id}}
+      {:symphony_resume, %{resume_value: rv, session_id: id, workspace_path: dir}}
 
   into the same Session's mailbox and loops for events as before.
   If the Session is no longer in the Registry (e.g. the BEAM
@@ -199,6 +227,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
 
   defp fresh_run(%Issue{} = issue, %Config{} = config, opts) do
     parent = Keyword.fetch!(opts, :parent)
+    # Required, not optional: a run with no workspace is a run against the
+    # orchestrator's own cwd. Raise rather than seed the agent without one.
+    workspace = Keyword.fetch!(opts, :workspace_path)
     attempt = Keyword.get(opts, :attempt)
     module = agent_module(config)
     timeout_ms = session_timeout_ms(config)
@@ -209,7 +240,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     with :ok <- ensure_session_streamer(),
          :ok <- subscribe(session_id),
          {:ok, _pid} <- start_session(session_id, module) do
-      seed_agent(session_id, issue, config, attempt)
+      seed_agent(session_id, issue, config, attempt, workspace)
 
       case loop(session_id, issue.id, parent, timeout_ms) do
         :ok ->
@@ -239,6 +270,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
          resume_value
        ) do
     parent = Keyword.fetch!(opts, :parent)
+    workspace = Keyword.fetch!(opts, :workspace_path)
     timeout_ms = session_timeout_ms(config)
     %{session_id: session_id} = resume_token
 
@@ -249,7 +281,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
       [{_pid, _}] ->
         with :ok <- ensure_session_streamer(),
              :ok <- subscribe(session_id) do
-          send_resume(session_id, resume_value)
+          send_resume(session_id, resume_value, workspace)
 
           case loop(session_id, issue.id, parent, timeout_ms) do
             :ok ->
@@ -363,10 +395,14 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     :exit, reason -> {:error, {:start_child, reason}}
   end
 
-  defp send_resume(session_id, resume_value) do
+  defp send_resume(session_id, resume_value, workspace) do
     Raxol.Agent.Session.send_message(session_id, {
       :symphony_resume,
-      %{session_id: session_id, resume_value: resume_value}
+      %{
+        session_id: session_id,
+        resume_value: resume_value,
+        workspace_path: workspace
+      }
     })
 
     :ok
@@ -382,12 +418,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSession do
     :exit, _ -> :ok
   end
 
-  defp seed_agent(session_id, issue, config, attempt) do
+  defp seed_agent(session_id, issue, config, attempt, workspace) do
     payload = %{
       issue: issue,
       prompt: build_prompt(issue, config, attempt),
       attempt: attempt,
-      session_id: session_id
+      session_id: session_id,
+      workspace_path: workspace
     }
 
     Raxol.Agent.Session.send_message(session_id, {:symphony_start, payload})

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent/agent_workflow_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent/agent_workflow_test.exs
@@ -17,6 +17,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflowTest do
   alias Raxol.Symphony.Runners.RaxolAgent
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -92,7 +96,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflowTest do
 
       # Pause on turn 1.
       assert {:pause, :awaiting_review, pause_token} =
-               RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Resume. after_turn_1 re-runs, calls Workflow.interrupt
       # which now returns the resume_value, clears pause_request,
@@ -102,6 +110,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflowTest do
       assert :ok =
                RaxolAgent.run(issue(), cfg,
                  parent: self(),
+                 workspace_path: @workspace,
                  attempt: nil,
                  resume_token: pause_token,
                  resume_value: :approved
@@ -117,7 +126,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflowTest do
 
       cfg = config(%{}, 3)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # 3 turns -> 3 turn_completed events.
       assert count_turn_completed("issue-1", 400) == 3
@@ -135,7 +149,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflowTest do
       cfg = config(%{pause_detector: detector})
 
       assert {:pause, :awaiting_review, _token} =
-               RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # The mock backend's events still arrived even though the very
       # first event triggered pause. Specifically: turn_completed

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent/self_improve_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent/self_improve_test.exs
@@ -6,6 +6,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.SelfImproveTest do
   alias Raxol.Agent.Skills.Store, as: Skills
   alias Raxol.Symphony.Runners.RaxolAgent.SelfImprove
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   defmodule DemoAgent do
     use Raxol.Agent
     def skills_provider, do: Raxol.Agent.Skills.Store
@@ -156,7 +160,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.SelfImproveTest do
           prompt_template: "Work on {{ issue.identifier }}"
         })
 
-      assert :ok = RaxolAgent.run(issue, config, parent: self())
+      assert :ok = RaxolAgent.run(issue, config, parent: self(), workspace_path: @workspace)
       assert [%{conversation_id: "issue-9"}] = SessionSearch.search(ss, "flyctl")
     end
   end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_module_metadata_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_module_metadata_test.exs
@@ -12,6 +12,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentModuleMetadataTest do
   alias Raxol.Symphony.TestSupport.AgentWithMetadata
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -63,7 +67,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentModuleMetadataTest do
 
       cfg = config(%{module: AgentWithMetadata})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # AgentWithMetadata's sandbox/0 includes a DenyTurnSandbox with
       # reason :module_deny -- the runner picked it up.
@@ -85,7 +94,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentModuleMetadataTest do
           sandboxes: [direct_sandbox]
         })
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # First-deny-wins: the direct config sandbox fired, not the
       # module-declared one.
@@ -106,7 +120,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentModuleMetadataTest do
 
       cfg = config(%{module: AgentWithMetadata})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: 0)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 0
+               )
 
       # The module-declared thread_log captured the run's snapshot
       # despite agent.thread_log being unset.
@@ -132,7 +151,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentModuleMetadataTest do
 
       cfg = config(%{module: AgentWithMetadata, thread_log: direct})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: 7)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 7
+               )
 
       # Direct config got the events.
       {:ok, direct_events} =

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_policy_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_policy_test.exs
@@ -16,6 +16,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentPolicyTest do
   alias Raxol.Symphony.Runners.RaxolAgent
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -87,7 +91,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentPolicyTest do
       attach_applied_counter(self(), :no_policies)
 
       cfg = config(%{})
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # An empty policies list still calls PolicyApplier.apply/3 with [],
       # which DOES emit the :applied event. So count >= 1. The contract
@@ -110,7 +120,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentPolicyTest do
 
       cfg = config(%{policies: policies}, 3)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # 3 turns wrapped -> 3 :applied events.
       assert count_applied(:multi, 400) == 3
@@ -134,7 +149,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentPolicyTest do
       policies = [Policy.Timeout.new(5_000)]
       cfg = config(%{policies: policies})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # PolicyApplier metadata exposes the params the runner threaded in.
       assert_receive {:metadata, metadata}, 200
@@ -149,7 +169,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentPolicyTest do
 
       cfg = config(%{policies: "not-a-list"})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_sandbox_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_sandbox_test.exs
@@ -17,6 +17,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSandboxTest do
   alias Raxol.Symphony.TestSupport.{AbstainSandbox, AllowSandbox, DenyTurnSandbox}
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -69,7 +73,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSandboxTest do
 
       cfg = config(%{})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # No denied telemetry should fire on the empty chain.
       refute_receive {:denied, :default, _}, 50
@@ -84,7 +93,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSandboxTest do
 
       cfg = config(%{sandboxes: [%AllowSandbox{}]})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       refute_receive {:denied, :allow, _}, 50
 
@@ -104,7 +118,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSandboxTest do
           sandboxes: [%DenyTurnSandbox{reason: :budget_exhausted}]
         })
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       assert_receive {:denied, :deny, metadata}, 200
       assert metadata.action == :turn
@@ -124,7 +143,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSandboxTest do
 
       cfg = config(%{sandboxes: [%DenyTurnSandbox{reason: :rate_limit}]}, 3)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Three turns, three denies (since each turn re-walks the chain).
       assert_receive {:denied, :deny_multi, _}, 200
@@ -151,7 +175,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSandboxTest do
           ]
         })
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       assert_receive {:denied, :compose, metadata}, 200
       assert metadata.reason == :downstream_block
@@ -170,7 +199,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSandboxTest do
           ]
         })
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       assert_receive {:denied, :compose_short, %{reason: :first_block}}, 200
     end
@@ -182,7 +216,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSandboxTest do
 
       cfg = config(%{sandboxes: "not-a-list"})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_prompt_cache_test.exs
@@ -31,6 +31,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
     SessionAgentSucceed
   }
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     case Process.whereis(Raxol.Agent.Registry) do
       nil -> start_supervised!(Raxol.Agent.Supervisor)
@@ -75,7 +79,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
     do: %Issue{id: "issue-1", identifier: "MT-1", title: "T", state: "Todo"}
 
   defp run(cfg, attempt \\ nil) do
-    RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: attempt)
+    RaxolAgentSession.run(issue(), cfg,
+      parent: self(),
+      workspace_path: @workspace,
+      attempt: attempt
+    )
   end
 
   defp table_of({_module, %{table: table}}), do: table
@@ -170,12 +178,18 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
       # The second run is a freshness miss that overwrites -- one row, never
       # a stale serve -- proving the fingerprint tracks all determinants.
       assert :ok =
-               RaxolAgentSession.run(%{issue() | description: "A"}, cfg, parent: self())
+               RaxolAgentSession.run(%{issue() | description: "A"}, cfg,
+                 parent: self(),
+                 workspace_path: @workspace
+               )
 
       assert [{_key, {fp_a, "MT-1"}, _}] = entries(adapter)
 
       assert :ok =
-               RaxolAgentSession.run(%{issue() | description: "B"}, cfg, parent: self())
+               RaxolAgentSession.run(%{issue() | description: "B"}, cfg,
+                 parent: self(),
+                 workspace_path: @workspace
+               )
 
       assert [{_key, {fp_b, "MT-1"}, _}] = entries(adapter)
       assert :ets.info(table_of(adapter), :size) == 1
@@ -207,7 +221,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionPromptCacheTest do
         id = "one-shot-#{n}"
         iss = %Issue{id: id, identifier: id, title: "T", state: "Todo"}
 
-        assert :ok = RaxolAgentSession.run(iss, cfg, parent: self(), attempt: nil)
+        assert :ok =
+                 RaxolAgentSession.run(iss, cfg,
+                   parent: self(),
+                   workspace_path: @workspace,
+                   attempt: nil
+                 )
+
         assert :ets.info(table, :size) == 1
 
         assert :ok = RaxolAgentSession.flush_prompt_cache(cfg, id)

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_session_test.exs
@@ -8,8 +8,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
     SessionAgentErrors,
     SessionAgentPausesResumes,
     SessionAgentSilent,
-    SessionAgentSucceed
+    SessionAgentSucceed,
+    SessionAgentWorkspaceEcho
   }
+
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
 
   setup do
     # The Registry is part of the raxol_agent application supervision
@@ -53,7 +58,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
       cfg = config(%{})
 
       assert {:error, :agent_module_required} =
-               RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgentSession.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 
@@ -62,7 +71,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
       cfg = config(%{module: SessionAgentSucceed})
 
       assert :ok =
-               RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgentSession.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # The :turn_complete event was forwarded to parent.
       assert_received {:run_event, "issue-1", %{event: :turn_complete}}
@@ -74,7 +87,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
       cfg = config(%{module: SessionAgentErrors})
 
       assert {:error, :backend_unavailable} =
-               RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgentSession.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 
@@ -87,7 +104,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
         })
 
       assert {:error, :session_timeout} =
-               RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgentSession.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 
@@ -96,7 +117,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
       cfg = config(%{module: SessionAgentPausesResumes})
 
       assert {:pause, :awaiting_review, token} =
-               RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: 1)
+               RaxolAgentSession.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 1
+               )
 
       assert is_binary(token.session_id)
       assert token.step == "first-half"
@@ -116,12 +141,17 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
       cfg = config(%{module: SessionAgentPausesResumes})
 
       assert {:pause, :awaiting_review, token} =
-               RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: 7)
+               RaxolAgentSession.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 7
+               )
 
       # Resume.
       assert :ok =
                RaxolAgentSession.run(issue(), cfg,
                  parent: self(),
+                 workspace_path: @workspace,
                  attempt: 7,
                  resume_token: token,
                  resume_value: :approved
@@ -139,10 +169,59 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
       assert {:error, :session_not_found} =
                RaxolAgentSession.run(issue(), cfg,
                  parent: self(),
+                 workspace_path: @workspace,
                  attempt: nil,
                  resume_token: ghost_token,
                  resume_value: :approved
                )
+    end
+  end
+
+  describe "workspace" do
+    test "run/3 refuses to run without a workspace rather than running unconfined" do
+      cfg = config(%{module: SessionAgentSucceed})
+
+      assert_raise KeyError, fn ->
+        RaxolAgentSession.run(issue(), cfg, parent: self(), attempt: nil)
+      end
+    end
+
+    test "resume refuses without a workspace too" do
+      cfg = config(%{module: SessionAgentSucceed})
+
+      assert_raise KeyError, fn ->
+        RaxolAgentSession.run(issue(), cfg,
+          parent: self(),
+          attempt: nil,
+          resume_token: %{session_id: "some-session"},
+          resume_value: :approved
+        )
+      end
+    end
+
+    test "the agent is handed its workspace on both the seed and resume messages" do
+      cfg = config(%{module: SessionAgentWorkspaceEcho})
+      workspace = "/srv/symphony/MT-1"
+
+      assert {:pause, :awaiting_review, token} =
+               RaxolAgentSession.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: workspace,
+                 attempt: nil
+               )
+
+      assert_received {:run_event, "issue-1", %{seed_workspace: ^workspace}}
+
+      assert :ok =
+               RaxolAgentSession.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: workspace,
+                 attempt: nil,
+                 resume_token: token,
+                 resume_value: :approved
+               )
+
+      assert_received {:run_event, "issue-1", %{resume_workspace: ^workspace}}
     end
   end
 
@@ -167,7 +246,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentSessionTest do
 
     defp run_issue(cfg, id) do
       issue = %Issue{id: id, identifier: id, title: "T", state: "Todo"}
-      assert :ok = RaxolAgentSession.run(issue, cfg, parent: self(), attempt: nil)
+
+      assert :ok =
+               RaxolAgentSession.run(issue, cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
 
     test "the continuation re-dispatch read flushes its entry", %{

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_test.exs
@@ -1,9 +1,14 @@
 defmodule Raxol.Symphony.Runners.RaxolAgentTest do
   use ExUnit.Case, async: false
 
+  alias Raxol.Agent.Actions.Fs
   alias Raxol.Symphony.{Config, Issue, Tracker}
   alias Raxol.Symphony.Runners.RaxolAgent
   alias Raxol.Symphony.Trackers.Memory
+
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
 
   setup do
     start_supervised!({Memory, []})
@@ -41,7 +46,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
     test "returns :ok and emits stream events to parent" do
       Memory.put_issue(%{issue() | state: "Done"})
 
-      :ok = RaxolAgent.run(issue(), config(), parent: self(), attempt: nil)
+      :ok =
+        RaxolAgent.run(issue(), config(),
+          parent: self(),
+          workspace_path: @workspace,
+          attempt: nil
+        )
 
       assert_received {:run_event, "issue-1", %{event: :text_delta}}
       assert_received {:run_event, "issue-1", %{event: :turn_completed}}
@@ -53,7 +63,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
       # received text_delta with the configured response.
       Memory.put_issue(%{issue() | state: "Done"})
 
-      :ok = RaxolAgent.run(issue(), config(%{response: "got it"}), parent: self())
+      :ok =
+        RaxolAgent.run(issue(), config(%{response: "got it"}),
+          parent: self(),
+          workspace_path: @workspace
+        )
 
       assert_received {:run_event, "issue-1", %{event: :text_delta, message: "got it"}}
     end
@@ -63,7 +77,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
     test "loops while issue stays active and stops at max_turns" do
       Memory.put_issue(%{issue() | state: "In Progress"})
 
-      :ok = RaxolAgent.run(issue(), config(%{}, _max_turns = 3), parent: self())
+      :ok =
+        RaxolAgent.run(issue(), config(%{}, _max_turns = 3),
+          parent: self(),
+          workspace_path: @workspace
+        )
 
       # We cannot rely on the order of receive between turns, but we should
       # have at least 3 turn_completed events.
@@ -75,7 +93,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
     test "stops when tracker reports terminal state" do
       Memory.put_issue(%{issue() | state: "Done"})
 
-      :ok = RaxolAgent.run(issue("Todo"), config(%{}, _max_turns = 5), parent: self())
+      :ok =
+        RaxolAgent.run(issue("Todo"), config(%{}, _max_turns = 5),
+          parent: self(),
+          workspace_path: @workspace
+        )
 
       events = collect_events("issue-1", 200)
       assert Enum.count(events, &(&1.event == :turn_completed)) == 1
@@ -83,7 +105,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
 
     test "stops when tracker tracker is unavailable" do
       # Memory is started but transition to non-existent ID -> empty result
-      :ok = RaxolAgent.run(issue("Todo"), config(%{}, _max_turns = 5), parent: self())
+      :ok =
+        RaxolAgent.run(issue("Todo"), config(%{}, _max_turns = 5),
+          parent: self(),
+          workspace_path: @workspace
+        )
 
       events = collect_events("issue-1", 200)
       # Single turn since Memory has no record of "issue-1" -> :done branch
@@ -102,7 +128,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
       cfg = config(%{pause_detector: detector})
 
       assert {:pause, :awaiting_buyer_payment, %{seq: 1}} =
-               RaxolAgent.run(issue(), cfg, parent: self())
+               RaxolAgent.run(issue(), cfg, parent: self(), workspace_path: @workspace)
     end
 
     test ":continue from detector falls through to normal completion" do
@@ -111,7 +137,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
       detector = fn _event -> :continue end
       cfg = config(%{pause_detector: detector})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self())
+      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), workspace_path: @workspace)
       assert_received {:run_event, "issue-1", %{event: :turn_completed}}
     end
 
@@ -122,7 +148,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
         config(%{pause_detector: {__MODULE__, :__test_always_pause__}})
 
       assert {:pause, :awaiting_delivery, :tok} =
-               RaxolAgent.run(issue(), cfg, parent: self())
+               RaxolAgent.run(issue(), cfg, parent: self(), workspace_path: @workspace)
     end
 
     test "detector only fires on a matching event tag" do
@@ -137,7 +163,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
 
       cfg = config(%{pause_detector: detector})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self())
+      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), workspace_path: @workspace)
     end
 
     test "events fire before the detector decides to pause" do
@@ -146,7 +172,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
       detector = fn _event -> {:pause, :awaiting_evaluator_approval, :tok} end
       cfg = config(%{pause_detector: detector})
 
-      _ = RaxolAgent.run(issue(), cfg, parent: self())
+      _ = RaxolAgent.run(issue(), cfg, parent: self(), workspace_path: @workspace)
 
       # At least one event should have been forwarded to parent before the
       # detector halted stream consumption.
@@ -156,6 +182,67 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
 
   @doc false
   def __test_always_pause__(_event), do: {:pause, :awaiting_delivery, :tok}
+
+  describe "workspace confinement" do
+    test "agent_context/1 carries the workspace path as the tool cwd" do
+      assert %{cwd: "/srv/symphony/MT-1"} =
+               RaxolAgent.agent_context(workspace_path: "/srv/symphony/MT-1")
+    end
+
+    test "the workspace context reaches Stream.run under the :context key" do
+      state = %{
+        backend: Raxol.Agent.Backend.Mock,
+        backend_opts: [],
+        system_prompt: nil,
+        context: RaxolAgent.agent_context(workspace_path: "/srv/symphony/MT-1")
+      }
+
+      opts = RaxolAgent.__stream_opts__(state)
+
+      # `Stream.run/2` reads this with a default, so a wrong key name would
+      # silently un-confine the run instead of raising.
+      assert Keyword.fetch!(opts, :context) == %{cwd: "/srv/symphony/MT-1"}
+    end
+
+    test "run/3 refuses to run without a workspace rather than running unconfined" do
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      assert_raise KeyError, fn ->
+        RaxolAgent.run(issue(), config(), parent: self(), attempt: nil)
+      end
+    end
+
+    @tag :tmp_dir
+    test "the context the runner builds confines the fs tools to the workspace",
+         %{tmp_dir: tmp_dir} do
+      workspace = Path.join(tmp_dir, "MT-1")
+      File.mkdir_p!(workspace)
+      File.write!(Path.join(workspace, "inside.txt"), "in")
+      File.write!(Path.join(tmp_dir, "outside.txt"), "out")
+
+      context = RaxolAgent.agent_context(workspace_path: workspace)
+
+      assert {:ok, resolved} = Fs.resolve("inside.txt", context)
+      assert resolved == Path.join(workspace, "inside.txt")
+
+      assert {:error, :outside_cwd} = Fs.resolve("../outside.txt", context)
+    end
+
+    @tag :tmp_dir
+    test "a run resolves against its own workspace, not the orchestrator's cwd",
+         %{tmp_dir: tmp_dir} do
+      workspace = Path.join(tmp_dir, "MT-1")
+      File.mkdir_p!(workspace)
+
+      context = RaxolAgent.agent_context(workspace_path: workspace)
+
+      # `mix.exs` exists in the BEAM's cwd (the package root) and not in the
+      # workspace. Resolving it must not reach the file the orchestrator was
+      # started next to.
+      assert File.regular?("mix.exs")
+      assert {:error, :outside_cwd} = Fs.resolve(Path.expand("mix.exs"), context)
+    end
+  end
 
   describe "compile-time absence" do
     test "returns :raxol_agent_not_loaded when stream module missing" do

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_test.exs
@@ -1,6 +1,8 @@
 defmodule Raxol.Symphony.Runners.RaxolAgentTest do
   use ExUnit.Case, async: false
 
+  alias Raxol.Agent.Action.ToolConverter
+  alias Raxol.Agent.Actions.Code, as: CodeActions
   alias Raxol.Agent.Actions.Fs
   alias Raxol.Symphony.{Config, Issue, Tracker}
   alias Raxol.Symphony.Runners.RaxolAgent
@@ -184,20 +186,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
   def __test_always_pause__(_event), do: {:pause, :awaiting_delivery, :tok}
 
   describe "workspace confinement" do
-    test "agent_context/1 carries the workspace path as the tool cwd" do
+    test "agent_context/2 carries the workspace path as the tool cwd" do
       assert %{cwd: "/srv/symphony/MT-1"} =
-               RaxolAgent.agent_context(workspace_path: "/srv/symphony/MT-1")
+               RaxolAgent.agent_context([workspace_path: "/srv/symphony/MT-1"], config())
     end
 
     test "the workspace context reaches Stream.run under the :context key" do
-      state = %{
-        backend: Raxol.Agent.Backend.Mock,
-        backend_opts: [],
-        system_prompt: nil,
-        context: RaxolAgent.agent_context(workspace_path: "/srv/symphony/MT-1")
-      }
-
-      opts = RaxolAgent.__stream_opts__(state)
+      opts = RaxolAgent.__stream_opts__(stream_state())
 
       # `Stream.run/2` reads this with a default, so a wrong key name would
       # silently un-confine the run instead of raising.
@@ -220,7 +215,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
       File.write!(Path.join(workspace, "inside.txt"), "in")
       File.write!(Path.join(tmp_dir, "outside.txt"), "out")
 
-      context = RaxolAgent.agent_context(workspace_path: workspace)
+      context = RaxolAgent.agent_context([workspace_path: workspace], config())
 
       assert {:ok, resolved} = Fs.resolve("inside.txt", context)
       assert resolved == Path.join(workspace, "inside.txt")
@@ -234,7 +229,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
       workspace = Path.join(tmp_dir, "MT-1")
       File.mkdir_p!(workspace)
 
-      context = RaxolAgent.agent_context(workspace_path: workspace)
+      context = RaxolAgent.agent_context([workspace_path: workspace], config())
 
       # `mix.exs` exists in the BEAM's cwd (the package root) and not in the
       # workspace. Resolving it must not reach the file the orchestrator was
@@ -253,6 +248,123 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTest do
       assert Code.ensure_loaded?(Raxol.Agent.Stream)
     end
   end
+
+  describe "agent.actions" do
+    test "no actions declared is the default: the run exposes no tools" do
+      opts = RaxolAgent.__stream_opts__(stream_state())
+
+      # `Stream.run/2` reads this with a default too, so a wrong key name would
+      # silently leave the model with no tools.
+      assert Keyword.fetch!(opts, :actions) == []
+    end
+
+    test "declared actions reach Stream.run" do
+      cfg = config(%{actions: [CodeActions.Grep, CodeActions.Write]})
+      opts = RaxolAgent.__stream_opts__(stream_state(cfg))
+
+      assert Keyword.fetch!(opts, :actions) == [CodeActions.Grep, CodeActions.Write]
+    end
+
+    test "validate_actions/1 accepts real Action modules" do
+      assert {:ok, [CodeActions.Grep]} =
+               RaxolAgent.validate_actions(config(%{actions: [CodeActions.Grep]}))
+    end
+
+    test "a module that is not an Action fails the run instead of being dropped" do
+      Memory.put_issue(%{issue() | state: "Done"})
+      cfg = config(%{actions: [CodeActions.Grep, NotAnActionModule, "grep"]})
+
+      assert {:error, {:invalid_actions, [NotAnActionModule, "grep"]}} =
+               RaxolAgent.validate_actions(cfg)
+
+      assert {:error, {:invalid_actions, _}} =
+               RaxolAgent.run(issue(), cfg, parent: self(), workspace_path: @workspace)
+    end
+  end
+
+  describe "agent.tool_policy" do
+    @tag :tmp_dir
+    test "unset leaves the framework default in force: reads allowed, writes denied",
+         %{tmp_dir: workspace} do
+      context = RaxolAgent.agent_context([workspace_path: workspace], config())
+
+      # No authorizer injected -- that IS the safe default, because
+      # ToolConverter falls back to ToolPolicy.deny_sensitive/0.
+      refute Map.has_key?(context, :tool_authorizer)
+
+      assert {:error, {:tool_denied, "write_file", :sensitive_tool}} =
+               write_call() |> dispatch(context)
+
+      refute File.exists?(Path.join(workspace, "written.txt"))
+
+      # A read-only tool in the same run is unaffected.
+      assert {:ok, %{paths: _}} = glob_call() |> dispatch(context)
+    end
+
+    @tag :tmp_dir
+    test "allow_all lets a write through, and it lands inside the workspace",
+         %{tmp_dir: workspace} do
+      cfg = config(%{tool_policy: :allow_all})
+      context = RaxolAgent.agent_context([workspace_path: workspace], cfg)
+
+      assert {:ok, _} = write_call() |> dispatch(context)
+      assert File.read!(Path.join(workspace, "written.txt")) == "hi"
+    end
+
+    @tag :tmp_dir
+    test "allow_all still cannot write outside the workspace", %{tmp_dir: tmp_dir} do
+      workspace = Path.join(tmp_dir, "MT-1")
+      File.mkdir_p!(workspace)
+
+      cfg = config(%{tool_policy: :allow_all})
+      context = RaxolAgent.agent_context([workspace_path: workspace], cfg)
+
+      assert {:error, :outside_cwd} =
+               write_call("../escaped.txt") |> dispatch(context)
+
+      refute File.exists?(Path.join(tmp_dir, "escaped.txt"))
+    end
+
+    @tag :tmp_dir
+    test "an unrecognized policy denies everything rather than widening the run",
+         %{tmp_dir: workspace} do
+      cfg = config(%{tool_policy: :allw_all})
+      context = RaxolAgent.agent_context([workspace_path: workspace], cfg)
+
+      # Not merely "sensitive denied" -- a typo must not land on the framework
+      # default, so even a read-only tool is refused.
+      assert {:error, {:tool_denied, "glob", :invalid_tool_policy}} =
+               glob_call() |> dispatch(context)
+    end
+
+    test "a shell sandbox reaches the context when configured" do
+      sandbox = Raxol.Agent.Sandbox.Shell.allowlist(["git"])
+      cfg = config(%{shell_sandbox: sandbox})
+
+      assert %{shell_sandbox: ^sandbox} =
+               RaxolAgent.agent_context([workspace_path: @workspace], cfg)
+    end
+  end
+
+  defp stream_state(cfg \\ nil) do
+    cfg = cfg || config()
+
+    %{
+      backend: Raxol.Agent.Backend.Mock,
+      backend_opts: [],
+      system_prompt: nil,
+      context: RaxolAgent.agent_context([workspace_path: "/srv/symphony/MT-1"], cfg),
+      actions: RaxolAgent.validate_actions(cfg) |> elem(1)
+    }
+  end
+
+  defp dispatch(call, context),
+    do: ToolConverter.dispatch_tool_call(call, CodeActions.all(), context)
+
+  defp write_call(path \\ "written.txt"),
+    do: %{"name" => "write_file", "arguments" => %{"path" => path, "content" => "hi"}}
+
+  defp glob_call, do: %{"name" => "glob", "arguments" => %{"pattern" => "*"}}
 
   describe "config dispatch" do
     test "runner.kind=raxol_agent resolves to RaxolAgent module" do

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_thread_log_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_thread_log_test.exs
@@ -22,6 +22,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
   alias Raxol.Symphony.Runners.RaxolAgent
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -65,7 +69,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
 
       cfg = config(%{})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 
@@ -77,7 +86,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
 
       cfg = config(%{thread_log: adapter}, 3)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: 1)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 1
+               )
 
       thread_id = "symphony-agent-issue-1-1"
 
@@ -113,7 +127,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
 
       # Pause.
       assert {:pause, :awaiting_review, pause_token} =
-               RaxolAgent.run(issue(), cfg, parent: self(), attempt: 2)
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 2
+               )
 
       thread_id = "symphony-agent-issue-1-2"
 
@@ -121,6 +139,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
       assert :ok =
                RaxolAgent.run(issue(), cfg,
                  parent: self(),
+                 workspace_path: @workspace,
                  attempt: 2,
                  resume_token: pause_token,
                  resume_value: :approved
@@ -147,7 +166,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
 
       cfg = config(%{thread_log: adapter})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: 7)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 7
+               )
 
       # No collision with the default "0" attempt -- write happens at
       # symphony-agent-issue-1-7.
@@ -167,7 +191,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
 
       cfg = config(%{thread_log: adapter}, 3)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: 3)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 3
+               )
 
       thread_id = "symphony-agent-issue-1-3"
 
@@ -183,7 +212,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
 
       cfg = config(%{thread_log: Raxol.Agent.ThreadLog.Ets})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: 4)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 4
+               )
 
       # Default Ets table is used.
       {:ok, events} =

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_tracker_cache_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_tracker_cache_test.exs
@@ -24,6 +24,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTrackerCacheTest do
   alias Raxol.Symphony.Runners.RaxolAgent
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -67,7 +71,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTrackerCacheTest do
 
       cfg = config(%{})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 
@@ -83,7 +92,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTrackerCacheTest do
           tracker_cache_ttl_ms: 60_000
         })
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Cache MUST contain the tracker result keyed by {:tracker, issue.id}.
       assert {:ok, result} = Raxol.Agent.Cache.get(adapter, {:tracker, "issue-1"})
@@ -106,7 +120,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTrackerCacheTest do
           3
         )
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # After a multi-turn run, the cache holds the latest tracker
       # result. Memory tracker returns {:active, refreshed} for an
@@ -126,7 +145,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTrackerCacheTest do
 
       cfg = config(%{tracker_cache: adapter})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # The entry should still be live (we just wrote it; TTL=30s).
       assert {:ok, _} = Raxol.Agent.Cache.get(adapter, {:tracker, "issue-1"})
@@ -139,7 +163,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTrackerCacheTest do
 
       cfg = config(%{tracker_cache: Raxol.Agent.Cache.Ets})
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Default table is used.
       assert {:ok, _} =

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_turn_error_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_turn_error_test.exs
@@ -19,6 +19,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest do
   alias Raxol.Symphony.TestSupport.DenyTurnSandbox
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -70,7 +74,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest do
       cfg = config(%{policies: policies, latency_ms: 200})
 
       assert {:error, {:policy_failed, :timeout}} =
-               RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 
@@ -97,7 +105,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest do
 
       # Deny IS surfaced as :ok -- the orchestrator's retry layer
       # would do nothing useful here (every retry would deny again).
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # The telemetry handler caught the deny -- this is the
       # operator-visible signal.
@@ -111,14 +124,26 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest do
       Memory.put_issue(%{issue() | state: "Done"})
 
       cfg = config(%{})
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
 
     test "all-pass policies: :ok" do
       Memory.put_issue(%{issue() | state: "Done"})
 
       cfg = config(%{policies: [Policy.Timeout.new(5_000)]})
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 
@@ -144,7 +169,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest do
         })
 
       assert {:error, {:policy_failed, :timeout}} =
-               RaxolAgent.run(issue(), cfg, parent: self(), attempt: 9)
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: 9
+               )
 
       {:ok, events} =
         Raxol.Agent.ThreadLog.list(

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_workflow_envelope_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_workflow_envelope_test.exs
@@ -18,6 +18,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
   alias Raxol.Symphony.Runners.RaxolAgent
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -66,7 +70,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
       Memory.put_issue(%{issue() | state: "Done"})
 
       assert :ok =
-               RaxolAgent.run(issue(), config(%{}, 3), parent: self(), attempt: nil)
+               RaxolAgent.run(issue(), config(%{}, 3),
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Events were still forwarded from the mock backend.
       assert_received {:run_event, "issue-1", %{event: :text_delta}}
@@ -77,7 +85,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
       Memory.put_issue(%{issue() | state: "In Progress"})
 
       assert :ok =
-               RaxolAgent.run(issue(), config(%{}, 2), parent: self(), attempt: nil)
+               RaxolAgent.run(issue(), config(%{}, 2),
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       events = collect_events("issue-1", 200)
       # Two full turns under workflow_mode.
@@ -98,7 +110,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
       cfg = config(%{pause_detector: detector})
 
       assert {:pause, :awaiting_buyer_payment, token} =
-               RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # The runner-level token carries workflow_run_id so the orchestrator
       # can route a later resume_run/3 back through Compiled.resume.
@@ -126,7 +142,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
 
       # First pass pauses.
       assert {:pause, :awaiting_external, pause_token} =
-               RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       assert is_binary(pause_token.workflow_run_id)
 
@@ -137,6 +157,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
       assert :ok =
                RaxolAgent.run(issue(), cfg,
                  parent: self(),
+                 workspace_path: @workspace,
                  attempt: nil,
                  resume_token: pause_token,
                  resume_value: :approved
@@ -165,7 +186,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
           prompt_template: ""
         })
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/sandboxes/integration_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/sandboxes/integration_test.exs
@@ -13,6 +13,10 @@ defmodule Raxol.Symphony.Sandboxes.IntegrationTest do
   alias Raxol.Symphony.Sandboxes.{BudgetCap, TimeOfDayWindow, TurnRateLimit}
   alias Raxol.Symphony.Trackers.Memory
 
+  # The orchestrator allocates a per-issue workspace and the runner requires
+  # it; these cases assert other behaviour, so any path will do.
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -71,7 +75,12 @@ defmodule Raxol.Symphony.Sandboxes.IntegrationTest do
 
       cfg = config([sandbox], 3)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Turn 1 is allowed -- mock backend's :turn_completed arrives.
       assert_received {:run_event, "issue-1", %{event: :turn_completed}}
@@ -106,7 +115,12 @@ defmodule Raxol.Symphony.Sandboxes.IntegrationTest do
 
       cfg = config([sandbox], 2)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Both turns are denied with :outside_window.
       assert_receive {:denied, %{reason: :outside_window}}, 200
@@ -130,7 +144,12 @@ defmodule Raxol.Symphony.Sandboxes.IntegrationTest do
 
       cfg = config([sandbox], 3)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # First turn allowed; budget hits the cap mid-second-turn.
       assert_received {:run_event, "issue-1", %{event: :turn_completed}}
@@ -155,7 +174,12 @@ defmodule Raxol.Symphony.Sandboxes.IntegrationTest do
 
       cfg = config([sandbox], 2)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Mock backend emits {input_tokens, output_tokens}. Two turns ran
       # (max_turns = 2), so spend = sum of both turns' (input + output).
@@ -182,7 +206,12 @@ defmodule Raxol.Symphony.Sandboxes.IntegrationTest do
 
       cfg = config([sandbox], 3)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Three turns charged at cost_per_turn=1 = 3.
       assert BudgetCap.spend(table, "issue-1") == 3
@@ -204,7 +233,12 @@ defmodule Raxol.Symphony.Sandboxes.IntegrationTest do
 
       cfg = config([rate_limit, time_window], 1)
 
-      assert :ok = RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
 
       # Rate limit (first in chain) fires before the time window check
       # is reached.

--- a/packages/raxol_symphony/test/support/symphony_test_session_agent.ex
+++ b/packages/raxol_symphony/test/support/symphony_test_session_agent.ex
@@ -124,3 +124,49 @@ defmodule Raxol.Symphony.TestSupport.SessionAgentPausesResumes do
 
   def view(_model), do: %{type: :text, content: "pause"}
 end
+
+defmodule Raxol.Symphony.TestSupport.SessionAgentWorkspaceEcho do
+  @moduledoc """
+  TEA agent that reports the workspace it was handed, on both the seed and
+  the resume message. Proves the runner passes the per-issue workspace to
+  the agent module, which is what owns tool-context construction on the
+  Session path.
+
+  Pauses on `:symphony_start` so one run exercises both payloads.
+  """
+
+  def init(_args), do: {%{}, []}
+
+  def update({:agent_message, _, {:symphony_start, payload}}, model) do
+    if Code.ensure_loaded?(Raxol.Agent.SessionStreamer) do
+      Raxol.Agent.SessionStreamer.emit(
+        payload.session_id,
+        {:turn_complete, %{seed_workspace: Map.get(payload, :workspace_path)}}
+      )
+
+      Raxol.Agent.SessionStreamer.emit(
+        payload.session_id,
+        {:paused, %{reason: :awaiting_review, token: %{}}}
+      )
+    end
+
+    {model, []}
+  end
+
+  def update({:agent_message, _, {:symphony_resume, payload}}, model) do
+    if Code.ensure_loaded?(Raxol.Agent.SessionStreamer) do
+      Raxol.Agent.SessionStreamer.emit(
+        payload.session_id,
+        {:turn_complete, %{resume_workspace: Map.get(payload, :workspace_path)}}
+      )
+
+      Raxol.Agent.SessionStreamer.emit(payload.session_id, {:done, %{result: :ok}})
+    end
+
+    {model, []}
+  end
+
+  def update(_msg, model), do: {model, []}
+
+  def view(_model), do: %{type: :text, content: "workspace"}
+end


### PR DESCRIPTION
Closes #920.

Both Symphony agent runners accepted `:workspace_path` and neither read it. The
orchestrator's isolation story is that each issue gets its own workspace under
`config.workspace.root`; for these two runners that was a directory that got
created and then not enforced, so the agent's fs tools resolved against
whatever cwd the orchestrator process had. `Runners.Codex` was unaffected (it
takes `thread_sandbox: "workspace-write"` from Codex itself), so the runners
disagreed about whether a Symphony run is confined.

## Runners.RaxolAgent

Threads the workspace into the agent's tool context as `:cwd`, which is what
`Raxol.Agent.Actions.Fs.resolve/2` confines against. Both run paths (simple and
workflow-envelope) build their `Stream.run/2` options through one shared
`__stream_opts__/1` so they cannot drift.

This one is pre-wiring, not a live hole: the runner passes no `:actions`, so a
run has no fs tools to confine yet. Threading the cwd now means tool use lands
into an already-enforced workspace. Wiring `agent.actions` (the moduledoc's
"currently ignored") is a separate decision -- it gives an autonomous agent
tools ahead of the hook/approval layer that moduledoc defers to.

## Runners.RaxolAgentSession

The more exposed of the two, and not latent: it drives a `use Raxol.Agent`
module that declares its own actions, so fs tools there are real today.

It gets the workspace in the `:symphony_start` and `:symphony_resume` payloads.
It cannot *enforce* the boundary, and the moduledoc now says so plainly rather
than implying a guarantee: the agent module owns its own tool-execution path and
constructs the context its Actions receive, and `Raxol.Agent.Session` builds its
Lifecycle options internally with no seam for a caller to inject one. Enforcing
it from Symphony's side would need `Raxol.Agent.Session` to accept
caller-supplied lifecycle options -- worth doing, but a cross-package API change.

## Fail-closed

Both runners now `Keyword.fetch!` the opt, matching `Runners.Codex`. A missing
workspace raises instead of silently running against the orchestrator's cwd --
which is the exact failure mode this issue is about, so `Keyword.get` would have
preserved it for every direct caller. That is what drives the test churn: 13
test files gained a `@workspace` fixture.

`Runner`'s moduledoc documents the requirement where the contract lives.

## Testing

992 pass (969 tests + 23 doctests), 6 excluded. Root and package `mix format`
clean, `--warnings-as-errors` clean, no new credo findings (the one `length/1`
warning is on master too).

Mutation-proven rather than assumed:

- reintroducing the original bug (`%{cwd: File.cwd!()}`) turns all five new
  RaxolAgent confinement tests red;
- misspelling the `Stream.run/2` option key turns the pin test red -- that one
  matters because `Stream.run/2` reads it as `Keyword.get(opts, :context, %{})`,
  so a typo would fall back to an empty context instead of raising;
- dropping the workspace from the session runner's seed payload, and reverting
  its `fetch!` to `get`, each turn their own tests red.

The confinement assertions use the real `Fs.resolve/2` against a real tmp
workspace, no mocks. An end-to-end tool-execution test is not available: the
Mock backend emits only `{:chunk, _}` and `{:done, _}`, so proving a tool call
gets refused would need a test double.

## Manual testing

- [ ] Run the orchestrator against a real tracker issue and confirm agent file
      writes land under `config.workspace.root/<identifier>`, not in the repo
      the orchestrator was started in.
- [ ] Confirm a runner invoked without `:workspace_path` raises rather than
      running.
