### PR TITLE
Fix stdin, timeout and result handling on spawned ports

### DIFF
--- a/packages/raxol_agent/lib/raxol/agent/actions/code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/code.ex
@@ -718,9 +718,22 @@ defmodule Raxol.Agent.Actions.Code do
         # `sleep 600` (and every child it spawned) is actually dead, not
         # orphaned; `Port.close/1` alone leaves the OS process alive.
         Raxol.Agent.Interrupt.kill_os_pid(os_pid)
-        Port.close(port)
+        close_port(port)
         {acc |> Enum.reverse() |> IO.iodata_to_binary(), :timeout}
     end
+  end
+
+  # The SIGKILL above usually brings the port down before this runs -- a port
+  # terminates as soon as its OS process dies -- and `Port.close/1` raises on a
+  # port that is already gone. Unguarded, every genuinely timed-out command
+  # crashed at the caller instead of returning the `:timeout` this function
+  # documents. `Port.info/1` narrows the window but cannot close it, since the
+  # port can die between the check and the close, so the rescue is what makes
+  # this correct. Mirrors `Actions.Shell` and `Backend.Native`.
+  defp close_port(port) do
+    if Port.info(port), do: Port.close(port)
+  rescue
+    ArgumentError -> :ok
   end
 
   defp port_os_pid(port) do

--- a/packages/raxol_agent/lib/raxol/agent/actions/code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/code.ex
@@ -682,8 +682,13 @@ defmodule Raxol.Agent.Actions.Code do
         {String.to_charlist(to_string(k)), String.to_charlist(to_string(v))}
       end)
 
+    # `:in` closes the command's stdin instead of handing it a write pipe
+    # `collect_port/4` never writes to. An open pipe carries nothing and only
+    # ever signals "more input is coming", so a command that reads stdin blocks
+    # until the deadline and comes back `:timeout` having done nothing.
     base = [
       :binary,
+      :in,
       :exit_status,
       :use_stdio,
       :stderr_to_stdout,

--- a/packages/raxol_agent/lib/raxol/agent/actions/code.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/code.ex
@@ -304,7 +304,8 @@ defmodule Raxol.Agent.Actions.Code do
           command: [type: :string],
           stdout: [type: :string],
           exit_status: [type: :integer],
-          truncated: [type: :boolean]
+          truncated: [type: :boolean],
+          timed_out: [type: :boolean]
         ]
       ]
 
@@ -318,16 +319,29 @@ defmodule Raxol.Agent.Actions.Code do
           Raxol.Agent.Actions.Code.run_shell(command, cd, timeout)
 
         {truncated, output} = Raxol.Agent.Actions.Code.truncate_output(output)
+        {exit_status, timed_out} = exit_status(status)
 
         {:ok,
          %{
            command: command,
            stdout: output,
-           exit_status: status,
-           truncated: truncated
+           exit_status: exit_status,
+           truncated: truncated,
+           timed_out: timed_out
          }}
       end
     end
+
+    # `run_shell/4` reports a timeout as the atom `:timeout`, but this action
+    # declares `exit_status` an integer, so returning the atom failed output
+    # validation in `Action.__call__/3`: a timed-out command reached the agent
+    # as `{:error, [exit_status: "must be of type :integer"]}`, naming the wrong
+    # problem and dropping the partial output with it. 124 is what a timeout is
+    # conventionally reported as, and what the sibling `shell` tool already
+    # returns, with `timed_out` carrying the distinction from a command that
+    # genuinely exited 124.
+    defp exit_status(:timeout), do: {124, true}
+    defp exit_status(status) when is_integer(status), do: {status, false}
 
     # No `cd` given → run in the working dir. A `cd` must stay under cwd.
     defp resolve_cd(nil, context), do: {:ok, Fs.working_dir(context)}
@@ -682,10 +696,7 @@ defmodule Raxol.Agent.Actions.Code do
         {String.to_charlist(to_string(k)), String.to_charlist(to_string(v))}
       end)
 
-    # `:in` closes the command's stdin instead of handing it a write pipe
-    # `collect_port/4` never writes to. An open pipe carries nothing and only
-    # ever signals "more input is coming", so a command that reads stdin blocks
-    # until the deadline and comes back `:timeout` having done nothing.
+    # `:in` closes the command's stdin; see `Raxol.Agent.SpawnedPort` for why.
     base = [
       :binary,
       :in,
@@ -723,18 +734,7 @@ defmodule Raxol.Agent.Actions.Code do
     end
   end
 
-  # The SIGKILL above usually brings the port down before this runs -- a port
-  # terminates as soon as its OS process dies -- and `Port.close/1` raises on a
-  # port that is already gone. Unguarded, every genuinely timed-out command
-  # crashed at the caller instead of returning the `:timeout` this function
-  # documents. `Port.info/1` narrows the window but cannot close it, since the
-  # port can die between the check and the close, so the rescue is what makes
-  # this correct. Mirrors `Actions.Shell` and `Backend.Native`.
-  defp close_port(port) do
-    if Port.info(port), do: Port.close(port)
-  rescue
-    ArgumentError -> :ok
-  end
+  defp close_port(port), do: Raxol.Agent.SpawnedPort.close(port)
 
   defp port_os_pid(port) do
     case Port.info(port, :os_pid) do

--- a/packages/raxol_agent/lib/raxol/agent/actions/shell.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/shell.ex
@@ -88,9 +88,14 @@ defmodule Raxol.Agent.Actions.Shell do
     timeout = Map.get(params, :timeout_ms) || @default_timeout_ms
     cwd = Raxol.Agent.Actions.Fs.working_dir(context)
 
+    # `:in` closes the command's stdin instead of handing it a write pipe this
+    # loop never writes to. An open pipe carries nothing and only ever signals
+    # "more input is coming", so a command that reads stdin blocks until the
+    # deadline and gets reported as a timeout it never earned.
     port =
       Port.open({:spawn_executable, shell_path()}, [
         :binary,
+        :in,
         :exit_status,
         :stderr_to_stdout,
         {:args, ["-c", command]},

--- a/packages/raxol_agent/lib/raxol/agent/actions/shell.ex
+++ b/packages/raxol_agent/lib/raxol/agent/actions/shell.ex
@@ -88,10 +88,7 @@ defmodule Raxol.Agent.Actions.Shell do
     timeout = Map.get(params, :timeout_ms) || @default_timeout_ms
     cwd = Raxol.Agent.Actions.Fs.working_dir(context)
 
-    # `:in` closes the command's stdin instead of handing it a write pipe this
-    # loop never writes to. An open pipe carries nothing and only ever signals
-    # "more input is coming", so a command that reads stdin blocks until the
-    # deadline and gets reported as a timeout it never earned.
+    # `:in` closes the command's stdin; see `Raxol.Agent.SpawnedPort` for why.
     port =
       Port.open({:spawn_executable, shell_path()}, [
         :binary,
@@ -204,9 +201,7 @@ defmodule Raxol.Agent.Actions.Shell do
   end
 
   defp close_port(port) do
-    if is_port(port) and not is_nil(Port.info(port)) do
-      Port.close(port)
-    end
+    Raxol.Agent.SpawnedPort.close(port)
   rescue
     _ -> :ok
   catch

--- a/packages/raxol_agent/lib/raxol/agent/backend/native.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/native.ex
@@ -125,14 +125,8 @@ defmodule Raxol.Agent.Backend.Native do
     end
   end
 
-  # `:in` makes the port input-only, so the CLI's stdin is closed instead of
-  # inheriting a write pipe this module never writes to. Nothing here calls
-  # `Port.command/2` -- the prompt goes over argv, built by `driver.args/1` --
-  # so an open pipe carries nothing and only ever signals "more input is
-  # coming". A CLI that reads stdin before doing its work then blocks until the
-  # run times out, having produced nothing. The one case `:in` would break is a
-  # child whose parent-death signal is EOF on stdin, which needs a pipe held
-  # open; no driver here works that way.
+  # `:in` closes the CLI's stdin; the prompt goes over argv via `driver.args/1`.
+  # See `Raxol.Agent.SpawnedPort` for why.
   defp run_port(exe, args, cwd, driver, timeout, caller, ref) do
     port =
       Port.open(
@@ -208,11 +202,7 @@ defmodule Raxol.Agent.Backend.Native do
     send(caller, {ref, {:error, {:exit, status}}})
   end
 
-  defp close(port) do
-    if Port.info(port), do: Port.close(port)
-  rescue
-    ArgumentError -> :ok
-  end
+  defp close(port), do: Raxol.Agent.SpawnedPort.close(port)
 
   defp response(content, usage) do
     %{content: content, usage: usage, metadata: %{backend: :native}}

--- a/packages/raxol_agent/lib/raxol/agent/backend/native.ex
+++ b/packages/raxol_agent/lib/raxol/agent/backend/native.ex
@@ -125,12 +125,27 @@ defmodule Raxol.Agent.Backend.Native do
     end
   end
 
+  # `:in` makes the port input-only, so the CLI's stdin is closed instead of
+  # inheriting a write pipe this module never writes to. Nothing here calls
+  # `Port.command/2` -- the prompt goes over argv, built by `driver.args/1` --
+  # so an open pipe carries nothing and only ever signals "more input is
+  # coming". A CLI that reads stdin before doing its work then blocks until the
+  # run times out, having produced nothing. The one case `:in` would break is a
+  # child whose parent-death signal is EOF on stdin, which needs a pipe held
+  # open; no driver here works that way.
   defp run_port(exe, args, cwd, driver, timeout, caller, ref) do
     port =
       Port.open(
         {:spawn_executable, exe},
-        [:binary, :exit_status, :stderr_to_stdout, :hide, {:line, @line_bytes}, {:args, args}] ++
-          cd_opt(cwd)
+        [
+          :binary,
+          :in,
+          :exit_status,
+          :stderr_to_stdout,
+          :hide,
+          {:line, @line_bytes},
+          {:args, args}
+        ] ++ cd_opt(cwd)
       )
 
     drain(port, driver, timeout, caller, ref, %{buffer: "", content: "", usage: %{}, done: false})

--- a/packages/raxol_agent/lib/raxol/agent/spawned_port.ex
+++ b/packages/raxol_agent/lib/raxol/agent/spawned_port.ex
@@ -1,0 +1,86 @@
+defmodule Raxol.Agent.SpawnedPort do
+  @moduledoc """
+  Lifecycle helpers shared by every port that spawns an OS process.
+
+  The agent spawns processes from four places -- the native CLI backend, the
+  two shell tools, and the directive executor -- and each one had drifted into
+  its own answer for the same two questions. This module holds the answers
+  once.
+
+  ## Why stdin is closed
+
+  Every spawner here passes its input over argv: the native backend puts the
+  prompt in `-p`, and both shell tools pass the command to `sh -c`. None of
+  them ever calls `Port.command/2`. Opening the port for both directions
+  therefore hands the child a write pipe that carries nothing and is never
+  closed, which reads to the child as "more input is coming" forever. Anything
+  that drains stdin before doing its work then blocks until the caller's
+  deadline and dies having produced nothing.
+
+  Passing `:in` opens the port for input only, which points the child's stdin
+  at `/dev/null` so a read returns EOF immediately. The one case it would break
+  is a child whose parent-death signal is EOF on stdin, which needs the pipe
+  held open; nothing spawned here works that way.
+
+  The opposite case -- a child that must actually RECEIVE stdin -- is not
+  solvable this way at all, because a spawned port cannot half-close. See
+  `Raxol.System.PortCommand`, which feeds stdin from a temp file for exactly
+  that reason.
+
+  Note what closing stdin changes besides the hang. A command that prompts for
+  input used to block on the open pipe and get killed at the deadline; it now
+  reads EOF and continues down its non-interactive path, which for tools like
+  `ssh`, `git` and `curl` can mean falling through to another credential source
+  rather than failing. That is the correct behaviour for a shell tool, and the
+  sandbox (`Raxol.Agent.Actions.Code.shell_allow/2`, the jail flag, the
+  allow/denylist) is what decides whether a command runs at all -- a stalled
+  pipe was never a security control. It is recorded here because the change is
+  easy to read as purely a hang fix.
+
+  ## Why closing needs a guard and a drain
+
+  On a timeout the caller SIGKILLs the process group first, so by the time the
+  port is closed it has usually already died on its own -- and `Port.close/1`
+  raises on a port that is already gone. `Port.info/1` narrows that window but
+  cannot close it, since the port can die between the check and the close, so
+  the rescue is what makes it correct rather than merely unlikely.
+
+  A port that died on its own has already queued its `{port, {:exit_status,
+  _}}` to the owner, and closing does not retract a message that was already
+  sent. Left there it never matches again -- every collect loop matches on its
+  own `^port` -- so it accumulates in a long-lived session process that runs
+  many commands. `close/1` therefore drains that message after closing.
+  """
+
+  @doc """
+  Close a spawned port and drain the exit status it may already have queued.
+
+  Safe to call on a port that has already died, which is the common case on a
+  timeout path. Always returns `:ok`.
+
+  The drain is `after 0`: it collects the status when the port died before the
+  close, which is precisely the case that leaks. A status that arrives later
+  still goes unread -- closing a live port suppresses it, so that window is
+  narrow, but it is not zero.
+  """
+  @spec close(port()) :: :ok
+  def close(port) when is_port(port) do
+    safe_close(port)
+    drain_exit_status(port)
+  end
+
+  defp safe_close(port) do
+    if Port.info(port), do: Port.close(port)
+    :ok
+  rescue
+    ArgumentError -> :ok
+  end
+
+  defp drain_exit_status(port) do
+    receive do
+      {^port, {:exit_status, _}} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+end

--- a/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
@@ -374,6 +374,17 @@ defmodule Raxol.Agent.Actions.CodeTest do
       assert status == 3
     end
 
+    test "a command that reads stdin sees EOF instead of an open pipe" do
+      # `run_shell/4` never writes to the port, so an inherited write pipe only
+      # signals "more input is coming". Without `:in`, `cat` blocks until the
+      # deadline and `exit_status` comes back `:timeout`.
+      assert {:ok, result} =
+               Code.Bash.run(%{command: "cat", timeout_ms: 2_000}, %{})
+
+      assert result.exit_status == 0
+      assert result.truncated == false
+    end
+
     test "runs in the working directory by default", %{dir: dir} do
       # `/bin/sh pwd` reports the physical path (macOS resolves /var ->
       # /private/var), so match on the unique dir basename rather than the

--- a/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
@@ -374,25 +374,50 @@ defmodule Raxol.Agent.Actions.CodeTest do
       assert status == 3
     end
 
-    test "a timed-out command reports :timeout instead of raising" do
-      # The process-group SIGKILL on the timeout path brings the port down as
-      # soon as the OS process dies, and `Port.close/1` raises on an already
-      # dead port. The tool crashed at the caller rather than returning the
-      # `:timeout` its own docs promise.
+    # These two go through `call/2` rather than `run/2` deliberately. `run/2`
+    # skips output-schema validation, so a test written against it passes while
+    # the path the tool loop actually takes fails.
+    test "a timed-out command reports 124 and survives output validation" do
+      # Two defects met here. The port was closed unguarded, so the SIGKILL on
+      # the line above left `Port.close/1` raising on an already dead port; and
+      # `run_shell/4` reports a timeout as the atom `:timeout` against an
+      # `exit_status` field declared as an integer, so the agent got
+      # `{:error, [exit_status: "must be of type :integer"]}` and no output.
       assert {:ok, result} =
-               Code.Bash.run(%{command: "sleep 5", timeout_ms: 200}, %{})
+               Code.Bash.call(%{command: "sleep 5", timeout_ms: 200}, %{})
 
-      assert result.exit_status == :timeout
+      assert result.exit_status == 124
+      assert result.timed_out == true
+    end
+
+    test "a timed-out command leaves no port message in the caller's mailbox" do
+      # The SIGKILL brings the port down before the close, so its exit status is
+      # already queued and closing does not retract it. Nothing matches it
+      # afterwards -- every collect loop matches its own `^port` -- so an
+      # undrained message accumulates for the life of the session process.
+      assert {_out, :timeout} =
+               Code.run_shell("sleep 5", System.tmp_dir!(), 200)
+
+      {:messages, messages} = Process.info(self(), :messages)
+
+      port_messages =
+        Enum.filter(messages, fn
+          {port, {:exit_status, _}} when is_port(port) -> true
+          _ -> false
+        end)
+
+      assert port_messages == []
     end
 
     test "a command that reads stdin sees EOF instead of an open pipe" do
       # `run_shell/4` never writes to the port, so an inherited write pipe only
       # signals "more input is coming". Without `:in`, `cat` blocks until the
-      # deadline and `exit_status` comes back `:timeout`.
+      # deadline and comes back timed out.
       assert {:ok, result} =
-               Code.Bash.run(%{command: "cat", timeout_ms: 2_000}, %{})
+               Code.Bash.call(%{command: "cat", timeout_ms: 2_000}, %{})
 
       assert result.exit_status == 0
+      assert result.timed_out == false
       assert result.truncated == false
     end
 

--- a/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/code_test.exs
@@ -374,6 +374,17 @@ defmodule Raxol.Agent.Actions.CodeTest do
       assert status == 3
     end
 
+    test "a timed-out command reports :timeout instead of raising" do
+      # The process-group SIGKILL on the timeout path brings the port down as
+      # soon as the OS process dies, and `Port.close/1` raises on an already
+      # dead port. The tool crashed at the caller rather than returning the
+      # `:timeout` its own docs promise.
+      assert {:ok, result} =
+               Code.Bash.run(%{command: "sleep 5", timeout_ms: 200}, %{})
+
+      assert result.exit_status == :timeout
+    end
+
     test "a command that reads stdin sees EOF instead of an open pipe" do
       # `run_shell/4` never writes to the port, so an inherited write pipe only
       # signals "more input is coming". Without `:in`, `cat` blocks until the

--- a/packages/raxol_agent/test/raxol/agent/actions/shell_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/actions/shell_test.exs
@@ -27,6 +27,17 @@ defmodule Raxol.Agent.Actions.ShellTest do
       assert result.exit_code == 7
       assert result.timed_out == false
     end
+
+    test "a command that reads stdin sees EOF instead of an open pipe" do
+      # Nothing ever writes to this port, so an inherited write pipe carries
+      # nothing and only signals "more input is coming". Without `:in`, `cat`
+      # blocks until the deadline and the tool reports a timeout it never
+      # earned. The short timeout keeps the regression cheap to observe.
+      assert {:ok, result} = Shell.run(%{command: "cat", timeout_ms: 2_000}, %{})
+
+      assert result.exit_code == 0
+      assert result.timed_out == false
+    end
   end
 
   describe "wall-clock timeout kills the OS process group" do

--- a/packages/raxol_agent/test/raxol/agent/backend/native_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/backend/native_test.exs
@@ -64,6 +64,16 @@ defmodule Raxol.Agent.Backend.NativeTest do
       assert [{:chunk, "partial"}, {:done, %{content: "partial"}}] = events
     end
 
+    test "a CLI that reads stdin sees EOF instead of an open pipe" do
+      # The port is never written to, so a child that reads stdin before doing
+      # its work blocks until the run times out. The short timeout keeps the
+      # regression cheap to observe: without `:in` this is `{:error, :timeout}`.
+      {:ok, stream} =
+        Native.stream(FakeDriver, messages(), extra_args: ["stdin_read"], timeout: 2_000)
+
+      assert [{:done, %{content: "read stdin"}}] = Enum.to_list(stream)
+    end
+
     test "returns an error when the executable is not found" do
       defmodule MissingDriver do
         @behaviour Raxol.Agent.NativeHarness

--- a/packages/raxol_agent/test/raxol/agent/spawned_port_test.exs
+++ b/packages/raxol_agent/test/raxol/agent/spawned_port_test.exs
@@ -1,0 +1,59 @@
+defmodule Raxol.Agent.SpawnedPortTest do
+  @moduledoc """
+  Contract for the shared close path. Every spawner that kills on a deadline
+  reaches `close/1` with a port that has usually already died, so both the
+  guard and the drain are load-bearing rather than defensive.
+  """
+
+  use ExUnit.Case, async: true
+
+  @moduletag :unix_only
+
+  alias Raxol.Agent.SpawnedPort
+
+  defp spawn_sh(command) do
+    Port.open(
+      {:spawn_executable, "/bin/sh"},
+      [:binary, :in, :exit_status, {:args, ["-c", command]}]
+    )
+  end
+
+  test "closing a live port returns :ok" do
+    assert :ok = SpawnedPort.close(spawn_sh("sleep 5"))
+  end
+
+  test "closing a port that already exited does not raise" do
+    port = spawn_sh("exit 3")
+
+    # Consume the status so the port is provably gone before the close --
+    # `Port.close/1` raises on a dead port, which is what the guard exists for.
+    assert_receive {^port, {:exit_status, 3}}, 5_000
+
+    assert :ok = SpawnedPort.close(port)
+  end
+
+  test "an exit status queued before the close is drained, not left behind" do
+    port = spawn_sh("exit 0")
+
+    # Wait for the port to die on its own without consuming its message, so
+    # `close/1` meets exactly the state a killed process leaves behind.
+    wait_until_dead(port)
+
+    assert :ok = SpawnedPort.close(port)
+    refute_received {^port, {:exit_status, _}}
+  end
+
+  defp wait_until_dead(port, budget_ms \\ 3_000)
+
+  defp wait_until_dead(port, budget_ms) when budget_ms <= 0,
+    do: flunk("port #{inspect(port)} never exited")
+
+  defp wait_until_dead(port, budget_ms) do
+    if Port.info(port) do
+      Process.sleep(25)
+      wait_until_dead(port, budget_ms - 25)
+    else
+      :ok
+    end
+  end
+end

--- a/packages/raxol_agent/test/support/fake_stream_cli.sh
+++ b/packages/raxol_agent/test/support/fake_stream_cli.sh
@@ -27,6 +27,12 @@ case "$mode" in
   no_done)
     printf '%s\n' '{"type":"assistant","message":{"content":[{"type":"text","text":"partial"}]}}'
     ;;
+  stdin_read)
+    # Reads stdin to EOF before doing its work, the way a CLI that accepts a
+    # piped prompt does. Hangs forever if the port leaves a write pipe open.
+    cat >/dev/null
+    printf '%s\n' '{"type":"result","subtype":"success","result":"read stdin","usage":{}}'
+    ;;
   *)
     printf '%s\n' '{"type":"result","subtype":"success","result":"","usage":{}}'
     ;;


### PR DESCRIPTION
Four defects on the ports raxol spawns commands through. The first was the
issue; the rest surfaced while testing it, and each one is what let the next
stay hidden.

Closes #964.

## 1. Three ports left stdin open

Three spawn sites opened their port without `:in`, so the spawned process
inherited a stdin pipe held open for the port's lifetime and never closed.
None of the three collect loops ever calls `Port.command/2`, so the pipe
carried nothing and only ever signalled "more input is coming".

Anything that reads stdin before doing its work blocked until the deadline:

| Site | Symptom |
| --- | --- |
| `Backend.Native.run_port/7` | native CLI run dies `{:error, :timeout}` after the 120s default, having produced nothing |
| `Actions.Shell.run_allowed/3` | `shell` tool reports a timeout it never earned |
| `Actions.Code.run_shell/4` | `bash` tool comes back timed out |

`Directive.Executor` already passed `:in`, so this was three of four sibling
spawners disagreeing about the same option.

For the native backend this is latent for `claude`, `cursor` and `grok`, which
pass their prompt over `-p` and do not read stdin, and fatal for any CLI that
does -- which is what makes it a blocker for handing a fourth native driver to
that backend. For the two shell tools it bites any command expecting a pipe:
`cat` with no args, a bare `read`, anything that drains stdin first.

## 2. The bash timeout path raised instead of returning

`Code.run_shell/4` closed the port unguarded. The process-group SIGKILL on the
line above brings the port down as soon as the OS process dies, and
`Port.close/1` raises on a port that is already gone, so every genuinely
timed-out `bash` call crashed at the caller instead of returning the
`{output, :timeout}` its `@doc` promises. The kill runs first, so nothing
leaked -- the caller just got an `ArgumentError` where it expected a result.

The timeout path had no test coverage at all, which is how it survived.

## 3. Guarding that close traded a crash for a silent leak

A port killed on the timeout path has already queued its
`{port, {:exit_status, _}}`, and closing does not retract a message already
sent. Before the guard the raise killed the caller and took the mailbox with
it; after it, the message accumulates, because every collect loop matches only
its own `^port`. Measured in a long-lived process:

```
before drain:  {:messages, [{#Port<0.13>, {:exit_status, 137}}]}
after drain:   {:messages, []}
```

The drain is `after 0`, which covers the case that actually leaks -- a port
that died before the close. A status arriving later still goes unread; the
moduledoc says so rather than implying the window is closed.

## 4. A timed-out bash call never reached the agent as a timeout

`Code.Bash` declares `exit_status` an integer; `run_shell/4` reports a timeout
as the atom `:timeout`. Output validation in `Action.__call__/3` therefore
rejected the whole result:

```elixir
Raxol.Agent.Actions.Code.Bash.call(%{command: "sleep 5", timeout_ms: 200}, %{})
# before: {:error, [exit_status: "must be of type :integer"]}
# after:  {:ok, %{exit_status: 124, timed_out: true, stdout: "", ...}}
```

The agent got a schema error naming the wrong problem and lost the partial
output with it. Now 124 plus a `timed_out` flag, matching what the sibling
`shell` tool already returns.

My first tests used `run/2`, which skips output validation and hid this
completely -- they passed while the path the tool loop actually takes failed.
They now go through `call/2`.

## Consolidation

`Actions.Shell`, `Backend.Native` and `Actions.Code` each had their own private
port-close, with two guard shapes and two rescue strictnesses between them.
Adding a fourth variant contradicted this PR's own premise, that a missing
option diverging across sibling spawners is what caused the bug in the first
place. `Raxol.Agent.SpawnedPort` now holds close-and-drain once, and carries
the canonical `:in` rationale the three call sites had been repeating in
near-identical comments.

## Evidence

Mechanism proved before each stdin fix, against `/bin/cat` and `/bin/sh -c cat`
so the reproduction needs nothing installed, timed on the child's own process:

```
native.ex opts as-is               :BLOCKED     ms=3003
native.ex opts + :in               {:exit, 0}   ms=3

shell.ex as-is                     :BLOCKED     ms=3006
shell.ex + :in                     {:exit, 0}   ms=15
code.ex as-is (:use_stdio)         :BLOCKED     ms=3005
code.ex + :in (:use_stdio)         {:exit, 0}   ms=13
```

The last pair matters on its own: `Code.run_shell/4` sets `:use_stdio`
explicitly, so `:in` had to be shown to compose with it rather than assumed to.

What `:in` actually does to fd 0, rather than assumed: `cr--r--r-- 1 root wheel
0x3000002 /dev/fd/0` -- a character device, i.e. `/dev/null`, not a closed
descriptor. That is why `cat` reads EOF and exits 0 instead of failing `EBADF`.

RED before GREEN for every fix. The native backend gets a `stdin_read` scenario
in the fake CLI that reads stdin to EOF before emitting its result; both shell
tools get a `cat` command; the timeout path gets `sleep 5` under a 200ms
deadline; the leak gets a mailbox assertion.

## Diagnostic traps worth knowing

Probing with `--help` proves nothing: help short-circuits before the stdin read
and reports success under both configurations. A shell pipeline is also the
wrong instrument, since the shell waits for every pipeline member, so a timeout
reflects the upstream member rather than the process under test. Only a command
that reaches the stdin read, timed on its own process, distinguishes the two.

And for an Action, `run/2` is the wrong entry point to test through: it skips
the output schema that `call/2` enforces.

## Behaviour change worth knowing

Closing stdin is not only a hang fix. A command that prompts for input used to
block on the open pipe and get SIGKILLed at the deadline; it now reads EOF and
continues down its non-interactive path, which for `ssh`, `git` and `curl` can
mean falling through to another credential source rather than failing. That is
correct for a shell tool -- the sandbox (`shell_allow/2`, the jail flag, the
allow/denylist) decides whether a command runs at all, and a stalled pipe was
never a security control -- but it is easy to read this as purely a hang fix,
so `SpawnedPort`'s moduledoc records it.

Prior art: `Raxol.System.PortCommand` in main raxol already documents this
failure class from the other direction, for children that must actually
*receive* stdin. A spawned port cannot half-close, so that case needs a
temp-file redirect and this one needs `:in`. The knowledge existed in the repo
and had not reached raxol_agent's spawners.

## Manual testing

- [x] Reproduced all three stdin hangs against real binaries with the exact
      port option sets, before any change (blocked ~3000ms vs exit 0 in 3-15ms)
- [x] Confirmed `:in` composes with `Code.run_shell/4`'s explicit `:use_stdio`
- [x] Confirmed fd 0 becomes `/dev/null`, not a closed descriptor
- [x] Reproduced the timeout raise, the mailbox leak, and the validation
      rejection directly via `mix run` before their fixes, and re-ran each
      probe after
- [x] Each new test fails before its fix and passes after
- [x] Full package suite: `cd packages/raxol_agent && MIX_ENV=test mix test`
      -- 2606 passed (19 properties, 2587 tests), 38 excluded
- [x] `mix format --check-formatted` clean from the repo root
- [ ] Exercise a real native backend (`claude` / `cursor` / `grok`) end to end,
      confirming no behaviour change on the paths that never read stdin

One run of the full suite failed `TurnRunnerTest` "hung backend: Interrupt
fires promptly" on a 2s `assert_receive`. It passes in isolation, passed in
four other full runs of this branch, and uses an interrupt double with no port
involved -- the #909 nondeterminism, not a regression from this change.
