### PR TITLE
Fix 19 audited defects in raxol_symphony

### DIFF
--- a/packages/raxol_symphony/RUNBOOK.md
+++ b/packages/raxol_symphony/RUNBOOK.md
@@ -62,9 +62,10 @@ references the issue. Stop when the PR is open.
 ```
 
 `workflow_mode: graph_parallel` fans up to `workflow_parallelism` eligible
-issues through one graph run per tick (no pause support). Use `default` for
-the simplest inline path, or `graph` for the per-node checkpointed pipeline
-with runner pause/resume.
+issues through one graph run per tick. A branch that pauses is parked as
+resumable, the same way a sequential run is; compensating the sibling branches
+that already completed is still open (#517). Use `default` for the simplest
+inline path, or `graph` for the per-node checkpointed pipeline.
 
 ## 4. start the orchestrator
 

--- a/packages/raxol_symphony/RUNBOOK.md
+++ b/packages/raxol_symphony/RUNBOOK.md
@@ -87,8 +87,12 @@ Watch / JSON API). All six consume the same snapshot over `Phoenix.PubSub`.
 
 ## 5. Capture evidence
 
-Per-run asciicasts land under `<workspace>/.raxol_symphony/run-<attempt>.cast`
-when `recording.enabled: true`. Aggregate CI + PR evidence for a run:
+Asciicasts land under `<workspace>/.raxol_symphony/run-<attempt>-<stamp>.cast`
+when `recording.enabled: true`. One file per dispatch, not per run: a run that
+continues or resumes writes a further fragment each time rather than truncating
+the one before it, so replay a long run fragment by fragment in dispatch order.
+Fragments live until the workspace is removed. Aggregate CI + PR evidence for a
+run:
 
 ```elixir
 Raxol.Symphony.Evidence.collect(config, %{

--- a/packages/raxol_symphony/lib/raxol/symphony/config.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/config.ex
@@ -114,6 +114,7 @@ defmodule Raxol.Symphony.Config do
   @spec load_and_validate(Path.t()) :: {:ok, t()} | {:error, term()}
   def load_and_validate(path) do
     with {:ok, workflow} <- Raxol.Symphony.Workflow.load(path),
+         :ok <- Schema.validate_sections(workflow.config),
          config <- from_workflow(workflow, Path.expand(path)),
          :ok <- Schema.validate(config) do
       {:ok, config}

--- a/packages/raxol_symphony/lib/raxol/symphony/config.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/config.ex
@@ -64,6 +64,10 @@ defmodule Raxol.Symphony.Config do
   @default_max_concurrent_agents 10
   @default_max_turns 20
   @default_max_retry_backoff_ms 300_000
+  # Consecutive tracker outages a single retry waits out before the claim is
+  # released back to the poll path. At the default backoff this is roughly half
+  # an hour of an unreachable tracker (10s doubling to the 300s ceiling).
+  @default_max_tracker_requeues 10
   @default_codex_command "codex app-server"
   @default_codex_api_key_env "OPENAI_API_KEY"
   @default_turn_timeout_ms 3_600_000
@@ -189,6 +193,8 @@ defmodule Raxol.Symphony.Config do
       max_turns: Map.get(section, :max_turns, @default_max_turns),
       max_retry_backoff_ms:
         Map.get(section, :max_retry_backoff_ms, @default_max_retry_backoff_ms),
+      max_tracker_requeues:
+        Map.get(section, :max_tracker_requeues, @default_max_tracker_requeues),
       max_concurrent_agents_by_state:
         normalize_state_map(Map.get(section, :max_concurrent_agents_by_state, %{}))
     }

--- a/packages/raxol_symphony/lib/raxol/symphony/config/schema.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/config/schema.ex
@@ -184,8 +184,9 @@ defmodule Raxol.Symphony.Config.Schema do
 
   defp validate_agent(agent) do
     with :ok <- positive_integer(agent.max_concurrent_agents, :max_concurrent_agents),
-         :ok <- positive_integer(agent.max_turns, :max_turns) do
-      positive_integer(agent.max_retry_backoff_ms, :max_retry_backoff_ms)
+         :ok <- positive_integer(agent.max_turns, :max_turns),
+         :ok <- positive_integer(agent.max_retry_backoff_ms, :max_retry_backoff_ms) do
+      positive_integer(agent.max_tracker_requeues, :max_tracker_requeues)
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/config/schema.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/config/schema.ex
@@ -35,8 +35,32 @@ defmodule Raxol.Symphony.Config.Schema do
           | :reviewer_kind_must_differ
           | {:invalid_ssh_host, term()}
           | {:invalid_value, atom(), term()}
+          | {:workflow_section_not_a_map, [atom()]}
 
   @codex_auth_modes [:inherit, :api_key, :codex_home]
+
+  # Front-matter paths that are read as maps. A mis-indented edit leaves a
+  # scalar, a list, or (most often) nothing at all under one of these keys,
+  # and reading that as a map raises BadMapError. Most raise in the `Config`
+  # section builders, which escapes WorkflowStore's last-known-good fallback
+  # and takes the Symphony tree down. `runner.agent` is stored raw and read by
+  # the runner instead, so it raises later, once per dispatched run, with only
+  # a stacktrace in a worker task to go on. Checked against the raw front
+  # matter so either way the typo comes back as an error tuple at load.
+  @map_sections [
+    [:tracker],
+    [:polling],
+    [:workspace],
+    [:hooks],
+    [:agent],
+    [:codex],
+    [:codex, :auth],
+    [:runner],
+    [:runner, :agent],
+    [:review],
+    [:recording],
+    [:worker]
+  ]
 
   @doc """
   Validates a config struct. Returns `:ok` or `{:error, reason}`.
@@ -65,6 +89,41 @@ defmodule Raxol.Symphony.Config.Schema do
       end
     end
   end
+
+  @doc """
+  Validates the shape of the raw front-matter map before it is built into a
+  `Config.t()`.
+
+  Every section that is later read as a map must be a map (or absent).
+  Returns `:ok` or `{:error, {:workflow_section_not_a_map, path}}`.
+  """
+  @spec validate_sections(map()) :: :ok | {:error, error()}
+  def validate_sections(raw) when is_map(raw) do
+    Enum.reduce_while(@map_sections, :ok, fn path, :ok ->
+      case fetch_section(raw, path) do
+        :absent -> {:cont, :ok}
+        {:ok, value} when is_map(value) -> {:cont, :ok}
+        {:ok, _malformed} -> {:halt, {:error, {:workflow_section_not_a_map, path}}}
+      end
+    end)
+  end
+
+  defp fetch_section(map, [key]) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> {:ok, value}
+      :error -> :absent
+    end
+  end
+
+  defp fetch_section(map, [key | rest]) when is_map(map) do
+    case Map.fetch(map, key) do
+      {:ok, value} -> fetch_section(value, rest)
+      :error -> :absent
+    end
+  end
+
+  # A malformed parent is reported by its own entry, which comes first.
+  defp fetch_section(_not_a_map, _path), do: :absent
 
   # -- Tracker ----------------------------------------------------------------
 

--- a/packages/raxol_symphony/lib/raxol/symphony/config/schema.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/config/schema.ex
@@ -71,21 +71,34 @@ defmodule Raxol.Symphony.Config.Schema do
   defp validate_tracker(%{kind: nil}), do: {:error, :missing_tracker_kind}
 
   defp validate_tracker(%{kind: kind} = tracker) do
-    cond do
-      kind not in @supported_tracker_kinds ->
-        {:error, {:unsupported_tracker_kind, kind}}
+    with :ok <- state_list(tracker.active_states, :tracker_active_states),
+         :ok <- state_list(tracker.terminal_states, :tracker_terminal_states) do
+      cond do
+        kind not in @supported_tracker_kinds ->
+          {:error, {:unsupported_tracker_kind, kind}}
 
-      tracker.kind == "memory" ->
-        :ok
+        tracker.kind == "memory" ->
+          :ok
 
-      blank?(tracker.api_key) ->
-        {:error, :missing_tracker_api_key}
+        blank?(tracker.api_key) ->
+          {:error, :missing_tracker_api_key}
 
-      tracker.kind == "linear" and blank?(tracker.project_slug) ->
-        {:error, :missing_tracker_project_slug}
+        tracker.kind == "linear" and blank?(tracker.project_slug) ->
+          {:error, :missing_tracker_project_slug}
 
-      true ->
-        :ok
+        true ->
+          :ok
+      end
+    end
+  end
+
+  # `Issue.active?/2` guards on a list and downcases each entry, so anything
+  # else reaches the poll tick as a raise rather than a preflight error.
+  defp state_list(states, name) do
+    if is_list(states) and Enum.all?(states, &is_binary/1) do
+      :ok
+    else
+      {:error, {:invalid_value, name, states}}
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/evidence/capture.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/evidence/capture.ex
@@ -31,6 +31,7 @@ defmodule Raxol.Symphony.Evidence.Capture do
   @default_width 80
   @default_height 24
   @max_text_bytes 16_384
+  @truncation_marker "...[truncated]"
 
   @type opts :: [
           path: Path.t(),
@@ -214,8 +215,25 @@ defmodule Raxol.Symphony.Evidence.Capture do
   defp truncate(text, limit) when byte_size(text) <= limit, do: text
 
   defp truncate(text, limit) do
-    head_size = limit - 13
-    <<head::binary-size(^head_size), _::binary>> = text
-    head <> "...[truncated]"
+    text
+    |> binary_part(0, limit - byte_size(@truncation_marker))
+    |> valid_prefix()
+    |> Kernel.<>(@truncation_marker)
+  end
+
+  # The budget is bytes, so the cut can land inside a multi-byte
+  # codepoint; Jason rejects the invalid binary that would leave behind.
+  # A codepoint is at most four bytes, so three trims settle any cut. A
+  # head still invalid after that was invalid before the cut (a tool
+  # result carrying raw binary), and scanning the whole 16 KB head byte
+  # by byte would not rescue it -- leave it for the encoder to drop.
+  defp valid_prefix(head, trims_left \\ 3)
+  defp valid_prefix(head, 0), do: head
+
+  defp valid_prefix(head, trims_left) do
+    case String.valid?(head) do
+      true -> head
+      false -> head |> binary_part(0, byte_size(head) - 1) |> valid_prefix(trims_left - 1)
+    end
   end
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/evidence/capture.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/evidence/capture.ex
@@ -12,9 +12,10 @@ defmodule Raxol.Symphony.Evidence.Capture do
       header     -- {"version":2, "width":80, "height":24, "timestamp":<unix>, ...}
       frame...   -- [<elapsed_seconds>, "o", "<text>\\r\\n"]
 
-  The file is opened in `:append` mode and synced on every frame, so a
-  partial cast survives a BEAM crash mid-run -- asciinema happily replays
-  whatever frames the file contains.
+  Each dispatch gets its own file (`path_for/2` mints a fresh name), so a
+  run that takes several dispatches to finish leaves several fragments
+  rather than one cast. asciinema happily replays whatever frames a
+  fragment contains, including a partial one.
 
   ## Failure mode
 
@@ -80,20 +81,31 @@ defmodule Raxol.Symphony.Evidence.Capture do
   end
 
   @doc """
-  Path constructor: `<workspace>/.raxol_symphony/run-<attempt>.cast`.
+  Path constructor: `<workspace>/.raxol_symphony/run-<attempt>-<stamp>.cast`.
 
-  When `attempt` is nil, a single timestamp is used so concurrent
-  retries land on distinct files.
+  The stamp makes the name unique per dispatch, not per attempt. The
+  orchestrator re-enters the same workspace with the same attempt on
+  every continuation retry and on every resume, and a name stable across
+  those would have the next capture truncate the stretch the previous
+  one recorded. `Evidence.Recording` advertises every `*.cast` in the
+  directory, so the extra files stay visible.
   """
   @spec path_for(Path.t(), non_neg_integer() | nil) :: Path.t()
   def path_for(workspace, attempt) when is_binary(workspace) do
-    suffix =
+    prefix =
       case attempt do
-        n when is_integer(n) and n >= 0 -> Integer.to_string(n)
-        _ -> Integer.to_string(System.unique_integer([:positive, :monotonic]))
+        n when is_integer(n) and n >= 0 -> "run-#{n}-"
+        _ -> "run-"
       end
 
-    Path.join([workspace, ".raxol_symphony", "run-#{suffix}.cast"])
+    Path.join([workspace, ".raxol_symphony", prefix <> dispatch_stamp() <> ".cast"])
+  end
+
+  # Wall clock disambiguates across BEAM restarts (the unique integer
+  # restarts with the VM and would collide with a prior boot's files);
+  # the unique integer disambiguates within one millisecond.
+  defp dispatch_stamp do
+    "#{System.os_time(:millisecond)}-#{System.unique_integer([:positive, :monotonic])}"
   end
 
   # ---------------------------------------------------------------------------

--- a/packages/raxol_symphony/lib/raxol/symphony/evidence/capture.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/evidence/capture.ex
@@ -19,10 +19,13 @@ defmodule Raxol.Symphony.Evidence.Capture do
 
   ## Failure mode
 
-  If the cast file can't be opened (e.g., directory creation fails),
-  `start_link/1` returns `{:ok, pid}` for a no-op process and logs a
-  warning. `record/2` and `stop/1` then become no-ops. The run itself
-  is never blocked by recording failures.
+  If the cast file can't be opened or its header can't be written (e.g.,
+  directory creation fails, the disk is full), `start/1` returns
+  `{:ok, pid}` for a no-op process and logs a warning. `record/2` and
+  `stop/1` then become no-ops. A frame the JSON encoder rejects is
+  dropped; a write the device rejects retires the recording. The run
+  itself is never blocked by recording failures, and the process is
+  unlinked so a fault here cannot reach the orchestrator.
   """
 
   use Raxol.Core.Behaviours.BaseManager
@@ -46,10 +49,29 @@ defmodule Raxol.Symphony.Evidence.Capture do
   # Client API
   # ---------------------------------------------------------------------------
 
-  @doc "Starts a capture process. Always returns `{:ok, pid}` (fail-soft)."
-  @spec start_link(opts()) :: GenServer.on_start()
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
+  @doc """
+  Starts a capture process. Always returns `{:ok, pid}` (fail-soft).
+
+  The process is deliberately NOT linked to its caller: recording is
+  best-effort evidence, and the orchestrator does not trap exits, so a
+  link makes every capture fault fatal to the run loop. The caller is
+  monitored instead, which also cleans up better than a link did -- a
+  caller exiting `:normal` leaves a linked child running.
+  """
+  @spec start(opts()) :: GenServer.on_start()
+  def start(opts) do
+    GenServer.start(__MODULE__, Keyword.put(opts, :owner, self()))
+  end
+
+  # BaseManager hands every manager a linked start and a `child_spec/1`
+  # pointing at it. Both are wrong here for the reason above, so refuse
+  # rather than let a supervisor quietly wire recording into the run's
+  # fate.
+  @doc false
+  def start_link(_opts) do
+    raise ArgumentError,
+          "#{inspect(__MODULE__)} must be started unlinked via start/1: " <>
+            "a linked capture makes a recording fault fatal to the run it observes"
   end
 
   @doc "Records a Symphony run event. Returns `:ok`. Safe with `nil` pid."
@@ -119,14 +141,15 @@ defmodule Raxol.Symphony.Evidence.Capture do
     height = Keyword.get(opts, :height, @default_height)
     title = Keyword.get(opts, :title)
 
-    case open_file(path) do
-      {:ok, io} ->
-        :ok = write_header(io, width, height, title)
+    owner_ref = monitor_owner(Keyword.get(opts, :owner))
 
+    case start_cast(path, width, height, title) do
+      {:ok, io} ->
         {:ok,
          %{
            io: io,
            path: path,
+           owner_ref: owner_ref,
            start_us: System.monotonic_time(:microsecond)
          }}
 
@@ -135,18 +158,48 @@ defmodule Raxol.Symphony.Evidence.Capture do
           "symphony.evidence.capture.open_failed path=#{path} reason=#{inspect(reason)}"
         )
 
-        {:ok, %{io: nil, path: path, start_us: 0}}
+        {:ok, %{io: nil, path: path, owner_ref: owner_ref, start_us: 0}}
     end
   end
+
+  defp monitor_owner(owner) when is_pid(owner), do: Process.monitor(owner)
+  defp monitor_owner(_owner), do: nil
 
   @impl Raxol.Core.Behaviours.BaseManager
   def handle_manager_cast({:record, _event, _at_us}, %{io: nil} = state), do: {:noreply, state}
 
   def handle_manager_cast({:record, event, at_us}, %{io: io, start_us: start_us} = state) do
     elapsed_seconds = (at_us - start_us) / 1_000_000.0
-    text = format_event(event)
 
-    :ok = write_frame(io, elapsed_seconds, text)
+    case write_frame(io, elapsed_seconds, format_event(event)) do
+      :ok ->
+        {:noreply, state}
+
+      {:error, {:encode, reason}} ->
+        Logger.warning(
+          "symphony.evidence.capture.frame_dropped path=#{state.path} reason=#{inspect(reason)}"
+        )
+
+        {:noreply, state}
+
+      {:error, reason} ->
+        # The device is gone (full disk, closed fd): retire the recording
+        # rather than raising on every subsequent frame.
+        Logger.warning(
+          "symphony.evidence.capture.write_failed path=#{state.path} reason=#{inspect(reason)}"
+        )
+
+        {:noreply, %{state | io: nil}}
+    end
+  end
+
+  @impl Raxol.Core.Behaviours.BaseManager
+  def handle_manager_info({:DOWN, ref, :process, _pid, _reason}, %{owner_ref: ref} = state) do
+    {:stop, :normal, state}
+  end
+
+  def handle_manager_info(message, state) do
+    Logger.debug("symphony.evidence.capture.unhandled_info message=#{inspect(message)}")
     {:noreply, state}
   end
 
@@ -167,9 +220,19 @@ defmodule Raxol.Symphony.Evidence.Capture do
   # Internals
   # ---------------------------------------------------------------------------
 
-  defp open_file(path) do
-    with :ok <- File.mkdir_p(Path.dirname(path)) do
-      File.open(path, [:write, :binary])
+  # A cast without its header is not a cast, so a failed header is a
+  # failed open: close the handle and let the caller go no-op.
+  defp start_cast(path, width, height, title) do
+    with :ok <- File.mkdir_p(Path.dirname(path)),
+         {:ok, io} <- File.open(path, [:write, :binary]) do
+      case write_header(io, width, height, title) do
+        :ok ->
+          {:ok, io}
+
+        {:error, reason} ->
+          File.close(io)
+          {:error, reason}
+      end
     end
   end
 
@@ -183,12 +246,26 @@ defmodule Raxol.Symphony.Evidence.Capture do
     }
 
     header = if is_binary(title), do: Map.put(header, "title", title), else: header
-    IO.binwrite(io, Jason.encode!(header) <> "\n")
+
+    case Jason.encode(header) do
+      {:ok, encoded} -> binwrite(io, encoded <> "\n")
+      {:error, reason} -> {:error, {:encode, reason}}
+    end
   end
 
   defp write_frame(io, elapsed_seconds, text) do
-    frame = [Float.round(elapsed_seconds, 6), "o", text]
-    IO.binwrite(io, Jason.encode!(frame) <> "\n")
+    case Jason.encode([Float.round(elapsed_seconds, 6), "o", text]) do
+      {:ok, frame} -> binwrite(io, frame <> "\n")
+      {:error, reason} -> {:error, {:encode, reason}}
+    end
+  end
+
+  # IO.binwrite/2 is specced `:ok` but exits when the device is gone (a
+  # closed fd, a full disk). A best-effort recorder should not die of that.
+  defp binwrite(io, data) do
+    IO.binwrite(io, data)
+  catch
+    kind, reason -> {:error, {kind, reason}}
   end
 
   @doc false

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -677,7 +677,9 @@ defmodule Raxol.Symphony.Orchestrator do
             ssh: dispatch.ssh
           )
 
-        graph_outcome(WorkflowCompiled.invoke(compiled, state))
+        compiled
+        |> WorkflowCompiled.invoke(state)
+        |> graph_outcome(issue, dispatch.parent)
 
       {:error, reason} ->
         exit({:graph_compile_failed, reason})
@@ -736,17 +738,32 @@ defmodule Raxol.Symphony.Orchestrator do
     end
   end
 
-  defp graph_outcome({:ok, %{run_result: :ok}, _meta}), do: :ok
+  defp graph_outcome({:ok, %{run_result: :ok}, _meta}, _issue, _parent), do: :ok
 
-  defp graph_outcome({:ok, %{run_result: {:error, reason}}, _meta}),
+  defp graph_outcome({:ok, %{run_result: {:error, reason}}, _meta}, _issue, _parent),
     do: exit({:runner_error, reason})
 
-  defp graph_outcome({:ok, _final, _meta}), do: :ok
+  defp graph_outcome({:ok, _final, _meta}, _issue, _parent), do: :ok
 
-  defp graph_outcome({:error, reason, _state}),
+  defp graph_outcome({:error, reason, _state}, _issue, _parent),
     do: exit({:graph_runtime_error, reason})
 
-  defp graph_outcome({:interrupted, _run_id, _state, value}),
+  # A runner pause reaches the worker as a graph interrupt. Speak the same
+  # protocol `interpret_runner_result/3` does so the orchestrator parks the run
+  # (and keeps its reserved host) instead of reading the interrupt as a crash:
+  # a run that never enters `paused` cannot be resumed by any surface, and the
+  # retry re-runs the whole agent only to pause again, forever.
+  defp graph_outcome(
+         {:interrupted, _run_id, _state, {reason, token}},
+         %Issue{} = issue,
+         parent
+       )
+       when is_atom(reason) and is_pid(parent) do
+    send(parent, {:run_paused, issue.id, reason, token})
+    :ok
+  end
+
+  defp graph_outcome({:interrupted, _run_id, _state, value}, _issue, _parent),
     do: exit({:graph_interrupted, value})
 
   # -- Parallel batch dispatch (:graph_parallel) ------------------------------

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -286,7 +286,7 @@ defmodule Raxol.Symphony.Orchestrator do
   end
 
   @impl Raxol.Core.Behaviours.BaseManager
-  def handle_manager_info(:tick, %State{} = state) do
+  def handle_manager_info({:timeout, ref, :tick}, %State{tick_timer_ref: ref} = state) do
     new_state =
       state
       |> Map.put(:tick_timer_ref, nil)
@@ -294,6 +294,15 @@ defmodule Raxol.Symphony.Orchestrator do
       |> schedule_next_tick()
 
     {:noreply, new_state}
+  end
+
+  # A tick from a superseded timer. `Process.cancel_timer/1` does not unsend an
+  # already-delivered message, so a `run_tick` that outlives the poll interval
+  # leaves one queued behind the reschedule that follows it. Running it would
+  # arm a SECOND timer and orphan the live one, and every recurrence adds
+  # another chain -- permanently multiplying tracker polling.
+  def handle_manager_info({:timeout, _superseded_ref, :tick}, %State{} = state) do
+    {:noreply, state}
   end
 
   def handle_manager_info({:retry_fire, issue_id}, %State{} = state) do
@@ -1911,7 +1920,9 @@ defmodule Raxol.Symphony.Orchestrator do
       Process.cancel_timer(state.tick_timer_ref)
     end
 
-    ref = Process.send_after(self(), :tick, delay_ms)
+    # `start_timer/3` puts the timer's own ref inside the message it delivers,
+    # which is what lets the handler tell a live tick from a superseded one.
+    ref = :erlang.start_timer(delay_ms, self(), :tick)
     %State{state | tick_timer_ref: ref}
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -1843,7 +1843,11 @@ defmodule Raxol.Symphony.Orchestrator do
         terminate_running(acc, id, entry, true)
 
       Issue.active?(issue, acc.config.tracker.active_states) ->
-        %{acc | running: Map.put(acc.running, id, %{entry | issue: issue})}
+        # The denormalized `:state` copy is what per-state slot accounting
+        # counts and what every surface renders, so it has to move with the
+        # issue -- an agent advancing its own issue between two active states
+        # is the ordinary workflow, not an edge case.
+        %{acc | running: Map.put(acc.running, id, %{entry | issue: issue, state: issue.state})}
 
       true ->
         terminate_running(acc, id, entry, false)

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -491,7 +491,7 @@ defmodule Raxol.Symphony.Orchestrator do
 
         state
         |> release_host(host)
-        |> schedule_failure_retry(issue, attempt || 0, reason)
+        |> schedule_failure_retry(issue, (attempt || 0) + 1, reason)
     end
   end
 
@@ -1512,8 +1512,8 @@ defmodule Raxol.Symphony.Orchestrator do
       {:ok, []} ->
         release_issue(state, issue_id)
 
-      {:error, _reason} ->
-        requeue_retry(state, issue_id, retry_entry)
+      {:error, reason} ->
+        requeue_retry(state, issue_id, retry_entry, reason)
     end
   end
 
@@ -1555,7 +1555,15 @@ defmodule Raxol.Symphony.Orchestrator do
     state
   end
 
-  defp requeue_retry(%State{} = state, issue_id, retry_entry) do
+  # The tracker could not say whether the issue is still active, so the retry
+  # has to be re-armed. Treat that as a failure rather than a continuation:
+  # the flat 1s continuation delay re-reads the tracker once a second for the
+  # whole outage -- against an API that may be rate-limiting us precisely
+  # because of it -- and freezes `attempt`, so the dashboard shows one attempt
+  # forever. Record the CURRENT reason too: wrapping the entry's own error
+  # nests one level per requeue, and `snapshot_retry/2` inspects that term into
+  # every broadcast.
+  defp requeue_retry(%State{} = state, issue_id, retry_entry, reason) do
     placeholder = %Issue{
       id: issue_id,
       identifier: retry_entry.identifier,
@@ -1563,12 +1571,11 @@ defmodule Raxol.Symphony.Orchestrator do
       state: ""
     }
 
-    schedule_retry(
+    schedule_failure_retry(
       state,
       placeholder,
-      retry_entry.attempt,
-      Retry.continuation_delay_ms(),
-      {:tracker_unavailable_during_retry, retry_entry.error}
+      (retry_entry.attempt || 0) + 1,
+      {:tracker_unavailable_during_retry, reason}
     )
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -469,10 +469,29 @@ defmodule Raxol.Symphony.Orchestrator do
         dispatch_issue_on_host(state, issue, attempt, host)
 
       # Every configured SSH host is busy (one-worker-lifetime-per-host).
-      # Leave the issue unclaimed; the next tick re-dispatches it once a
-      # host frees. Nothing was reserved, so there is nothing to release.
+      # Nothing was reserved, so there is nothing to release.
       :none_free ->
-        state
+        defer_on_host_exhaustion(state, issue, attempt)
+    end
+  end
+
+  # A fresh dispatch out of `dispatch_candidates/1` holds no claim, so dropping
+  # it is safe: the next tick re-dispatches it once a host frees. A retry
+  # arrives here already in `claimed` and with its `retry_attempts` entry
+  # deleted, so dropping it strands the issue -- claimed, but in no running,
+  # batch or paused map and with no timer, which `Candidate.eligible/4` then
+  # skips forever and no release site can reach.
+  defp defer_on_host_exhaustion(%State{} = state, %Issue{} = issue, attempt) do
+    if MapSet.member?(state.claimed, issue.id) do
+      schedule_retry(
+        state,
+        issue,
+        attempt,
+        state.config.polling.interval_ms,
+        :host_pool_exhausted
+      )
+    else
+      state
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -98,6 +98,11 @@ defmodule Raxol.Symphony.Orchestrator do
   payload describing the external event the run was waiting on) in `opts`.
 
   Returns `{:error, :not_paused}` if no paused entry exists for `issue_id`.
+
+  `:ok` means the resume was accepted, not that a runner started: with the
+  concurrency caps full the run stays parked holding `resume_value` and the
+  next tick starts it once a slot frees. `snapshot/1` reports those as
+  `resume_pending?`.
   """
   @spec resume_run(GenServer.server(), binary(), term()) ::
           :ok | {:error, :not_paused}
@@ -254,15 +259,7 @@ defmodule Raxol.Symphony.Orchestrator do
         {:reply, {:error, :not_paused}, state}
 
       paused_entry ->
-        forget_paused(state.paused_saver, issue_id)
-
-        new_state =
-          state
-          |> Map.put(:paused, Map.delete(state.paused, issue_id))
-          |> dispatch_resumption(paused_entry, resume_value)
-          |> notify_listeners(:run_resumed)
-
-        {:reply, :ok, new_state}
+        {:reply, :ok, resume_paused(state, issue_id, paused_entry, resume_value)}
     end
   end
 
@@ -356,6 +353,7 @@ defmodule Raxol.Symphony.Orchestrator do
         state
         |> reconcile_host_pool()
         |> reconcile()
+        |> drain_deferred_resumes()
         |> dispatch_candidates()
         |> notify_listeners(:tick_completed)
 
@@ -1297,6 +1295,69 @@ defmodule Raxol.Symphony.Orchestrator do
     end
   end
 
+  # A resume starts an agent, so it spends a concurrency slot like any other
+  # dispatch. Parking took the run out of `running`, so every parked issue reads
+  # the global and per-state budgets as free at the same instant, and
+  # `Resumer.fan_out_matches/2` calls `resume_run/3` for EVERY paused entry a
+  # single telemetry event matches -- ungated, one event starts one agent per
+  # parked issue whatever `max_concurrent_agents` says, with no operator in the
+  # loop. Over the cap, keep the run parked holding the value it was handed.
+  defp resume_paused(%State{} = state, issue_id, paused_entry, resume_value) do
+    case Candidate.apply_concurrency_slots(
+           [paused_entry.issue],
+           state.config,
+           running_for_slots(state)
+         ) do
+      [%Issue{}] ->
+        forget_paused(state.paused_saver, issue_id)
+
+        state
+        |> Map.put(:paused, Map.delete(state.paused, issue_id))
+        |> dispatch_resumption(paused_entry, resume_value)
+        |> notify_listeners(:run_resumed)
+
+      [] ->
+        defer_resumption(state, issue_id, paused_entry, resume_value)
+    end
+  end
+
+  defp defer_resumption(%State{} = state, issue_id, paused_entry, resume_value) do
+    queued = Map.put(paused_entry, :pending_resume, {:queued, resume_value})
+
+    state
+    |> Map.put(:paused, Map.put(state.paused, issue_id, queued))
+    |> announce_first_deferral(paused_entry)
+  end
+
+  # Only entering the queue is worth a line and a broadcast: every tick
+  # re-offers a queued resume, and a run waiting out a long backlog would
+  # otherwise repeat both for as long as the caps stay full.
+  defp announce_first_deferral(%State{} = state, %{pending_resume: {:queued, _}}), do: state
+
+  defp announce_first_deferral(%State{} = state, paused_entry) do
+    Logger.info(
+      "symphony.orchestrator.resume_deferred issue=#{paused_entry.issue.identifier} " <>
+        "reason=awaiting_concurrency_slot"
+    )
+
+    notify_listeners(state, :run_resume_deferred)
+  end
+
+  # A slot only frees while the orchestrator is doing something else, so a
+  # queued resume needs re-offering. Do it ahead of `dispatch_candidates/1`:
+  # a parked run already owns a workspace and a reserved host, so giving the
+  # freed slot to fresh work instead would strand it behind every future poll.
+  defp drain_deferred_resumes(%State{} = state) do
+    state.paused
+    |> Enum.flat_map(fn
+      {issue_id, %{pending_resume: {:queued, value}} = entry} -> [{issue_id, entry, value}]
+      _ -> []
+    end)
+    |> Enum.reduce(state, fn {issue_id, entry, value}, acc ->
+      resume_paused(acc, issue_id, entry, value)
+    end)
+  end
+
   defp dispatch_resumption(%State{} = state, paused_entry, resume_value) do
     issue = paused_entry.issue
 
@@ -1527,10 +1588,34 @@ defmodule Raxol.Symphony.Orchestrator do
         release_issue(state, issue.id)
 
       Issue.active?(issue, state.config.tracker.active_states) ->
-        dispatch_issue(state, issue, retry_entry.attempt)
+        dispatch_within_slots(state, issue, retry_entry)
 
       true ->
         release_issue(state, issue.id)
+    end
+  end
+
+  # A retry timer fires outside the poll path, where nothing has applied the
+  # concurrency caps. Parking the issue took it out of `running`, so both the
+  # global and the per-state budget read as free and the re-dispatch registers
+  # an extra worker over `max_concurrent_agents`. Re-check against the same
+  # accounting `dispatch_candidates/1` uses and wait for a slot instead.
+  defp dispatch_within_slots(%State{} = state, %Issue{} = issue, retry_entry) do
+    case Candidate.apply_concurrency_slots([issue], state.config, running_for_slots(state)) do
+      [%Issue{}] ->
+        dispatch_issue(state, issue, retry_entry.attempt)
+
+      [] ->
+        # Not a failure of this run: the wait ends when another worker exits, so
+        # hold the attempt count rather than inflating the failure backoff, and
+        # re-check on the cadence dispatch is already evaluated on.
+        schedule_retry(
+          state,
+          issue,
+          retry_entry.attempt,
+          state.config.polling.interval_ms,
+          :awaiting_concurrency_slot
+        )
     end
   end
 
@@ -1878,6 +1963,9 @@ defmodule Raxol.Symphony.Orchestrator do
       interrupt_reason: entry.interrupt_reason,
       paused_ms_ago: max(now_system_ms - Map.get(entry, :paused_at_system, now_system_ms), 0),
       durable?: Map.get(entry, :durable?, false),
+      # A resume was asked for and is waiting on a concurrency slot. Without it
+      # a capped-out resume is indistinguishable from a run nobody has resumed.
+      resume_pending?: match?({:queued, _}, Map.get(entry, :pending_resume)),
       attempt: entry.attempt,
       turn_count: entry.turn_count,
       last_event: entry.last_event,

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -617,7 +617,7 @@ defmodule Raxol.Symphony.Orchestrator do
          attempt,
          workspace_path
        ) do
-    case Capture.start_link(
+    case Capture.start(
            path: Capture.path_for(workspace_path, attempt),
            width: rec.width,
            height: rec.height,

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator.ex
@@ -1541,12 +1541,15 @@ defmodule Raxol.Symphony.Orchestrator do
     schedule_retry(state, issue, attempt, delay, error)
   end
 
+  # `requeues` defaults to 0 so that every caller reached through a SUCCESSFUL
+  # tracker read clears the outage counter; only `rearm_retry/5` carries it.
   defp schedule_retry(
          %State{} = state,
          %Issue{} = issue,
          attempt,
          delay_ms,
-         error
+         error,
+         requeues \\ 0
        ) do
     state = cancel_retry(state, issue.id)
     timer_ref = Process.send_after(self(), {:retry_fire, issue.id}, delay_ms)
@@ -1556,6 +1559,7 @@ defmodule Raxol.Symphony.Orchestrator do
       issue_id: issue.id,
       identifier: issue.identifier,
       attempt: attempt,
+      requeues: requeues,
       due_at_ms: due_at_ms,
       timer_ref: timer_ref,
       error: error
@@ -1603,14 +1607,39 @@ defmodule Raxol.Symphony.Orchestrator do
     }
 
     case Tracker.fetch_issue_states_by_ids(state.config, [issue_id]) do
-      {:ok, [%Issue{} = issue]} ->
-        retry_with_refreshed_issue(state, issue, retry_entry)
-
-      {:ok, []} ->
-        release_issue(state, issue_id)
+      {:ok, issues} when is_list(issues) ->
+        resolve_retry_answer(state, issue_id, issues, retry_entry)
 
       {:error, reason} ->
         requeue_retry(state, issue_id, retry_entry, reason)
+    end
+  end
+
+  # A per-ID refresh is evidence about the ID it asked for and nothing else.
+  # An empty answer is the tracker saying the issue is gone; any other answer
+  # has to CONTAIN our row to mean anything, because acting on a row we did not
+  # ask for dispatches the wrong issue and releases the wrong claim -- leaving
+  # ours claimed with no timer, which no release site can reach.
+  #
+  # This used to match `{:ok, [issue]}` positionally, so a tracker answering a
+  # single-ID query with two rows raised CaseClauseError inside the callback,
+  # and a single row for a DIFFERENT issue was acted on as if it were ours.
+  defp resolve_retry_answer(%State{} = state, issue_id, [], _retry_entry) do
+    release_issue(state, issue_id)
+  end
+
+  defp resolve_retry_answer(%State{} = state, issue_id, issues, retry_entry) do
+    case Enum.find(issues, &match?(%Issue{id: ^issue_id}, &1)) do
+      %Issue{} = issue ->
+        retry_with_refreshed_issue(state, issue, retry_entry)
+
+      nil ->
+        requeue_retry(
+          state,
+          issue_id,
+          retry_entry,
+          {:tracker_answered_other_issues, length(issues)}
+        )
     end
   end
 
@@ -1677,14 +1706,31 @@ defmodule Raxol.Symphony.Orchestrator do
   end
 
   # The tracker could not say whether the issue is still active, so the retry
-  # has to be re-armed. Treat that as a failure rather than a continuation:
-  # the flat 1s continuation delay re-reads the tracker once a second for the
-  # whole outage -- against an API that may be rate-limiting us precisely
-  # because of it -- and freezes `attempt`, so the dashboard shows one attempt
-  # forever. Record the CURRENT reason too: wrapping the entry's own error
-  # nests one level per requeue, and `snapshot_retry/2` inspects that term into
-  # every broadcast.
+  # has to be re-armed. Treat that as a failure rather than a continuation: the
+  # flat 1s continuation delay re-reads the tracker once a second for the whole
+  # outage, against an API that may be rate-limiting us precisely because of it.
+  #
+  # The backoff escalates on `requeues`, NOT on `attempt`. They are different
+  # numbers: `attempt` counts executions and reaches the prompt template and the
+  # cast filename, so escalating it tells an agent it is on attempt 47 of a run
+  # that never executed once. `requeues` counts consecutive outages and resets
+  # the moment a refresh succeeds, because every other `schedule_retry/6` caller
+  # takes the default.
+  #
+  # Record the CURRENT reason too: wrapping the entry's own error nests one
+  # level per requeue, and `snapshot_retry/2` inspects that term into every
+  # broadcast.
   defp requeue_retry(%State{} = state, issue_id, retry_entry, reason) do
+    requeues = retry_entry.requeues + 1
+
+    if requeues > state.config.agent.max_tracker_requeues do
+      give_up_on_retry(state, issue_id, retry_entry, reason, requeues)
+    else
+      rearm_retry(state, issue_id, retry_entry, reason, requeues)
+    end
+  end
+
+  defp rearm_retry(%State{} = state, issue_id, retry_entry, reason, requeues) do
     placeholder = %Issue{
       id: issue_id,
       identifier: retry_entry.identifier,
@@ -1692,12 +1738,31 @@ defmodule Raxol.Symphony.Orchestrator do
       state: ""
     }
 
-    schedule_failure_retry(
+    delay =
+      Retry.failure_delay_ms(requeues, state.config.agent.max_retry_backoff_ms)
+
+    schedule_retry(
       state,
       placeholder,
-      (retry_entry.attempt || 0) + 1,
-      {:tracker_unavailable_during_retry, reason}
+      retry_entry.attempt,
+      delay,
+      {:tracker_unavailable_during_retry, reason},
+      requeues
     )
+  end
+
+  # The requeue loop is bounded, because an unbounded one is its own strand: a
+  # tracker that never comes back holds the claim forever, with the issue in no
+  # running, batch or paused map and no timer left to fire. Releasing hands it
+  # back to the poll path, which re-claims it from scratch once the tracker
+  # answers again -- the same recovery a fresh issue gets, rather than none.
+  defp give_up_on_retry(%State{} = state, issue_id, retry_entry, reason, requeues) do
+    Logger.warning(
+      "symphony.orchestrator.retry_gave_up issue=#{retry_entry.identifier} " <>
+        "requeues=#{requeues} reason=#{inspect(reason)}"
+    )
+
+    release_issue(state, issue_id)
   end
 
   # -- Reconciliation ---------------------------------------------------------
@@ -1991,6 +2056,10 @@ defmodule Raxol.Symphony.Orchestrator do
       issue_id: entry.issue_id,
       issue_identifier: entry.identifier,
       attempt: entry.attempt,
+      # Distinct from `attempt`: consecutive tracker outages this retry has
+      # waited out, which is what the backoff escalates on. Surfacing it is
+      # what lets `attempt` stay honest about executions.
+      requeues: entry.requeues,
       due_in_ms: max(entry.due_at_ms - now_ms, 0),
       error: inspect_error(entry.error)
     }

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator/retry.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator/retry.ex
@@ -8,7 +8,14 @@ defmodule Raxol.Symphony.Orchestrator.Retry do
     (`1000 ms`) so the orchestrator can re-check whether the issue is still
     in an active state and needs another worker session.
   - **Failure-driven retries** -- exponential backoff:
-      `delay = min(10000 * 2^(attempt - 1), max_retry_backoff_ms)`
+      `delay = min(10000 * 2^(step - 1), max_retry_backoff_ms)`
+
+  `step` is whichever counter the caller is escalating on. The orchestrator has
+  two, and they are not interchangeable: `attempt` counts executions and reaches
+  the prompt template and the cast filename, while `requeues` counts consecutive
+  tracker outages a retry has waited out. A tracker outage escalates the second,
+  so the backoff grows without telling an agent it is on attempt 47 of a run
+  that never executed.
   """
 
   @continuation_delay_ms 1_000
@@ -21,15 +28,15 @@ defmodule Raxol.Symphony.Orchestrator.Retry do
   def continuation_delay_ms, do: @continuation_delay_ms
 
   @doc """
-  Delay for a failure-driven retry on the given attempt number (1-based).
+  Delay for a failure-driven retry on the given step number (1-based).
 
   `max_retry_backoff_ms` caps the result.
   """
   @spec failure_delay_ms(pos_integer(), pos_integer()) :: pos_integer()
-  def failure_delay_ms(attempt, max_retry_backoff_ms)
-      when is_integer(attempt) and attempt >= 1 and is_integer(max_retry_backoff_ms) and
+  def failure_delay_ms(step, max_retry_backoff_ms)
+      when is_integer(step) and step >= 1 and is_integer(max_retry_backoff_ms) and
              max_retry_backoff_ms > 0 do
-    raw = @failure_base_delay_ms * Bitwise.bsl(1, attempt - 1)
+    raw = @failure_base_delay_ms * Bitwise.bsl(1, step - 1)
     min(raw, max_retry_backoff_ms)
   end
 end

--- a/packages/raxol_symphony/lib/raxol/symphony/orchestrator/state.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/orchestrator/state.ex
@@ -38,7 +38,10 @@ defmodule Raxol.Symphony.Orchestrator.State do
           error: term() | nil
         }
 
+  # `pending_resume` is present only while a resume is queued behind the
+  # concurrency caps; it carries the value the caller asked to resume with.
   @type paused_entry :: %{
+          optional(:pending_resume) => {:queued, term()},
           issue: Issue.t(),
           attempt: non_neg_integer() | nil,
           workspace_path: Path.t(),

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex.ex
@@ -47,9 +47,14 @@ defmodule Raxol.Symphony.Runners.Codex do
   or `:rejected` (the MCP surface sends them as strings; both spellings
   are accepted).
 
-  A rejection ends the attempt with `{:error, :approval_rejected}`. Nothing
-  can carry the "no" to Codex -- the paused session died with the pause --
-  so re-running would only re-request the same approval.
+  A rejection ends THIS ATTEMPT with `{:error, :approval_rejected}`. Nothing
+  can carry the "no" to Codex -- the paused session died with the pause -- so
+  the agent cannot be talked out of asking. It does not end the run: the
+  orchestrator treats a runner error as a failure, so it re-dispatches the
+  issue after the usual backoff, uncapped, and the agent asks again. The
+  re-dispatch also increments `attempt`, which the prompt reports, so the
+  agent is told it is retrying a failed attempt when nothing failed.
+  "Reject" is not a stop button; `Orchestrator.stop_run/2` is.
 
   An approval starts a FRESH Codex session, and the grant has to survive that
   respawn or the run cannot move: the new session replays from the top and

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex.ex
@@ -39,16 +39,34 @@ defmodule Raxol.Symphony.Runners.Codex do
   When `approval_policy == "never"`, command-execution / file-change /
   exec-command / apply-patch approvals are auto-approved. Any other policy
   surfaces the approval to the orchestrator as
-  `{:pause, :awaiting_approval, %{decision: ..., issue_id: ..., turn: ..., paused_at: ...}}`,
+  `{:pause, :awaiting_approval, %{decision: ..., issue_id: ..., turn: ...,
+  approvals_granted: ..., paused_at: ...}}`,
   which `Raxol.Symphony.Orchestrator` parks via `park_paused/4`. An
   operator drives the resolution with
-  `Orchestrator.resume_run(pid, issue_id, decision)`; on resume the runner
-  starts a fresh Codex session and re-enters the turn loop (the prior
-  stdio session is gone, so conversational context is not preserved
-  across the pause -- the agent re-decides what to do given the
-  operator's `:approved | :rejected` choice). An `:awaiting_approval`
-  run event is emitted at the moment of the pause and a `:resumed`
-  event when the orchestrator dispatches the resumption.
+  `Orchestrator.resume_run(pid, issue_id, decision)`, passing `:approved`
+  or `:rejected` (the MCP surface sends them as strings; both spellings
+  are accepted).
+
+  A rejection ends the attempt with `{:error, :approval_rejected}`. Nothing
+  can carry the "no" to Codex -- the paused session died with the pause --
+  so re-running would only re-request the same approval.
+
+  An approval starts a FRESH Codex session, and the grant has to survive that
+  respawn or the run cannot move: the new session replays from the top and
+  hits the same approval point, so a grant covering only the dead session
+  would leave the run asking the same question forever. The pause token
+  carries `approvals_granted`, the number of approval points an operator has
+  already cleared for this run. On an approval that count goes up by one and
+  the fresh session answers that many requests before pausing on the next, so
+  each resume clears exactly one more approval point and the run advances.
+
+  The grant is positional, not bound to the action the operator read. A
+  fresh session is free to propose different work, so request #n after the
+  respawn is only usually the request #n that was approved. Closing that
+  gap means holding the paused session open rather than respawning it.
+
+  An `:awaiting_approval` run event is emitted at the moment of the pause
+  and a `:resumed` event when the orchestrator dispatches the resumption.
 
   Tool calls (`item/tool/call`) currently respond with an "unsupported"
   result; dynamic-tool registration lands in a follow-up.
@@ -79,17 +97,42 @@ defmodule Raxol.Symphony.Runners.Codex do
          :ok <- Auth.gate(config.codex, auth) do
       maybe_emit_resumed(parent, issue, resume_value, resume_token)
 
-      do_run(issue, config, %{
+      resume_or_run(issue, config, approval_decision(resume_value), %{
         parent: parent,
         attempt: attempt,
         workspace_path: workspace_path,
         host: host,
         turn: 1,
         max_turns: config.agent.max_turns,
-        auth_env: auth.env
+        auth_env: auth.env,
+        granted_approvals: granted_approvals(resume_token)
       })
     end
   end
+
+  # The MCP surface resumes with the raw JSON value, so the same decision
+  # arrives as a string there and as an atom from the TUI. Anything else
+  # carries no approval: the run starts over and pauses again, which is the
+  # fail-closed answer for a decision we cannot read.
+  defp approval_decision(decision) when decision in [:approved, "approved"], do: :approved
+  defp approval_decision(decision) when decision in [:rejected, "rejected"], do: :rejected
+  defp approval_decision(_), do: :none
+
+  # How many approval points this run has already cleared. A token from
+  # anywhere but our own `pause_for_approval/3` counts as none cleared, so a
+  # malformed one costs a re-ask rather than a blanket grant.
+  defp granted_approvals(%{approvals_granted: n}) when is_integer(n) and n >= 0, do: n
+  defp granted_approvals(_), do: 0
+
+  defp resume_or_run(_issue, _config, :rejected, _ctx), do: {:error, :approval_rejected}
+
+  # The approval the operator just gave is the (n+1)th this run has cleared,
+  # so the fresh session answers that many before it pauses again. Without
+  # the increment every resume would stop at the same request.
+  defp resume_or_run(issue, config, :approved, ctx),
+    do: do_run(issue, config, %{ctx | granted_approvals: ctx.granted_approvals + 1})
+
+  defp resume_or_run(issue, config, :none, ctx), do: do_run(issue, config, ctx)
 
   # Operator-driven resume: announce that the run is starting over with
   # the supplied decision. The orchestrator parks paused runs with the
@@ -114,7 +157,7 @@ defmodule Raxol.Symphony.Runners.Codex do
   end
 
   defp do_run(%Issue{} = issue, %Config{} = config, ctx) do
-    policy = build_policy(config)
+    policy = build_policy(config, ctx.granted_approvals)
     env = Map.get(ctx, :auth_env, [])
 
     case Session.start(ctx.workspace_path, config.codex.command, policy, env, Map.get(ctx, :host)) do
@@ -161,7 +204,10 @@ defmodule Raxol.Symphony.Runners.Codex do
   # Convert a non-auto-approve approval request from `Session.run_turn`
   # into an orchestrator-level pause. The token captures the decision
   # payload so an operator inspecting the snapshot sees exactly what
-  # they are approving (e.g. the proposed shell command or file edit).
+  # they are approving (e.g. the proposed shell command or file edit),
+  # plus `approvals_granted`: the session spends its whole standing grant
+  # before it pauses, so that count is exactly how many approval points
+  # this run has cleared, and the next resume can carry it forward.
   defp pause_for_approval(decision, %Issue{} = issue, ctx) do
     Logger.info(
       "symphony.runners.codex.awaiting_approval issue=#{issue.identifier} " <>
@@ -184,6 +230,7 @@ defmodule Raxol.Symphony.Runners.Codex do
        decision: decision,
        issue_id: issue.id,
        turn: ctx.turn,
+       approvals_granted: ctx.granted_approvals,
        paused_at: DateTime.utc_now()
      }}
   end
@@ -263,7 +310,7 @@ defmodule Raxol.Symphony.Runners.Codex do
     end
   end
 
-  defp build_policy(%Config{codex: codex}) do
+  defp build_policy(%Config{codex: codex}, granted_approvals) do
     approval_policy = codex.approval_policy || "never"
 
     %{
@@ -273,6 +320,7 @@ defmodule Raxol.Symphony.Runners.Codex do
       read_timeout_ms: codex.read_timeout_ms,
       turn_timeout_ms: codex.turn_timeout_ms,
       auto_approve?: approval_policy == "never",
+      granted_approvals: granted_approvals,
       dynamic_tools: []
     }
   end

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/codex/session.ex
@@ -41,7 +41,8 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
           required(:read_timeout_ms) => pos_integer(),
           required(:turn_timeout_ms) => pos_integer(),
           required(:auto_approve?) => boolean(),
-          required(:dynamic_tools) => list()
+          required(:dynamic_tools) => list(),
+          optional(:granted_approvals) => non_neg_integer()
         }
 
   @port_line_bytes 1_048_576
@@ -439,6 +440,17 @@ defmodule Raxol.Symphony.Runners.Codex.Session do
   defp handle_approval(%{policy: %{auto_approve?: true}} = session, on_event, id, decision) do
     send_payload(session.port, Protocol.approval_result(id, decision))
     receive_turn(session, on_event, "")
+  end
+
+  # `granted_approvals` is how many approval requests an operator has already
+  # cleared for this run (see `Runners.Codex`). A resumed run replays from the
+  # top, so the first that many are answered from the standing grant and the
+  # next one still reaches a human -- which is what lets each resume advance
+  # one approval point further instead of re-asking the same one forever.
+  defp handle_approval(%{policy: %{granted_approvals: n}} = session, on_event, id, decision)
+       when is_integer(n) and n > 0 do
+    send_payload(session.port, Protocol.approval_result(id, decision))
+    receive_turn(put_in(session.policy.granted_approvals, n - 1), on_event, "")
   end
 
   defp handle_approval(_session, _on_event, _id, decision),

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
@@ -139,6 +139,13 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
   Detection is bypassed when `agent.pause_detector` is `nil`, falling
   back to the legacy `EventForwarder.to_parent/3` path with no overhead.
 
+  Under `agent.workflow_mode`, a detector also requires an explicit
+  `agent.workflow_saver`: the run pauses in one worker task and resumes
+  in another, so a saver whose store dies with the writing process
+  loses the checkpoint. `run/3` returns
+  `{:error, :no_durable_workflow_saver}` rather than start a run it
+  cannot resume.
+
   ## Self-improvement (opt-in)
 
   Optional: set `agent.module` to a `use Raxol.Agent` module whose
@@ -323,8 +330,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
     max_turns = config.agent.max_turns
 
     with {:ok, backend, backend_opts} <- resolve_backend(config),
-         {:ok, compiled} <-
-           AgentWorkflow.compile(max_turns, workflow_compile_opts(config)) do
+         {:ok, compiled} <- compile_workflow(config, max_turns) do
       case resume_token do
         %{workflow_run_id: run_id}
         when not is_nil(run_id) and not is_nil(resume_value) ->
@@ -345,18 +351,44 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
     end
   end
 
-  defp workflow_compile_opts(%Config{runner: %{agent: agent}}) do
-    # The workflow runtime's Compiled.resume/4 requires a Saver
-    # (otherwise it returns {:error, :no_saver_configured, _}). Default
-    # to a shared in-memory ETS table; consumers wanting BEAM-restart
-    # durability override via agent.workflow_saver, typically to
-    # `{Raxol.Workflow.Checkpoint.Saver.Dets, %{name: ...}}` or the
-    # Postgrex equivalent.
-    saver =
-      Map.get(agent, :workflow_saver) ||
-        {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: :raxol_symphony_agent_workflow}}
+  defp compile_workflow(%Config{} = config, max_turns) do
+    with {:ok, compile_opts} <- workflow_compile_opts(config) do
+      AgentWorkflow.compile(max_turns, compile_opts)
+    end
+  end
 
-    [saver: saver]
+  # The workflow runtime's Compiled.resume/4 requires a Saver (otherwise
+  # it returns {:error, :no_saver_configured, _}).
+  defp workflow_compile_opts(%Config{runner: %{agent: agent}}) do
+    case Map.get(agent, :workflow_saver) do
+      nil -> default_saver_opts(agent)
+      saver -> {:ok, [saver: saver]}
+    end
+  end
+
+  # Checkpoints are only ever read back on resume, and a resume only
+  # follows a pause, which only a pause_detector can raise. The default
+  # ETS saver creates its table in whichever process writes first --
+  # the orchestrator's worker task -- and an ETS table dies with its
+  # owner, so a pause's checkpoint is gone before an operator can act on
+  # it. Refuse that combination instead of handing back a saver whose
+  # checkpoints cannot outlive the run that wrote them; consumers point
+  # agent.workflow_saver at a store with a longer-lived owner
+  # (`{Raxol.Workflow.Checkpoint.Saver.Dets, %{name: ...}}`, the
+  # Postgrex equivalent, or an ETS table a supervised process created).
+  # A run that cannot pause never reads a checkpoint back, so it keeps
+  # the convenient default.
+  defp default_saver_opts(agent) do
+    case Map.get(agent, :pause_detector) do
+      nil ->
+        {:ok,
+         [
+           saver: {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: :raxol_symphony_agent_workflow}}
+         ]}
+
+      _detector ->
+        {:error, :no_durable_workflow_saver}
+    end
   end
 
   defp build_workflow_state(issue, config, opts, backend, backend_opts) do

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent.ex
@@ -77,11 +77,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
   `:retry_exhausted`, `:timeout`, `:cache_hit`, `:cache_miss` fire
   on the corresponding decisions.
 
-  Policy failures (retries exhausted, timeout) currently advance
-  the turn with empty events + no pause_request rather than
-  failing the run -- the orchestrator's retry layer handles
-  whole-run failure. Surfacing per-turn errors into a hard
-  `{:error, _}` return is a follow-up.
+  A turn the policies could not rescue fails the run: `run/3`
+  returns `{:error, reason}` and the orchestrator's retry ladder
+  takes over. `reason` is the turn's own failure verbatim (the
+  provider error a Retry exhausted on), or `{:policy_failed, _}`
+  when the applier itself gave up on wall-clock or a crashed task.
 
   Default `[]` (empty list) skips the wrap entirely.
 
@@ -554,58 +554,80 @@ defmodule Raxol.Symphony.Runners.RaxolAgent do
   end
 
   defp run_authorized_turn(state, prompt, policies, turn_payload) do
+    # The verdict is decided INSIDE the wrapped op, not after the
+    # applier returns: a failed turn handed back as `{:ok, _}` is a
+    # success to every policy, so Retry never retries the class of
+    # failure it was configured for and Cache memoizes the failure for
+    # its whole TTL, turning one transient provider error into a run
+    # that fails instantly on a stale reason until the entry expires.
     op = fn _params ->
-      stream = stream_module().run(prompt, __stream_opts__(state))
-
-      {:ok,
-       collect_with_detector(
-         stream,
-         state.parent,
-         state.issue.id,
-         state.pause_detector
-       )}
+      stream_module().run(prompt, __stream_opts__(state))
+      |> collect_with_detector(state.parent, state.issue.id, state.pause_detector)
+      |> turn_result()
     end
 
     case Raxol.Agent.PolicyApplier.apply(policies, op, turn_payload) do
       {:ok, {events, pause_request}} ->
         {:ok, events, pause_request}
 
-      {:error, reason} ->
-        # Policies could not recover (retries exhausted / wall-clock
-        # timeout). Unlike a sandbox deny, this IS a hard failure --
-        # surface it as `{:error, _}` so AgentWorkflow.run_turn sets
-        # state.run_result and the runner's translate_workflow_result
-        # propagates {:error, ...} back to the orchestrator (which
-        # then schedules a failure retry with exponential backoff).
+      # Either failure IS a hard one, unlike a sandbox deny: surfacing
+      # `{:error, _}` makes AgentWorkflow.run_turn set state.run_result
+      # so translate_workflow_result propagates it back to the
+      # orchestrator, which schedules a failure retry with backoff.
+      # The applier synthesises exactly these two reasons, so they are
+      # the only ones the policy machinery itself is answerable for;
+      # anything else is the turn's own reason and is reported verbatim
+      # (a Retry that exhausts reports the provider's last error, which
+      # is what an operator needs to read).
+      {:error, :timeout} ->
+        {:error, {:policy_failed, :timeout}}
+
+      {:error, {:exit, _} = reason} ->
         {:error, {:policy_failed, reason}}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
+  # A queued pause outranks a stream error: the pause fires at the turn
+  # boundary, so the operator's decision is what the run is waiting on.
+  defp turn_result({events, {:pause, _reason, _token} = pause_request, _outcome}),
+    do: {:ok, {events, pause_request}}
+
+  defp turn_result({events, nil, :ok}), do: {:ok, {events, nil}}
+  defp turn_result({_events, nil, {:error, reason}}), do: {:error, reason}
+
   defp collect_with_detector(stream, parent, issue_id, detector) do
-    Enum.reduce(stream, {[], nil}, fn event, {events, pause_acc} ->
+    Enum.reduce(stream, {[], nil, {:error, :no_done}}, fn event, {events, pause_acc, outcome} ->
       send(parent, {:run_event, issue_id, legacy_payload(event)})
       payload = legacy_payload(event)
       events = [payload | events]
 
-      pause_acc =
-        case pause_acc do
-          nil ->
-            case apply_detector(detector, event) do
-              {:pause, reason, token} when is_atom(reason) ->
-                {:pause, reason, token}
-
-              _ ->
-                nil
-            end
-
-          existing ->
-            existing
-        end
-
-      {events, pause_acc}
+      {events, queue_pause(pause_acc, detector, event), stream_outcome(outcome, event)}
     end)
-    |> then(fn {events, pause_acc} -> {Enum.reverse(events), pause_acc} end)
+    |> then(fn {events, pause_acc, outcome} ->
+      {Enum.reverse(events), pause_acc, outcome}
+    end)
   end
+
+  defp queue_pause(nil, detector, event) do
+    case apply_detector(detector, event) do
+      {:pause, reason, token} when is_atom(reason) -> {:pause, reason, token}
+      _ -> nil
+    end
+  end
+
+  defp queue_pause(queued, _detector, _event), do: queued
+
+  # Same terminal-outcome verdict as `legacy_forward/3` and
+  # `forward_with_detector/4`: the first terminal event decides, and a
+  # stream that reaches neither is a failed turn rather than a clean one.
+  # Those two halt on it; this one keeps folding so a queued pause still
+  # sees the whole turn.
+  defp stream_outcome({:error, :no_done}, {:done, _info}), do: :ok
+  defp stream_outcome({:error, :no_done}, {:error, reason}), do: {:error, reason}
+  defp stream_outcome(outcome, _event), do: outcome
 
   @doc false
   def __workflow_still_active__(%{tracker_cache: nil} = state) do

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent/agent_workflow.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/raxol_agent/agent_workflow.ex
@@ -75,8 +75,9 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflow do
   `max_turns` (>= 1).
 
   `opts` forwards to `Graph.compile/2`. The most load-bearing one is
-  `:saver`; the runner defaults to an in-memory ETS saver if the
-  consumer hasn't set `agent.workflow_saver`.
+  `:saver`; the runner defaults to an in-memory ETS saver when the
+  consumer hasn't set `agent.workflow_saver` and the run cannot pause,
+  and refuses to compile otherwise.
   """
   @spec compile(pos_integer(), keyword()) :: {:ok, Compiled.t()} | {:error, term()}
   def compile(max_turns, opts \\ []) when is_integer(max_turns) and max_turns >= 1 do

--- a/packages/raxol_symphony/lib/raxol/symphony/runners/review.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/runners/review.ex
@@ -21,6 +21,10 @@ defmodule Raxol.Symphony.Runners.Review do
      `{:error, {:changes_requested, reason}}` so the orchestrator's failure retry
      re-dispatches the implementer with the feedback. A human escalation
      (`:awaiting_human`) resumes with an operator decision in `:resume_value`.
+     Both the implementer and the reviewer can pause on their own behalf (a
+     Codex approval request, say). Those pauses are forwarded wrapped in a
+     `:review_delegate` envelope naming which phase minted them, so the resume
+     goes back to the agent that asked and nowhere else.
 
   ## Test seams
 
@@ -37,14 +41,31 @@ defmodule Raxol.Symphony.Runners.Review do
   alias Raxol.Symphony.{Config, Issue, Review, Runner}
   alias Raxol.Symphony.Review.Contract
 
+  # Every pause that leaves this module is routed back by the shape of its
+  # own token, never by a fallthrough: an operator's decision is consent
+  # about one agent's proposed action, and delivering it to a different agent
+  # in a different workspace is worse than refusing it. A token we do not
+  # recognise is reported rather than guessed at, since guessing means
+  # running the implementer -- write access to the real worktree -- on a
+  # decision that was never about it.
   @impl true
   def run(%Issue{} = issue, %Config{} = config, opts) do
-    if Keyword.has_key?(opts, :resume_value) do
-      review_phase(issue, config, opts)
-    else
-      implement_phase(issue, config, opts)
-    end
+    opts |> Keyword.get(:resume_token) |> route(issue, config, opts)
   end
+
+  defp route(nil, issue, config, opts), do: implement_phase(issue, config, opts)
+
+  defp route(%{review_delegate: :implementer, inner: inner}, issue, config, opts),
+    do: implement_phase(issue, config, Keyword.put(opts, :resume_token, inner))
+
+  defp route(%{review_delegate: :reviewer, inner: inner} = token, issue, config, opts) do
+    resume = [resume_token: inner, resume_value: Keyword.get(opts, :resume_value)]
+    dispatch_reviewer(issue, config, opts, token, Map.fetch!(token, :reviewer_kind), resume)
+  end
+
+  defp route(%{contract: _}, issue, config, opts), do: review_phase(issue, config, opts)
+
+  defp route(other, _issue, _config, _opts), do: {:error, {:unroutable_resume_token, other}}
 
   # -- Phase 1: implement -----------------------------------------------------
 
@@ -56,10 +77,19 @@ defmodule Raxol.Symphony.Runners.Review do
          :ok <- impl_mod.run(issue, config, opts) do
       maybe_request_review(issue, config, opts, implementer_kind)
     else
-      # Implementer paused, errored, returned a non-:ok result, or could not be
+      # Implementer errored, returned a non-:ok result, or could not be
       # resolved -- pass it through. Review only triggers on a clean :ok.
-      {:error, {:unsupported_runner_kind, _}} = err -> err
-      other -> other
+      {:error, {:unsupported_runner_kind, _}} = err ->
+        err
+
+      # A pause the implementer raised for itself. Envelope it so the resume
+      # comes back here labelled, instead of arriving as a bare token the
+      # review phase would mistake for one of its own.
+      {:pause, reason, token} ->
+        {:pause, reason, %{review_delegate: :implementer, inner: token}}
+
+      other ->
+        other
     end
   end
 
@@ -98,25 +128,32 @@ defmodule Raxol.Symphony.Runners.Review do
     token = Keyword.get(opts, :resume_token, %{})
 
     case Map.get(token, :reviewer_kind) do
-      kind when is_binary(kind) -> dispatch_reviewer(issue, config, opts, token, kind)
+      kind when is_binary(kind) -> dispatch_reviewer(issue, config, opts, token, kind, [])
       _ -> human_decision(opts)
     end
   end
 
-  defp dispatch_reviewer(issue, config, opts, token, reviewer_kind) do
+  # `resume` is the reviewer's own parked pause coming back to it, empty on a
+  # first dispatch. The workspace is freshly isolated either way -- the old one
+  # was deleted when the reviewer paused -- so the reviewer restarts from the
+  # Contract, which is all it ever had.
+  defp dispatch_reviewer(issue, config, opts, token, reviewer_kind, resume) do
     contract = Map.fetch!(token, :contract)
 
     case resolve(config, reviewer_kind, opts) do
       {:ok, reviewer_mod} ->
         with_isolated_workspace(fn isolated ->
-          reviewer_opts = [
-            parent: Keyword.fetch!(opts, :parent),
-            workspace_path: isolated,
-            review_contract: contract,
-            review_prompt: Review.review_prompt(contract)
-          ]
+          reviewer_opts =
+            [
+              parent: Keyword.fetch!(opts, :parent),
+              workspace_path: isolated,
+              review_contract: contract,
+              review_prompt: Review.review_prompt(contract)
+            ] ++ resume
 
-          map_review_result(reviewer_mod.run(issue, config, reviewer_opts))
+          issue
+          |> reviewer_mod.run(config, reviewer_opts)
+          |> map_review_result(contract, reviewer_kind)
         end)
 
       {:error, reason} ->
@@ -124,17 +161,34 @@ defmodule Raxol.Symphony.Runners.Review do
     end
   end
 
-  defp map_review_result(:ok), do: :ok
-  defp map_review_result({:error, reason}), do: {:error, {:changes_requested, reason}}
-  defp map_review_result({:pause, _, _} = pause), do: pause
-  defp map_review_result(other), do: other
+  defp map_review_result(:ok, _contract, _kind), do: :ok
+
+  defp map_review_result({:error, reason}, _contract, _kind),
+    do: {:error, {:changes_requested, reason}}
+
+  # Carry the Contract and the vendor with a forwarded reviewer pause: the
+  # resume has to reach the same reviewer, and nothing else in the token says
+  # which one asked.
+  defp map_review_result({:pause, reason, token}, contract, kind) do
+    {:pause, reason,
+     %{review_delegate: :reviewer, inner: token, contract: contract, reviewer_kind: kind}}
+  end
+
+  defp map_review_result(other, _contract, _kind), do: other
 
   # A human escalation resumes with the operator's decision in :resume_value.
+  # The MCP surface passes the raw JSON value through, so the same decision
+  # arrives as a string there and as an atom from the TUI.
   defp human_decision(opts) do
     case Keyword.get(opts, :resume_value) do
-      :approved -> :ok
-      :rejected -> {:error, {:changes_requested, :rejected_by_human}}
-      other -> {:error, {:unexpected_human_decision, other}}
+      decision when decision in [:approved, "approved"] ->
+        :ok
+
+      decision when decision in [:rejected, "rejected"] ->
+        {:error, {:changes_requested, :rejected_by_human}}
+
+      other ->
+        {:error, {:unexpected_human_decision, other}}
     end
   end
 

--- a/packages/raxol_symphony/lib/raxol/symphony/surfaces/telegram/formatter.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/surfaces/telegram/formatter.ex
@@ -179,7 +179,7 @@ defmodule Raxol.Symphony.Surfaces.Telegram.Formatter do
 
   def event_message(:worker_paused, snapshot) do
     paused = Map.get(snapshot, :paused, [])
-    head = List.first(paused)
+    head = newest_pause(paused)
 
     body =
       if head do
@@ -220,6 +220,12 @@ defmodule Raxol.Symphony.Surfaces.Telegram.Formatter do
   end
 
   def event_message(_other, _snapshot), do: :skip
+
+  # The snapshot lists paused runs in issue-id order, not pause recency, so
+  # the run that triggered this message is the shortest-parked entry rather
+  # than the head of the list.
+  defp newest_pause([]), do: nil
+  defp newest_pause(paused), do: Enum.min_by(paused, &Map.get(&1, :paused_ms_ago, 0))
 
   # -- Sections ---------------------------------------------------------------
 

--- a/packages/raxol_symphony/lib/raxol/symphony/surfaces/watch/formatter.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/surfaces/watch/formatter.ex
@@ -106,7 +106,7 @@ defmodule Raxol.Symphony.Surfaces.Watch.Formatter do
   end
 
   def event_notification(:worker_paused, snapshot) do
-    head = snapshot |> Map.get(:paused, []) |> List.first()
+    head = snapshot |> Map.get(:paused, []) |> newest_pause()
     paused_count = counts(snapshot)[:paused] || 0
 
     {body, actions} = paused_event_body(head, paused_count)
@@ -122,6 +122,12 @@ defmodule Raxol.Symphony.Surfaces.Watch.Formatter do
   end
 
   def event_notification(_other, _snapshot), do: :skip
+
+  # The snapshot lists paused runs in issue-id order, not pause recency, so
+  # the event that triggered this push is the shortest-parked entry rather
+  # than the head of the list.
+  defp newest_pause([]), do: nil
+  defp newest_pause(paused), do: Enum.min_by(paused, &Map.get(&1, :paused_ms_ago, 0))
 
   defp paused_event_body(nil, _count) do
     {"A run is paused. Tap Refresh to see details.", [refresh_action(), dismiss_action()]}

--- a/packages/raxol_symphony/lib/raxol/symphony/trackers/github.ex
+++ b/packages/raxol_symphony/lib/raxol/symphony/trackers/github.ex
@@ -7,7 +7,9 @@ defmodule Raxol.Symphony.Trackers.GitHub do
   e.g. `state/todo`, `state/in-progress`, `state/human-review`,
   `state/done`. The configured `active_states` and `terminal_states` are
   matched against label slugs case-insensitively, with spaces normalized
-  to dashes (`"In Progress" <-> "state/in-progress"`).
+  to dashes (`"In Progress" <-> "state/in-progress"`). The `state/` prefix
+  is matched case-insensitively too, so `STATE/todo` and `State/Todo` are
+  the same label; `stateful` and `state-todo` are not state labels at all.
 
   ## Configuration
 
@@ -26,7 +28,12 @@ defmodule Raxol.Symphony.Trackers.GitHub do
   - `fetch_issues_by_states/2` -- fetches with `state=all` so closed issues
     in terminal states are reachable, then filters by label.
   - `fetch_issue_states_by_ids/2` -- fetches each ID via the per-issue
-    endpoint in parallel (concurrency 5).
+    endpoint in parallel (concurrency 5). An ID that answers 404/410 is
+    omitted from the result, because that is knowledge: the issue is deleted,
+    transferred, or invisible to this token. Any OTHER per-ID failure fails
+    the whole call, because callers read a short list as "this issue is gone"
+    and act on it destructively -- `Orchestrator.retry_with_fresh_state/3`
+    releases the issue, and the runners' `still_active?/2` ends the run.
 
   ## Pagination
 
@@ -64,7 +71,8 @@ defmodule Raxol.Symphony.Trackers.GitHub do
   @page_size 100
   @default_endpoint "https://api.github.com"
   @max_id_concurrency 5
-  @id_fetch_timeout 10_000
+  @default_receive_timeout 15_000
+  @id_fetch_grace 5_000
 
   @impl true
   def fetch_candidate_issues(%Config{tracker: tracker} = _config) do
@@ -90,23 +98,42 @@ defmodule Raxol.Symphony.Trackers.GitHub do
   @impl true
   def fetch_issue_states_by_ids(%Config{tracker: tracker} = _config, ids) when is_list(ids) do
     with :ok <- validate(tracker) do
-      issues =
-        ids
-        |> Task.async_stream(
-          fn id -> fetch_one(tracker, id) end,
-          max_concurrency: @max_id_concurrency,
-          timeout: @id_fetch_timeout,
-          on_timeout: :kill_task,
-          ordered: true
-        )
-        |> Enum.flat_map(fn
-          {:ok, {:ok, issue}} -> [assign_state_name(issue, tracker)]
-          _ -> []
-        end)
+      ids
+      |> Task.async_stream(
+        fn id -> fetch_one(tracker, id) end,
+        max_concurrency: @max_id_concurrency,
+        timeout: id_fetch_timeout(),
+        on_timeout: :kill_task,
+        ordered: true
+      )
+      |> Enum.reduce_while({:ok, []}, &collect_one/2)
+      |> case do
+        {:ok, acc} ->
+          {:ok, acc |> Enum.reverse() |> Enum.map(&assign_state_name(&1, tracker))}
 
-      {:ok, issues}
+        {:error, _reason} = err ->
+          err
+      end
     end
   end
+
+  # An absent issue and an unreachable API must not reach the caller looking
+  # the same. `Orchestrator.retry_with_fresh_state/3` releases the issue on
+  # `{:ok, []}` and requeues the retry on `{:error, _}`; the runners'
+  # `still_active?/2` ends the run on `{:ok, []}`. Folding a 500 into an empty
+  # list therefore picked the destructive branch of both on a transient blip,
+  # and left those `{:error, _}` clauses unreachable on this tracker.
+  # `Trackers.Linear` already propagates transport failures, so this is also
+  # what stops the two disagreeing about what silence means.
+  defp collect_one({:ok, {:ok, issue}}, {:ok, acc}),
+    do: {:cont, {:ok, [issue | acc]}}
+
+  defp collect_one({:ok, :gone}, {:ok, acc}), do: {:cont, {:ok, acc}}
+
+  defp collect_one({:ok, {:error, reason}}, _acc), do: {:halt, {:error, reason}}
+
+  defp collect_one({:exit, reason}, _acc),
+    do: {:halt, {:error, {:github_api_request, reason}}}
 
   # -- Validation -------------------------------------------------------------
 
@@ -195,21 +222,45 @@ defmodule Raxol.Symphony.Trackers.GitHub do
   end
 
   defp fetch_one(tracker, id) do
-    path = "/repos/#{tracker.project_slug}/issues/#{id}"
+    tracker
+    |> client()
+    |> Req.get(url: "/repos/#{tracker.project_slug}/issues/#{id}")
+    |> classify_one()
+  end
 
-    case Req.get(client(tracker), url: path) do
-      {:ok, %Req.Response{status: 200, body: body}} when is_map(body) ->
-        case normalize_or_skip(body) do
-          [issue] -> {:ok, issue}
-          _ -> {:error, :github_unknown_payload}
-        end
-
-      {:ok, %Req.Response{status: status}} ->
-        {:error, {:github_api_status, status}}
-
-      {:error, reason} ->
-        {:error, {:github_api_request, reason}}
+  defp classify_one({:ok, %Req.Response{status: 200, body: body}}) when is_map(body) do
+    # A 200 that normalizes away is a pull request, which is not an issue this
+    # tracker owns: absent rather than broken.
+    case normalize_or_skip(body) do
+      [issue] -> {:ok, issue}
+      _ -> :gone
     end
+  end
+
+  defp classify_one({:ok, %Req.Response{status: 200}}),
+    do: {:error, :github_unknown_payload}
+
+  # The only two statuses that are knowledge rather than a failure to acquire
+  # it: 404 covers deleted, transferred, and not-visible-to-this-token; 410 is
+  # GitHub's answer for an issue deleted outright.
+  defp classify_one({:ok, %Req.Response{status: status}}) when status in [404, 410],
+    do: :gone
+
+  defp classify_one({:ok, %Req.Response{status: status}}),
+    do: {:error, {:github_api_status, status}}
+
+  defp classify_one({:error, reason}), do: {:error, {:github_api_request, reason}}
+
+  # The stream timeout has to sit ABOVE the HTTP receive timeout. At a fixed
+  # 10s against a 15s default it was the stream that killed a merely-slow
+  # request, so the configured `receive_timeout` never applied on this path and
+  # raising it did nothing.
+  defp id_fetch_timeout, do: receive_timeout() + @id_fetch_grace
+
+  defp receive_timeout do
+    :raxol_symphony
+    |> Application.get_env(:github, [])
+    |> Keyword.get(:receive_timeout, @default_receive_timeout)
   end
 
   # -- Header parsing ---------------------------------------------------------
@@ -317,18 +368,27 @@ defmodule Raxol.Symphony.Trackers.GitHub do
 
   defp extract_label_names(_), do: []
 
-  defp extract_state(labels) do
-    labels
-    |> Enum.find_value(fn
-      "state/" <> rest -> rest
-      "State/" <> rest -> rest
-      _ -> nil
-    end)
-    |> case do
-      nil -> ""
-      slug -> slug
+  defp extract_state(labels), do: Enum.find_value(labels, "", &state_slug/1)
+
+  # `state/<slug>`, with the prefix matched case-insensitively. The suffix
+  # already was (`slugify_state/1` downcases it), but the prefix was two
+  # hand-written spellings, so a repo labelling its issues `STATE/todo` had
+  # every issue read as stateless: the orchestrator polled a correctly
+  # labelled repo forever, claimed nothing, and raised no error saying why.
+  #
+  # Split rather than prefix-matched so `stateful` and `state-todo` stay what
+  # they are -- ordinary labels, not a state named `ful`.
+  defp state_slug(label) when is_binary(label) do
+    case String.split(label, "/", parts: 2) do
+      [prefix, rest] when rest != "" ->
+        if String.downcase(prefix) == "state", do: rest
+
+      _ ->
+        nil
     end
   end
+
+  defp state_slug(_), do: nil
 
   defp priority_from_labels(labels) do
     labels
@@ -360,7 +420,7 @@ defmodule Raxol.Symphony.Trackers.GitHub do
     extra = Application.get_env(:raxol_symphony, :github, [])
     plug = Keyword.get(extra, :plug)
     adapter = Keyword.get(extra, :adapter)
-    receive_timeout = Keyword.get(extra, :receive_timeout, 15_000)
+    receive_timeout = Keyword.get(extra, :receive_timeout, @default_receive_timeout)
     base_url = tracker.endpoint || @default_endpoint
 
     Raxol.Symphony.GitHub.Client.build(

--- a/packages/raxol_symphony/test/raxol/symphony/config/schema_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/config/schema_test.exs
@@ -148,4 +148,32 @@ defmodule Raxol.Symphony.Config.SchemaTest do
                Schema.validate(build_config(%{hooks: %{timeout_ms: 0}}))
     end
   end
+
+  describe "validate/1 -- tracker state lists" do
+    defp memory_config(tracker) do
+      Config.from_workflow(%{
+        config: %{tracker: Map.merge(%{kind: "memory"}, tracker)},
+        prompt_template: ""
+      })
+    end
+
+    test "an empty active_states key is rejected" do
+      assert {:error, {:invalid_value, :tracker_active_states, nil}} =
+               Schema.validate(memory_config(%{active_states: nil}))
+    end
+
+    test "a scalar active_states is rejected" do
+      assert {:error, {:invalid_value, :tracker_active_states, "Todo"}} =
+               Schema.validate(memory_config(%{active_states: "Todo"}))
+    end
+
+    test "a non-binary state name is rejected" do
+      assert {:error, {:invalid_value, :tracker_terminal_states, [1]}} =
+               Schema.validate(memory_config(%{terminal_states: [1]}))
+    end
+
+    test "an empty list is accepted -- it matches nothing, it does not crash" do
+      assert :ok = Schema.validate(memory_config(%{terminal_states: []}))
+    end
+  end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/config_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/config_test.exs
@@ -313,6 +313,115 @@ defmodule Raxol.Symphony.ConfigTest do
     end
   end
 
+  describe "load_and_validate/1 -- malformed front-matter sections" do
+    @tag :tmp_dir
+    test "rejects a section written with no body", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "WORKFLOW.md")
+
+      File.write!(path, """
+      ---
+      tracker:
+        kind: memory
+      polling:
+        # interval_ms: 30000
+      ---
+      hello
+      """)
+
+      assert {:error, {:workflow_section_not_a_map, [:polling]}} =
+               Config.load_and_validate(path)
+    end
+
+    @tag :tmp_dir
+    test "rejects a section written as a scalar", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "WORKFLOW.md")
+
+      File.write!(path, """
+      ---
+      tracker: memory
+      ---
+      hello
+      """)
+
+      assert {:error, {:workflow_section_not_a_map, [:tracker]}} =
+               Config.load_and_validate(path)
+    end
+
+    @tag :tmp_dir
+    test "rejects a section written as a list", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "WORKFLOW.md")
+
+      File.write!(path, """
+      ---
+      tracker:
+        kind: memory
+      workspace:
+        - /tmp/symphony
+      ---
+      hello
+      """)
+
+      assert {:error, {:workflow_section_not_a_map, [:workspace]}} =
+               Config.load_and_validate(path)
+    end
+
+    @tag :tmp_dir
+    test "rejects a malformed nested codex.auth section", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "WORKFLOW.md")
+
+      File.write!(path, """
+      ---
+      tracker:
+        kind: memory
+      codex:
+        auth: api_key
+      ---
+      hello
+      """)
+
+      assert {:error, {:workflow_section_not_a_map, [:codex, :auth]}} =
+               Config.load_and_validate(path)
+    end
+
+    @tag :tmp_dir
+    test "rejects a runner.agent block that lost its body", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "WORKFLOW.md")
+
+      File.write!(path, """
+      ---
+      tracker:
+        kind: memory
+      runner:
+        kind: raxol_agent
+        agent:
+      ---
+      hello
+      """)
+
+      assert {:error, {:workflow_section_not_a_map, [:runner, :agent]}} =
+               Config.load_and_validate(path)
+    end
+
+    @tag :tmp_dir
+    test "rejects a scalar runner.agent", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "WORKFLOW.md")
+
+      File.write!(path, """
+      ---
+      tracker:
+        kind: memory
+      runner:
+        kind: raxol_agent
+        agent: workflow_mode
+      ---
+      hello
+      """)
+
+      assert {:error, {:workflow_section_not_a_map, [:runner, :agent]}} =
+               Config.load_and_validate(path)
+    end
+  end
+
   describe "worker.ssh_hosts (issue #742)" do
     alias Raxol.Symphony.Config.Schema
 

--- a/packages/raxol_symphony/test/raxol/symphony/evidence/capture_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/evidence/capture_test.exs
@@ -76,6 +76,29 @@ defmodule Raxol.Symphony.Evidence.CaptureTest do
       assert byte_size(result) <= 16_400
       assert String.ends_with?(result, "...[truncated]")
     end
+
+    test "truncation cuts on a codepoint boundary" do
+      # An em dash (3 bytes) straddling the byte offset truncation lands on.
+      long_message =
+        String.duplicate("a", 16_369) <> "\u2014" <> String.duplicate("a", 5_000)
+
+      result = Capture.format_event(%{event: :text_delta, message: long_message})
+
+      assert String.valid?(result)
+      assert byte_size(result) <= 16_384
+      assert String.ends_with?(result, "...[truncated]")
+    end
+
+    test "a wholly invalid message stops trimming instead of eating the head" do
+      # Raw binary out of a tool result: no cut makes it valid, so the
+      # trim gives up after a codepoint's worth and the encoder drops it.
+      message = :binary.copy(<<0xFF>>, 20_000)
+
+      result = Capture.format_event(%{event: :tool_result, message: message})
+
+      refute String.valid?(result)
+      assert byte_size(result) > 16_000
+    end
   end
 
   describe "GenServer flow" do

--- a/packages/raxol_symphony/test/raxol/symphony/evidence/capture_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/evidence/capture_test.exs
@@ -27,9 +27,13 @@ defmodule Raxol.Symphony.Evidence.CaptureTest do
   end
 
   describe "path_for/2" do
-    test "uses attempt suffix when given an integer" do
-      assert Capture.path_for("/ws", 0) == "/ws/.raxol_symphony/run-0.cast"
-      assert Capture.path_for("/ws", 3) == "/ws/.raxol_symphony/run-3.cast"
+    test "carries the attempt in the name when given an integer" do
+      assert Capture.path_for("/ws", 0) =~ ~r{^/ws/\.raxol_symphony/run-0-\d+-\d+\.cast$}
+      assert Capture.path_for("/ws", 3) =~ ~r{^/ws/\.raxol_symphony/run-3-\d+-\d+\.cast$}
+    end
+
+    test "is unique per call for the same attempt" do
+      assert Capture.path_for("/ws", 1) != Capture.path_for("/ws", 1)
     end
 
     test "falls back to a unique suffix for nil attempt" do
@@ -167,6 +171,23 @@ defmodule Raxol.Symphony.Evidence.CaptureTest do
       :ok = Capture.stop(pid)
 
       refute File.exists?(bad_path)
+    end
+
+    test "a second dispatch at the same attempt keeps the earlier recording", %{
+      workspace: workspace
+    } do
+      first = Capture.path_for(workspace, 1)
+      {:ok, a} = Capture.start_link(path: first)
+      Capture.record(a, %{event: :text_delta, message: "first stretch"})
+      :ok = Capture.stop(a)
+
+      second = Capture.path_for(workspace, 1)
+      {:ok, b} = Capture.start_link(path: second)
+      Capture.record(b, %{event: :text_delta, message: "second stretch"})
+      :ok = Capture.stop(b)
+
+      assert Enum.any?(read_cast(first).frames, &(Enum.at(&1, 2) =~ "first stretch"))
+      assert Enum.any?(read_cast(second).frames, &(Enum.at(&1, 2) =~ "second stretch"))
     end
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/evidence/capture_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/evidence/capture_test.exs
@@ -108,7 +108,7 @@ defmodule Raxol.Symphony.Evidence.CaptureTest do
   describe "GenServer flow" do
     test "writes a valid asciicast v2 header on init", %{workspace: workspace} do
       path = Capture.path_for(workspace, 0)
-      {:ok, pid} = Capture.start_link(path: path, width: 132, height: 50, title: "MT-1")
+      {:ok, pid} = Capture.start(path: path, width: 132, height: 50, title: "MT-1")
       :ok = Capture.stop(pid)
 
       cast = read_cast(path)
@@ -124,7 +124,7 @@ defmodule Raxol.Symphony.Evidence.CaptureTest do
       workspace: workspace
     } do
       path = Capture.path_for(workspace, 1)
-      {:ok, pid} = Capture.start_link(path: path)
+      {:ok, pid} = Capture.start(path: path)
 
       Capture.record(pid, %{event: :session_started, message: "session abc"})
       Capture.record(pid, %{event: :text_delta, message: "hello"})
@@ -148,7 +148,7 @@ defmodule Raxol.Symphony.Evidence.CaptureTest do
       path = Capture.path_for(workspace, 0)
       refute File.dir?(Path.dirname(path))
 
-      {:ok, pid} = Capture.start_link(path: path)
+      {:ok, pid} = Capture.start(path: path)
       :ok = Capture.stop(pid)
 
       assert File.regular?(path)
@@ -166,28 +166,115 @@ defmodule Raxol.Symphony.Evidence.CaptureTest do
       File.write!(blocking, "not a dir")
       bad_path = Path.join(blocking, "run.cast")
 
-      {:ok, pid} = Capture.start_link(path: bad_path)
+      {:ok, pid} = Capture.start(path: bad_path)
       assert :ok = Capture.record(pid, %{event: :text_delta, message: "x"})
       :ok = Capture.stop(pid)
 
       refute File.exists?(bad_path)
     end
 
+    test "fails soft when the header can't be written", %{workspace: workspace} do
+      path = Capture.path_for(workspace, 0)
+
+      {:ok, pid} = Capture.start(path: path, title: <<0xFF>>)
+      assert :ok = Capture.record(pid, %{event: :text_delta, message: "x"})
+      :ok = Capture.stop(pid)
+
+      # A headerless cast is not a cast, so nothing is written at all.
+      assert File.read!(path) == ""
+    end
+
+    test "refuses a linked start", %{workspace: workspace} do
+      assert_raise ArgumentError, ~r/unlinked/, fn ->
+        Capture.start_link(path: Capture.path_for(workspace, 0))
+      end
+    end
+
     test "a second dispatch at the same attempt keeps the earlier recording", %{
       workspace: workspace
     } do
       first = Capture.path_for(workspace, 1)
-      {:ok, a} = Capture.start_link(path: first)
+      {:ok, a} = Capture.start(path: first)
       Capture.record(a, %{event: :text_delta, message: "first stretch"})
       :ok = Capture.stop(a)
 
       second = Capture.path_for(workspace, 1)
-      {:ok, b} = Capture.start_link(path: second)
+      {:ok, b} = Capture.start(path: second)
       Capture.record(b, %{event: :text_delta, message: "second stretch"})
       :ok = Capture.stop(b)
 
       assert Enum.any?(read_cast(first).frames, &(Enum.at(&1, 2) =~ "first stretch"))
       assert Enum.any?(read_cast(second).frames, &(Enum.at(&1, 2) =~ "second stretch"))
+    end
+
+    test "an unencodable frame costs that frame, not the process", %{workspace: workspace} do
+      path = Capture.path_for(workspace, 0)
+      {:ok, pid} = Capture.start(path: path)
+
+      Capture.record(pid, %{event: :text_delta, message: <<0xFF, 0xFE>>})
+      Capture.record(pid, %{event: :text_delta, message: "still here"})
+
+      :ok = Capture.stop(pid)
+
+      texts = Enum.map(read_cast(path).frames, &Enum.at(&1, 2))
+      assert texts == ["still here\r\n"]
+    end
+
+    test "a dead cast device retires the recording instead of the process", %{
+      workspace: workspace
+    } do
+      path = Capture.path_for(workspace, 0)
+      {:ok, pid} = Capture.start(path: path)
+
+      # Stands in for the disk going away mid-run.
+      :ok = pid |> :sys.get_state() |> Map.fetch!(:io) |> File.close()
+
+      Capture.record(pid, %{event: :text_delta, message: "into the void"})
+
+      assert Process.alive?(pid)
+      assert %{io: nil} = :sys.get_state(pid)
+
+      :ok = Capture.stop(pid)
+    end
+
+    test "an abnormal capture exit does not take its starter down", %{workspace: workspace} do
+      test_pid = self()
+
+      owner =
+        spawn(fn ->
+          {:ok, capture} = Capture.start(path: Capture.path_for(workspace, 0))
+          send(test_pid, {:capture, capture})
+          Process.sleep(:infinity)
+        end)
+
+      owner_ref = Process.monitor(owner)
+      assert_receive {:capture, capture}
+      capture_ref = Process.monitor(capture)
+
+      :ok = GenServer.stop(capture, :kaboom)
+
+      assert_receive {:DOWN, ^capture_ref, :process, ^capture, :kaboom}
+      refute_receive {:DOWN, ^owner_ref, :process, ^owner, _}, 200
+
+      Process.exit(owner, :kill)
+    end
+
+    test "a capture stops when the run that started it ends", %{workspace: workspace} do
+      test_pid = self()
+
+      owner =
+        spawn(fn ->
+          {:ok, capture} = Capture.start(path: Capture.path_for(workspace, 0))
+          send(test_pid, {:capture, capture})
+          receive do: (:finish -> :ok)
+        end)
+
+      assert_receive {:capture, capture}
+      capture_ref = Process.monitor(capture)
+
+      send(owner, :finish)
+
+      assert_receive {:DOWN, ^capture_ref, :process, ^capture, _}, 1_000
     end
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_host_pool_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_host_pool_test.exs
@@ -24,7 +24,7 @@ defmodule Raxol.Symphony.OrchestratorHostPoolTest do
     :ok
   end
 
-  defp config(ssh_hosts) do
+  defp config(ssh_hosts, max_retry_backoff_ms \\ 60_000) do
     Config.from_workflow(%{
       config: %{
         tracker: %{
@@ -33,7 +33,7 @@ defmodule Raxol.Symphony.OrchestratorHostPoolTest do
           terminal_states: ["Done", "Cancelled"]
         },
         polling: %{interval_ms: 60_000},
-        agent: %{max_concurrent_agents: 10, max_retry_backoff_ms: 60_000},
+        agent: %{max_concurrent_agents: 10, max_retry_backoff_ms: max_retry_backoff_ms},
         codex: %{stall_timeout_ms: 0},
         runner: %{kind: "noop"},
         worker: %{ssh_hosts: ssh_hosts}
@@ -169,6 +169,36 @@ defmodule Raxol.Symphony.OrchestratorHostPoolTest do
 
     :ok = Orchestrator.stop_run(pid, "a")
     assert Orchestrator.snapshot(pid).hosts == %{total: 1, free: 1, busy: 0}
+  end
+
+  test "a retry that fires with every host busy keeps its timer instead of stranding the claim" do
+    Memory.put_issues([issue("a", "HP-1"), issue("b", "HP-2")])
+    Noop.Director.set("HP-1", {:fail_after, 0, :boom})
+    Noop.Director.set("HP-2", :stall)
+
+    pid = start_orchestrator(config(["ci@build-1"], 400))
+    :ok = Orchestrator.tick_now(pid)
+
+    # HP-1's worker fails and frees the only host. Its failure retry holds the
+    # claim while it waits out the backoff.
+    wait_until(pid, fn s -> s.counts.retrying == 1 end)
+
+    # HP-2 takes the freed host, so HP-1's retry fires with the pool exhausted.
+    :ok = Orchestrator.tick_now(pid)
+    assert Orchestrator.snapshot(pid).hosts == %{total: 1, free: 0, busy: 1}
+
+    wait_until(pid, fn _snap ->
+      state = :sys.get_state(pid)
+
+      not Map.has_key?(state.retry_attempts, "a") or
+        get_in(state.retry_attempts, ["a", :error]) == :host_pool_exhausted
+    end)
+
+    state = :sys.get_state(pid)
+    assert MapSet.member?(state.claimed, "a")
+
+    assert Map.has_key?(state.retry_attempts, "a"),
+           "HP-1 is claimed with no run, no pause and no retry timer: nothing can re-dispatch it"
   end
 
   defp wait_until(pid, fun, timeout_ms \\ 1_000) do

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_test.exs
@@ -98,6 +98,47 @@ defmodule Raxol.Symphony.OrchestratorTest do
     if :ets.whereis(table) == :undefined, do: 0, else: :ets.info(table, :size)
   end
 
+  # The setup config with the agent caps (and optionally the workspace root)
+  # overridden, for the tests that turn one of those into the thing under test.
+  defp capped_config(overrides) do
+    agent =
+      %{
+        max_concurrent_agents: Keyword.get(overrides, :max_concurrent_agents, 3),
+        max_retry_backoff_ms: Keyword.get(overrides, :max_retry_backoff_ms, 60_000)
+      }
+
+    raw = %{
+      tracker: %{
+        kind: "memory",
+        active_states: ["Todo", "In Progress"],
+        terminal_states: ["Done", "Cancelled"]
+      },
+      polling: %{interval_ms: 60_000},
+      agent: agent,
+      codex: %{stall_timeout_ms: 0},
+      runner: %{kind: "noop"}
+    }
+
+    raw =
+      case Keyword.get(overrides, :workspace_root) do
+        nil -> raw
+        root -> Map.put(raw, :workspace, %{root: root})
+      end
+
+    Config.from_workflow(%{config: raw, prompt_template: ""})
+  end
+
+  defp retry_entry(pid, issue_id),
+    do: Map.get(:sys.get_state(pid).retry_attempts, issue_id)
+
+  # -1 when the issue has no retry entry, so a `>=` wait cannot pass on a nil.
+  defp retry_attempt(pid, issue_id) do
+    case retry_entry(pid, issue_id) do
+      %{attempt: attempt} when is_integer(attempt) -> attempt
+      _ -> -1
+    end
+  end
+
   defp wait_until(timeout_ms \\ 1_000, fun) do
     deadline = System.monotonic_time(:millisecond) + timeout_ms
     do_wait_until(deadline, fun)
@@ -241,6 +282,37 @@ defmodule Raxol.Symphony.OrchestratorTest do
       # in entry.issue, not the snapshot's :state. Both behaviours are acceptable
       # per SPEC s8.5; we just assert the run is still active.
       assert running.issue_id == "a"
+    end
+  end
+
+  describe "workspace failure retries" do
+    test "a workspace that cannot be created escalates the retry attempt" do
+      # A regular file where the workspace root should be: every `mkdir_p`
+      # under it fails with :enotdir, on this attempt and on every retry.
+      root =
+        Path.join(
+          System.tmp_dir!(),
+          "symphony_ws_not_a_dir_#{System.unique_integer([:positive])}"
+        )
+
+      File.write!(root, "not a directory")
+      on_exit(fn -> File.rm(root) end)
+
+      config = capped_config(max_retry_backoff_ms: 50, workspace_root: root)
+      Memory.put_issue(issue("a", "MT-1", "Todo"))
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+
+      wait_until(fn -> Orchestrator.snapshot(pid).counts.retrying == 1 end)
+      [retry] = Orchestrator.snapshot(pid).retrying
+
+      assert retry.attempt == 1,
+             "the first workspace failure recorded attempt #{inspect(retry.attempt)}"
+
+      # And every subsequent failure carries the count forward, so the backoff
+      # can actually grow rather than pinning at one delay forever.
+      wait_until(fn -> retry_attempt(pid, "a") >= 3 end)
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_test.exs
@@ -284,11 +284,51 @@ defmodule Raxol.Symphony.OrchestratorTest do
       :ok = Orchestrator.tick_now(pid)
 
       [running] = Orchestrator.snapshot(pid).running
-      assert running.state == "Todo"
-      # state field is what was at dispatch; the update happens to issue snapshot
-      # in entry.issue, not the snapshot's :state. Both behaviours are acceptable
-      # per SPEC s8.5; we just assert the run is still active.
       assert running.issue_id == "a"
+
+      assert running.state == "In Progress",
+             "the snapshot reports a state the tracker no longer holds; got #{inspect(running.state)}"
+    end
+
+    test "a reconciled state change is counted against the per-state cap" do
+      # One "In Progress" slot. MT-1 is dispatched from Todo and then advanced
+      # to In Progress by its agent -- the ordinary Symphony workflow. Once
+      # reconcile has seen that, MT-2 (already In Progress) must not be
+      # dispatched, or two agents run in a state capped at one.
+      config =
+        Config.from_workflow(%{
+          config: %{
+            tracker: %{
+              kind: "memory",
+              active_states: ["Todo", "In Progress"],
+              terminal_states: ["Done", "Cancelled"]
+            },
+            polling: %{interval_ms: 60_000},
+            agent: %{
+              max_concurrent_agents: 3,
+              max_retry_backoff_ms: 60_000,
+              max_concurrent_agents_by_state: %{"In Progress" => 1}
+            },
+            codex: %{stall_timeout_ms: 0},
+            runner: %{kind: "noop"}
+          },
+          prompt_template: ""
+        })
+
+      Memory.put_issue(issue("a", "MT-1", "Todo"))
+      Noop.Director.set("MT-1", :stall)
+      Noop.Director.set("MT-2", :stall)
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+      assert Orchestrator.snapshot(pid).counts.running == 1
+
+      Memory.transition("a", "In Progress")
+      Memory.put_issue(issue("b", "MT-2", "In Progress"))
+      :ok = Orchestrator.tick_now(pid)
+
+      assert Orchestrator.snapshot(pid).counts.running == 1,
+             "MT-2 was dispatched because the running entry still counts under its dispatch-time state"
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_test.exs
@@ -131,6 +131,13 @@ defmodule Raxol.Symphony.OrchestratorTest do
   defp retry_entry(pid, issue_id),
     do: Map.get(:sys.get_state(pid).retry_attempts, issue_id)
 
+  defp retry_error(pid, issue_id) do
+    case retry_entry(pid, issue_id) do
+      nil -> nil
+      entry -> entry.error
+    end
+  end
+
   # -1 when the issue has no retry entry, so a `>=` wait cannot pass on a nil.
   defp retry_attempt(pid, issue_id) do
     case retry_entry(pid, issue_id) do
@@ -285,6 +292,44 @@ defmodule Raxol.Symphony.OrchestratorTest do
     end
   end
 
+  describe "concurrency caps on the retry path" do
+    test "a retry that fires while the cap is full waits for a slot" do
+      # One agent slot. MT-1 fails immediately and is parked on a backoff;
+      # while it waits, MT-2 takes the freed slot. The retry timer then fires
+      # with the cap already full.
+      config = capped_config(max_concurrent_agents: 1, max_retry_backoff_ms: 400)
+
+      Memory.put_issues([issue("a", "MT-1", "Todo"), issue("b", "MT-2", "Todo")])
+      Noop.Director.set("MT-1", {:fail_after, 0, :boom})
+      Noop.Director.set("MT-2", :stall)
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+
+      wait_until(fn -> Orchestrator.snapshot(pid).counts.retrying == 1 end)
+
+      # A re-dispatched MT-1 now sticks in `running` instead of failing again,
+      # so the over-subscription is observable rather than instantaneous.
+      Noop.Director.set("MT-1", :stall)
+
+      :ok = Orchestrator.tick_now(pid)
+      assert Orchestrator.snapshot(pid).counts.running == 1
+
+      # Either the retry re-dispatched MT-1 (over the cap) or it re-armed.
+      wait_until(fn ->
+        Map.has_key?(:sys.get_state(pid).running, "a") or
+          retry_error(pid, "a") == :awaiting_concurrency_slot
+      end)
+
+      snap = Orchestrator.snapshot(pid)
+
+      assert snap.counts.running == 1,
+             "the retry dispatched past max_concurrent_agents: running=#{snap.counts.running}"
+
+      assert Enum.map(snap.running, & &1.issue_id) == ["b"]
+    end
+  end
+
   describe "workspace failure retries" do
     test "a workspace that cannot be created escalates the retry attempt" do
       # A regular file where the workspace root should be: every `mkdir_p`
@@ -436,6 +481,66 @@ defmodule Raxol.Symphony.OrchestratorTest do
       [paused] = Orchestrator.snapshot(pid).paused
       assert paused.turn_count == 1
       assert paused.tokens.total_tokens == 30
+    end
+  end
+
+  # One agent allowed: MT-1 parks on the first tick, MT-2 takes the only slot on
+  # the second (MT-1 is claimed, so it is not re-dispatched).
+  defp park_one_and_fill_the_slot do
+    Memory.put_issue(issue("a", "MT-1", "Todo"))
+    Memory.put_issue(issue("b", "MT-2", "Todo"))
+    Noop.Director.set("MT-1", {:pause_then, :awaiting_review, "rt", :stall})
+    Noop.Director.set("MT-2", :stall)
+
+    pid = start_orchestrator(capped_config(max_concurrent_agents: 1))
+
+    :ok = Orchestrator.tick_now(pid)
+    wait_until(fn -> Orchestrator.snapshot(pid).counts.paused == 1 end)
+
+    :ok = Orchestrator.tick_now(pid)
+    assert Orchestrator.snapshot(pid).counts.running == 1
+
+    pid
+  end
+
+  # A paused run holds no `running` entry, so every parked issue sees the caps
+  # as free at once. `Resumer.fan_out_matches/2` resumes EVERY paused entry one
+  # telemetry event matches, which without a cap check starts one agent per
+  # parked issue with no human in the loop.
+  describe "resume under the concurrency cap" do
+    test "resume_run/3 with no free slot leaves the run parked" do
+      pid = park_one_and_fill_the_slot()
+      :ok = Orchestrator.subscribe(pid)
+
+      assert :ok = Orchestrator.resume_run(pid, "a", :approved)
+
+      snap = Orchestrator.snapshot(pid)
+      assert snap.counts.running == 1
+      assert [%{issue_id: "a", resume_pending?: true}] = snap.paused
+      assert_receive {:symphony_event, :run_resume_deferred, _}, 500
+    end
+
+    test "a resume queued behind the cap dispatches once a slot frees" do
+      pid = park_one_and_fill_the_slot()
+
+      assert :ok = Orchestrator.resume_run(pid, "a", :approved)
+      assert Orchestrator.snapshot(pid).counts.paused == 1
+
+      # Free the only slot: the tracker takes MT-2 terminal, so reconcile tears
+      # its run down earlier in the same tick that drains the queued resume.
+      Memory.transition("b", "Done")
+      :ok = Orchestrator.tick_now(pid)
+
+      # `last_event: :resumed` is sent by the runner itself, so it proves the
+      # resumed worker ran rather than that the entry merely left `paused`.
+      wait_until(fn ->
+        match?(
+          [%{issue_id: "a", last_event: :resumed}],
+          Orchestrator.snapshot(pid).running
+        )
+      end)
+
+      assert Orchestrator.snapshot(pid).counts.paused == 0
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_tick_timer_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_tick_timer_test.exs
@@ -1,0 +1,107 @@
+defmodule Raxol.Symphony.OrchestratorTickTimerTest do
+  @moduledoc """
+  One poll timer chain, always.
+
+  `Process.cancel_timer/1` does not unsend a message that has already been
+  delivered, so a `run_tick` that outlives the poll interval leaves a tick
+  queued behind the reschedule that follows it. Treating that stale tick as
+  the live one arms a second timer and orphans the first, and every recurrence
+  adds another chain -- permanently multiplying tracker polling with no way
+  back short of restarting the orchestrator.
+
+  The ordering is produced deterministically with `:sys.suspend/1`: the refresh
+  cast is queued first, the poll timer expires behind it, and both are handled
+  on resume.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Symphony.{Config, Orchestrator}
+  alias Raxol.Symphony.Runners.Noop
+  alias Raxol.Symphony.Trackers.Memory
+
+  setup do
+    start_supervised!({Task.Supervisor, name: Raxol.Symphony.TaskSupervisor})
+    start_supervised!({Memory, []})
+    start_supervised!(Noop.Director)
+    Noop.Director.clear()
+    :ok
+  end
+
+  @interval_ms 200
+
+  defp config do
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{
+          kind: "memory",
+          active_states: ["Todo", "In Progress"],
+          terminal_states: ["Done", "Cancelled"]
+        },
+        polling: %{interval_ms: @interval_ms},
+        agent: %{max_concurrent_agents: 3, max_retry_backoff_ms: 60_000},
+        codex: %{stall_timeout_ms: 0},
+        runner: %{kind: "noop"}
+      },
+      prompt_template: ""
+    })
+  end
+
+  defp start_orchestrator do
+    {:ok, pid} =
+      start_supervised(
+        {Orchestrator, config: config(), runner_module: Noop, auto_start_tick: false, name: nil},
+        id: {Orchestrator, make_ref()}
+      )
+
+    pid
+  end
+
+  defp queue_len(pid) do
+    {:message_queue_len, len} = Process.info(pid, :message_queue_len)
+    len
+  end
+
+  defp wait_until(fun, timeout_ms \\ 2_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(fun, deadline)
+  end
+
+  defp do_wait_until(fun, deadline) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("wait_until timed out")
+
+      true ->
+        Process.sleep(10)
+        do_wait_until(fun, deadline)
+    end
+  end
+
+  test "a tick delivered before its own reschedule does not start a second timer chain" do
+    pid = start_orchestrator()
+    :ok = Orchestrator.subscribe(pid)
+
+    # Arm the poll timer and consume the event the arming tick emitted.
+    Orchestrator.refresh(pid)
+    assert_receive {:symphony_event, :tick_completed, _}, 1_000
+    timer_ref = :sys.get_state(pid).tick_timer_ref
+    assert is_reference(timer_ref)
+
+    :sys.suspend(pid)
+    Orchestrator.refresh(pid)
+    wait_until(fn -> Process.read_timer(timer_ref) == false end)
+    wait_until(fn -> queue_len(pid) >= 2 end)
+    :sys.resume(pid)
+
+    # The refresh runs its own poll cycle and reschedules.
+    assert_receive {:symphony_event, :tick_completed, _}, 1_000
+
+    # The superseded tick must be dropped. Running it would poll the tracker a
+    # second time and leave two live timers behind. The window is half the poll
+    # interval, so the legitimate next tick cannot account for the event.
+    refute_receive {:symphony_event, :tick_completed, _}, div(@interval_ms, 2)
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_tracker_outage_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_tracker_outage_test.exs
@@ -1,0 +1,175 @@
+defmodule Raxol.Symphony.OrchestratorTrackerOutageTest do
+  @moduledoc """
+  What a retry does when the tracker cannot answer.
+
+  `retry_with_fresh_state/3` re-reads the issue before re-dispatching it. When
+  that read fails the issue is neither known-active nor known-gone, so the retry
+  is re-armed -- and that re-arm is the only retry path in the orchestrator that
+  could skip the exponential backoff, freeze the attempt counter, and wrap the
+  PREVIOUS recorded error instead of the current cause.
+
+  The tracker is a real `Trackers.Linear` over a `Plug` stub (the seam
+  `linear_test.exs` uses), because the Memory tracker cannot fail.
+  """
+  use ExUnit.Case, async: false
+
+  alias Raxol.Symphony.{Config, Orchestrator}
+  alias Raxol.Symphony.Orchestrator.Retry
+  alias Raxol.Symphony.Runners.Noop
+
+  setup do
+    start_supervised!({Task.Supervisor, name: Raxol.Symphony.TaskSupervisor})
+    start_supervised!(Noop.Director)
+    Noop.Director.clear()
+    on_exit(fn -> Application.delete_env(:raxol_symphony, :linear) end)
+    :ok
+  end
+
+  @issue_id "iss_1"
+
+  defp config(max_retry_backoff_ms) do
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{
+          kind: "linear",
+          api_key: "lin_api_test",
+          project_slug: "demo",
+          active_states: ["Todo", "In Progress"],
+          terminal_states: ["Done", "Cancelled"]
+        },
+        polling: %{interval_ms: 60_000},
+        agent: %{max_concurrent_agents: 3, max_retry_backoff_ms: max_retry_backoff_ms},
+        codex: %{stall_timeout_ms: 0},
+        runner: %{kind: "noop"}
+      },
+      prompt_template: ""
+    })
+  end
+
+  # Candidate polls filter by project and are answered; the per-ID refresh a
+  # retry does is answered with 500, which is what `fetch_issue_states_by_ids/2`
+  # turns into `{:error, {:linear_api_status, 500}}`.
+  defp install_tracker_that_fails_id_lookups do
+    plug = fn conn ->
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      filter = get_in(Jason.decode!(body), ["variables", "filter"])
+
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> respond(filter)
+    end
+
+    Application.put_env(:raxol_symphony, :linear, plug: plug)
+  end
+
+  defp respond(conn, %{"id" => _}), do: Plug.Conn.send_resp(conn, 500, ~s({"message":"boom"}))
+
+  defp respond(conn, _project_filter) do
+    Plug.Conn.send_resp(conn, 200, Jason.encode!(candidates_payload()))
+  end
+
+  defp candidates_payload do
+    node = %{
+      "id" => @issue_id,
+      "identifier" => "MT-1",
+      "title" => "Hello",
+      "priority" => 2,
+      "createdAt" => "2026-05-01T12:00:00Z",
+      "updatedAt" => "2026-05-02T12:00:00Z",
+      "state" => %{"name" => "Todo"},
+      "labels" => %{"nodes" => []},
+      "inverseRelations" => %{"nodes" => []}
+    }
+
+    %{
+      "data" => %{
+        "issues" => %{
+          "nodes" => [node],
+          "pageInfo" => %{"hasNextPage" => false, "endCursor" => nil}
+        }
+      }
+    }
+  end
+
+  defp start_orchestrator(config) do
+    {:ok, pid} =
+      start_supervised(
+        {Orchestrator, config: config, runner_module: Noop, auto_start_tick: false, name: nil},
+        id: {Orchestrator, make_ref()}
+      )
+
+    pid
+  end
+
+  defp retry_entry(pid), do: Map.get(:sys.get_state(pid).retry_attempts, @issue_id)
+
+  defp requeued?(pid) do
+    match?(%{error: {:tracker_unavailable_during_retry, _}}, retry_entry(pid))
+  end
+
+  defp wait_until(timeout_ms \\ 3_000, fun) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_until(deadline, fun)
+  end
+
+  defp do_wait_until(deadline, fun) do
+    cond do
+      fun.() ->
+        :ok
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        flunk("wait_until timed out")
+
+      true ->
+        Process.sleep(10)
+        do_wait_until(deadline, fun)
+    end
+  end
+
+  test "an unreachable tracker backs the retry off instead of re-arming at the continuation delay" do
+    install_tracker_that_fails_id_lookups()
+    Noop.Director.set("MT-1", {:succeed_after, 0})
+
+    pid = start_orchestrator(config(60_000))
+    :ok = Orchestrator.tick_now(pid)
+
+    # The clean worker exit arms a continuation retry at attempt 1; when it
+    # fires, the per-ID refresh 500s and the entry is re-armed.
+    wait_until(fn -> requeued?(pid) end)
+
+    entry = retry_entry(pid)
+    remaining = entry.due_at_ms - System.monotonic_time(:millisecond)
+
+    assert entry.attempt == 2,
+           "the requeue must escalate the attempt, otherwise the backoff never grows; " <>
+             "got #{inspect(entry.attempt)}"
+
+    assert remaining > Retry.continuation_delay_ms(),
+           "the requeue re-armed at the flat continuation delay instead of backing off; " <>
+             "#{remaining}ms remaining"
+
+    assert entry.error == {:tracker_unavailable_during_retry, {:linear_api_status, 500}},
+           "the requeue must record the failure that caused it; got #{inspect(entry.error)}"
+  end
+
+  test "repeated tracker failures do not nest the recorded error" do
+    install_tracker_that_fails_id_lookups()
+    Noop.Director.set("MT-1", {:fail_after, 0, :boom})
+
+    # A 50ms ceiling keeps every backoff at 50ms, so two requeues are observable
+    # without waiting out a real exponential delay.
+    pid = start_orchestrator(config(50))
+    :ok = Orchestrator.tick_now(pid)
+
+    wait_until(fn -> requeued?(pid) end)
+    first = retry_entry(pid)
+
+    wait_until(fn -> requeued?(pid) and retry_entry(pid).timer_ref != first.timer_ref end)
+
+    second = retry_entry(pid)
+
+    assert second.error == {:tracker_unavailable_during_retry, {:linear_api_status, 500}},
+           "each requeue must wrap the current cause, not the previous entry's error; " <>
+             "got #{inspect(second.error)}"
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_tracker_outage_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_tracker_outage_test.exs
@@ -27,7 +27,11 @@ defmodule Raxol.Symphony.OrchestratorTrackerOutageTest do
 
   @issue_id "iss_1"
 
-  defp config(max_retry_backoff_ms) do
+  defp config(opts) do
+    agent =
+      %{max_concurrent_agents: 3, max_retry_backoff_ms: Keyword.fetch!(opts, :backoff)}
+      |> put_if(:max_tracker_requeues, Keyword.get(opts, :max_tracker_requeues))
+
     Config.from_workflow(%{
       config: %{
         tracker: %{
@@ -38,7 +42,7 @@ defmodule Raxol.Symphony.OrchestratorTrackerOutageTest do
           terminal_states: ["Done", "Cancelled"]
         },
         polling: %{interval_ms: 60_000},
-        agent: %{max_concurrent_agents: 3, max_retry_backoff_ms: max_retry_backoff_ms},
+        agent: agent,
         codex: %{stall_timeout_ms: 0},
         runner: %{kind: "noop"}
       },
@@ -46,45 +50,65 @@ defmodule Raxol.Symphony.OrchestratorTrackerOutageTest do
     })
   end
 
-  # Candidate polls filter by project and are answered; the per-ID refresh a
-  # retry does is answered with 500, which is what `fetch_issue_states_by_ids/2`
-  # turns into `{:error, {:linear_api_status, 500}}`.
-  defp install_tracker_that_fails_id_lookups do
+  defp put_if(map, _key, nil), do: map
+  defp put_if(map, key, value), do: Map.put(map, key, value)
+
+  # Candidate polls filter by project and are answered normally; only the
+  # per-ID refresh a retry does is under test, so each case supplies its own
+  # responder for that leg.
+  defp install_tracker(id_responder) do
     plug = fn conn ->
       {:ok, body, conn} = Plug.Conn.read_body(conn)
       filter = get_in(Jason.decode!(body), ["variables", "filter"])
 
       conn
       |> Plug.Conn.put_resp_content_type("application/json")
-      |> respond(filter)
+      |> respond(filter, id_responder)
     end
 
     Application.put_env(:raxol_symphony, :linear, plug: plug)
   end
 
-  defp respond(conn, %{"id" => _}), do: Plug.Conn.send_resp(conn, 500, ~s({"message":"boom"}))
-
-  defp respond(conn, _project_filter) do
-    Plug.Conn.send_resp(conn, 200, Jason.encode!(candidates_payload()))
+  # A 500 is what `fetch_issue_states_by_ids/2` turns into
+  # `{:error, {:linear_api_status, 500}}`.
+  defp install_tracker_that_fails_id_lookups do
+    install_tracker(fn conn -> Plug.Conn.send_resp(conn, 500, ~s({"message":"boom"})) end)
   end
 
-  defp candidates_payload do
-    node = %{
-      "id" => @issue_id,
-      "identifier" => "MT-1",
+  # A single-ID query answered with more than one issue. Linear maps every
+  # returned node to an `Issue`, so the orchestrator gets a two-element list
+  # back from a query it asked one ID for.
+  defp install_tracker_that_answers_with(nodes) do
+    install_tracker(fn conn ->
+      Plug.Conn.send_resp(conn, 200, Jason.encode!(payload(nodes)))
+    end)
+  end
+
+  defp respond(conn, %{"id" => _}, id_responder), do: id_responder.(conn)
+
+  defp respond(conn, _project_filter, _id_responder) do
+    Plug.Conn.send_resp(conn, 200, Jason.encode!(payload([node(@issue_id, "MT-1")])))
+  end
+
+  defp node(id, identifier, state \\ "Todo") do
+    %{
+      "id" => id,
+      "identifier" => identifier,
       "title" => "Hello",
       "priority" => 2,
       "createdAt" => "2026-05-01T12:00:00Z",
       "updatedAt" => "2026-05-02T12:00:00Z",
-      "state" => %{"name" => "Todo"},
+      "state" => %{"name" => state},
       "labels" => %{"nodes" => []},
       "inverseRelations" => %{"nodes" => []}
     }
+  end
 
+  defp payload(nodes) do
     %{
       "data" => %{
         "issues" => %{
-          "nodes" => [node],
+          "nodes" => nodes,
           "pageInfo" => %{"hasNextPage" => false, "endCursor" => nil}
         }
       }
@@ -130,7 +154,7 @@ defmodule Raxol.Symphony.OrchestratorTrackerOutageTest do
     install_tracker_that_fails_id_lookups()
     Noop.Director.set("MT-1", {:succeed_after, 0})
 
-    pid = start_orchestrator(config(60_000))
+    pid = start_orchestrator(config(backoff: 60_000))
     :ok = Orchestrator.tick_now(pid)
 
     # The clean worker exit arms a continuation retry at attempt 1; when it
@@ -140,9 +164,9 @@ defmodule Raxol.Symphony.OrchestratorTrackerOutageTest do
     entry = retry_entry(pid)
     remaining = entry.due_at_ms - System.monotonic_time(:millisecond)
 
-    assert entry.attempt == 2,
-           "the requeue must escalate the attempt, otherwise the backoff never grows; " <>
-             "got #{inspect(entry.attempt)}"
+    assert entry.requeues == 1,
+           "the requeue must escalate its own counter, otherwise the backoff never grows; " <>
+             "got #{inspect(entry.requeues)}"
 
     assert remaining > Retry.continuation_delay_ms(),
            "the requeue re-armed at the flat continuation delay instead of backing off; " <>
@@ -152,13 +176,39 @@ defmodule Raxol.Symphony.OrchestratorTrackerOutageTest do
            "the requeue must record the failure that caused it; got #{inspect(entry.error)}"
   end
 
+  # The backoff has to grow across an outage, but growing it by incrementing
+  # `attempt` conflates two different numbers: `attempt` is what reaches the
+  # prompt template and the cast filename, so an agent that never ran once is
+  # told it is on attempt 12 of a run that has not started.
+  test "a tracker outage does not inflate the execution attempt the agent is told about" do
+    install_tracker_that_fails_id_lookups()
+    Noop.Director.set("MT-1", {:fail_after, 0, :boom})
+
+    pid = start_orchestrator(config(backoff: 50))
+    :ok = Orchestrator.tick_now(pid)
+
+    wait_until(fn -> requeued?(pid) end)
+    first = retry_entry(pid)
+
+    wait_until(fn -> requeues_reached(pid, 3) end)
+    later = retry_entry(pid)
+
+    assert later.attempt == first.attempt,
+           "a tracker outage must not move the execution attempt: the agent never ran. " <>
+             "Went from #{inspect(first.attempt)} to #{inspect(later.attempt)}"
+
+    assert later.requeues > first.requeues,
+           "the outage counter must still escalate so the backoff grows; " <>
+             "stuck at #{inspect(later.requeues)}"
+  end
+
   test "repeated tracker failures do not nest the recorded error" do
     install_tracker_that_fails_id_lookups()
     Noop.Director.set("MT-1", {:fail_after, 0, :boom})
 
     # A 50ms ceiling keeps every backoff at 50ms, so two requeues are observable
     # without waiting out a real exponential delay.
-    pid = start_orchestrator(config(50))
+    pid = start_orchestrator(config(backoff: 50))
     :ok = Orchestrator.tick_now(pid)
 
     wait_until(fn -> requeued?(pid) end)
@@ -171,5 +221,83 @@ defmodule Raxol.Symphony.OrchestratorTrackerOutageTest do
     assert second.error == {:tracker_unavailable_during_retry, {:linear_api_status, 500}},
            "each requeue must wrap the current cause, not the previous entry's error; " <>
              "got #{inspect(second.error)}"
+  end
+
+  # Without a terminal give-up the requeue loop is unbounded: an indefinitely
+  # unreachable tracker holds the claim forever, so the issue is in no running,
+  # batch or paused map and `Candidate.eligible/4` skips it for good.
+  test "an indefinitely unreachable tracker eventually releases the claim instead of holding it" do
+    install_tracker_that_fails_id_lookups()
+    Noop.Director.set("MT-1", {:fail_after, 0, :boom})
+
+    pid = start_orchestrator(config(backoff: 50, max_tracker_requeues: 2))
+    :ok = Orchestrator.tick_now(pid)
+
+    wait_until(fn -> requeued?(pid) end)
+
+    wait_until(fn -> retry_entry(pid) == nil end)
+
+    state = :sys.get_state(pid)
+
+    refute MapSet.member?(state.claimed, @issue_id),
+           "giving up must release the claim, otherwise the issue is stranded: " <>
+             "claimed but in no running, batch, paused or retry map"
+
+    assert state.retry_attempts == %{},
+           "giving up must not leave a timer behind; got #{inspect(state.retry_attempts)}"
+  end
+
+  # `retry_with_fresh_state/3` matched `{:ok, [issue]}`, `{:ok, []}` and
+  # `{:error, _}` only, so a tracker answering a single-ID query with two rows
+  # raised CaseClauseError inside the orchestrator's own callback.
+  test "a single-ID query answered with two issues takes the matching row" do
+    install_tracker_that_answers_with([
+      node("iss_other", "MT-99"),
+      node(@issue_id, "MT-1")
+    ])
+
+    Noop.Director.set("MT-1", {:succeed_after, 0})
+
+    pid = start_orchestrator(config(backoff: 50))
+    ref = Process.monitor(pid)
+    :ok = Orchestrator.tick_now(pid)
+
+    # Wait for the continuation retry to be ARMED before watching for its fire:
+    # `retry_attempts` is empty at boot too, so waiting on the empty map alone
+    # would pass before the ambiguous answer was ever read.
+    wait_until(fn -> retry_entry(pid) != nil end)
+
+    # `retry_with_fresh_state/3` runs in the orchestrator's own callback, so a
+    # CaseClauseError on the two-row answer takes the whole orchestrator down.
+    refute_receive {:DOWN, ^ref, :process, ^pid, _}, 2_500
+
+    state = :sys.get_state(pid)
+
+    assert MapSet.member?(state.claimed, @issue_id),
+           "the row we asked for was in the answer, so the issue stays claimed"
+
+    refute MapSet.member?(state.claimed, "iss_other"),
+           "a row the query did not ask for must not be acted on as if it were ours"
+  end
+
+  test "a single-ID query answered only with rows it did not ask for is requeued, not released" do
+    install_tracker_that_answers_with([node("iss_other", "MT-99")])
+
+    Noop.Director.set("MT-1", {:succeed_after, 0})
+
+    pid = start_orchestrator(config(backoff: 50))
+    :ok = Orchestrator.tick_now(pid)
+
+    wait_until(fn -> requeued?(pid) end)
+
+    assert Process.alive?(pid)
+
+    assert MapSet.member?(:sys.get_state(pid).claimed, @issue_id),
+           "an answer that never mentions the issue says nothing about it, so the " <>
+             "claim must be held and retried rather than released"
+  end
+
+  defp requeues_reached(pid, n) do
+    match?(%{requeues: r} when r >= n, retry_entry(pid))
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/orchestrator_workflow_mode_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/orchestrator_workflow_mode_test.exs
@@ -124,6 +124,37 @@ defmodule Raxol.Symphony.OrchestratorWorkflowModeTest do
       end)
     end
 
+    test "a runner pause under :graph mode parks the run instead of retrying it" do
+      # The graph reports a runner pause as an interrupt. Classifying that as an
+      # abnormal exit re-runs the whole agent on a backoff and leaves `paused`
+      # empty, so no surface can ever approve it.
+      config = build_config(:graph)
+      Memory.put_issue(issue("g3", "GT-3", "Todo"))
+      Noop.Director.set("GT-3", {:pause_then, :awaiting_review, "tok", {:succeed_after, 0}})
+
+      pid = start_orchestrator(config)
+      :ok = Orchestrator.tick_now(pid)
+
+      wait_until(2_000, fn ->
+        snap = Orchestrator.snapshot(pid)
+        snap.counts.paused == 1 or snap.counts.retrying == 1
+      end)
+
+      snap = Orchestrator.snapshot(pid)
+
+      assert snap.counts.paused == 1,
+             "the graph interrupt was retried instead of parked: #{inspect(snap.retrying)}"
+
+      assert [%{interrupt_reason: :awaiting_review}] = snap.paused
+
+      :ok = Orchestrator.resume_run(pid, "g3", :approved)
+
+      wait_until(2_000, fn ->
+        Orchestrator.snapshot(pid).counts.paused == 0 and
+          MapSet.member?(:sys.get_state(pid).completed, "g3")
+      end)
+    end
+
     test ":default mode still dispatches without invoking the graph runtime" do
       # Sanity: the default path is unaffected. Distinguishing path is
       # implicit (same outcome shape); this just guards the regression.

--- a/packages/raxol_symphony/test/raxol/symphony/runners/codex_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/codex_test.exs
@@ -235,6 +235,161 @@ defmodule Raxol.Symphony.Runners.CodexTest do
     end
 
     @tag :unix_only
+    test "an :approved resume answers the approval Codex re-requests", %{
+      workspace: workspace
+    } do
+      System.put_env("FAKE_CODEX_MODE", "approval")
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      cfg = put_in(config().codex.approval_policy, "request")
+
+      assert :ok =
+               Codex.run(issue(), cfg,
+                 parent: self(),
+                 attempt: nil,
+                 workspace_path: workspace,
+                 resume_value: :approved,
+                 resume_token: %{decision: "acceptForSession", turn: 1}
+               )
+
+      events = collect_events("issue-1", 100)
+      assert Enum.any?(events, &(&1.event == :turn_completed))
+    after
+      System.delete_env("FAKE_CODEX_MODE")
+    end
+
+    @tag :unix_only
+    test "each approval clears one more approval point", %{workspace: workspace} do
+      System.put_env("FAKE_CODEX_MODE", "approval2")
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      cfg = put_in(config().codex.approval_policy, "request")
+
+      # The first approval is spent on the request the fresh session replays;
+      # the second request is what we pause on.
+      assert {:pause, :awaiting_approval, token} =
+               Codex.run(issue(), cfg,
+                 parent: self(),
+                 attempt: nil,
+                 workspace_path: workspace,
+                 resume_value: :approved,
+                 resume_token: %{decision: "acceptForSession", turn: 1, approvals_granted: 0}
+               )
+
+      assert token.approvals_granted == 1
+
+      events = collect_events("issue-1", 100)
+      assert Enum.count(events, &(&1.event == :blocked)) == 2
+
+      # Approving again carries that count forward, so the resumed run answers
+      # both and finishes. Without it the run would park on the same second
+      # request no matter how many times an operator said yes.
+      assert :ok =
+               Codex.run(issue(), cfg,
+                 parent: self(),
+                 attempt: nil,
+                 workspace_path: workspace,
+                 resume_value: :approved,
+                 resume_token: token
+               )
+    after
+      System.delete_env("FAKE_CODEX_MODE")
+    end
+
+    @tag :unix_only
+    test "an unreadable approval count is not a blanket grant", %{workspace: workspace} do
+      System.put_env("FAKE_CODEX_MODE", "approval2")
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      cfg = put_in(config().codex.approval_policy, "request")
+
+      # A token whose count we cannot read counts as zero cleared, so this
+      # approval grants one request and the second still stops for a human.
+      assert {:pause, :awaiting_approval, token} =
+               Codex.run(issue(), cfg,
+                 parent: self(),
+                 attempt: nil,
+                 workspace_path: workspace,
+                 resume_value: :approved,
+                 resume_token: %{decision: "acceptForSession", approvals_granted: "lots"}
+               )
+
+      assert token.approvals_granted == 1
+    after
+      System.delete_env("FAKE_CODEX_MODE")
+    end
+
+    @tag :unix_only
+    test "a :rejected resume ends the attempt without starting Codex", %{
+      workspace: workspace
+    } do
+      System.put_env("FAKE_CODEX_MODE", "approval")
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      cfg = put_in(config().codex.approval_policy, "request")
+
+      assert {:error, :approval_rejected} =
+               Codex.run(issue(), cfg,
+                 parent: self(),
+                 attempt: nil,
+                 workspace_path: workspace,
+                 resume_value: :rejected,
+                 resume_token: %{decision: "acceptForSession", turn: 1}
+               )
+
+      events = collect_events("issue-1", 100)
+      assert Enum.any?(events, &(&1.event == :resumed))
+      refute Enum.any?(events, &(&1.event == :session_started))
+    after
+      System.delete_env("FAKE_CODEX_MODE")
+    end
+
+    @tag :unix_only
+    test "an MCP resume carries the decision as a string", %{workspace: workspace} do
+      System.put_env("FAKE_CODEX_MODE", "approval")
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      cfg = put_in(config().codex.approval_policy, "request")
+
+      assert {:error, :approval_rejected} =
+               Codex.run(issue(), cfg,
+                 parent: self(),
+                 attempt: nil,
+                 workspace_path: workspace,
+                 resume_value: "rejected",
+                 resume_token: %{decision: "acceptForSession", turn: 1}
+               )
+    after
+      System.delete_env("FAKE_CODEX_MODE")
+    end
+
+    # The string is the spelling every operator surface actually sends, and
+    # "approved" is the direction that answers a live approval request.
+    @tag :unix_only
+    test "a string \"approved\" from an operator surface answers the request", %{
+      workspace: workspace
+    } do
+      System.put_env("FAKE_CODEX_MODE", "approval")
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      cfg = put_in(config().codex.approval_policy, "request")
+
+      assert :ok =
+               Codex.run(issue(), cfg,
+                 parent: self(),
+                 attempt: nil,
+                 workspace_path: workspace,
+                 resume_value: "approved",
+                 resume_token: %{decision: "acceptForSession", turn: 1}
+               )
+
+      events = collect_events("issue-1", 100)
+      assert Enum.any?(events, &(&1.event == :turn_completed))
+    after
+      System.delete_env("FAKE_CODEX_MODE")
+    end
+
+    @tag :unix_only
     test "resume_value triggers a :resumed event with the operator's decision",
          %{workspace: workspace} do
       System.put_env("FAKE_CODEX_MODE", "happy")

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent/agent_workflow_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent/agent_workflow_test.exs
@@ -46,6 +46,15 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflowTest do
     })
   end
 
+  # A detector under workflow_mode needs a saver whose store outlives
+  # the process that writes the checkpoint. Creating the table here
+  # makes the test process its owner.
+  defp workflow_saver do
+    table = :sym_agent_workflow_test_saver
+    Raxol.Workflow.Checkpoint.Saver.Ets.ensure_table(%{table: table})
+    {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: table}}
+  end
+
   defp issue(state \\ "Todo") do
     %Issue{
       id: "issue-1",
@@ -92,7 +101,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflowTest do
         end
       end
 
-      cfg = config(%{pause_detector: detector})
+      cfg = config(%{pause_detector: detector, workflow_saver: workflow_saver()})
 
       # Pause on turn 1.
       assert {:pause, :awaiting_review, pause_token} =
@@ -146,7 +155,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgent.AgentWorkflowTest do
 
       detector = fn _event -> {:pause, :awaiting_review, :tok} end
 
-      cfg = config(%{pause_detector: detector})
+      cfg = config(%{pause_detector: detector, workflow_saver: workflow_saver()})
 
       assert {:pause, :awaiting_review, _token} =
                RaxolAgent.run(issue(), cfg,

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_thread_log_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_thread_log_test.exs
@@ -37,6 +37,15 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
     {Raxol.Agent.ThreadLog.Ets, %{table: table}}
   end
 
+  # A detector under workflow_mode needs a saver whose store outlives
+  # the process that writes the checkpoint. Creating the table here
+  # makes the test process its owner.
+  defp workflow_saver do
+    table = :sym_runner_thread_log_saver
+    Raxol.Workflow.Checkpoint.Saver.Ets.ensure_table(%{table: table})
+    {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: table}}
+  end
+
   defp config(agent_overrides, max_turns \\ 1)
 
   defp config(agent_overrides, max_turns) do
@@ -123,7 +132,12 @@ defmodule Raxol.Symphony.Runners.RaxolAgentThreadLogTest do
         end
       end
 
-      cfg = config(%{thread_log: adapter, pause_detector: detector})
+      cfg =
+        config(%{
+          thread_log: adapter,
+          pause_detector: detector,
+          workflow_saver: workflow_saver()
+        })
 
       # Pause.
       assert {:pause, :awaiting_review, pause_token} =

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_turn_error_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_turn_error_test.exs
@@ -271,6 +271,10 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest do
       backend: Raxol.Agent.Backend.Mock,
       backend_opts: [response: "ok"],
       system_prompt: nil,
+      # `__stream_opts__/1` fetches both, so a turn state without them raises
+      # before the failure under test is ever reached.
+      context: %{cwd: "/tmp/raxol-symphony-test-workspace"},
+      actions: [],
       pause_detector: nil,
       turn: 1,
       max_turns: 1,

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_turn_error_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_turn_error_test.exs
@@ -1,3 +1,27 @@
+defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest.TruncatedBackend do
+  @moduledoc """
+  Backend whose stream ends without a `{:done, _}` event, the shape a
+  provider connection dropped mid-turn produces.
+  """
+
+  @behaviour Raxol.Agent.AIBackend
+
+  @impl true
+  def complete(_messages, _opts), do: {:error, :truncated}
+
+  @impl true
+  def stream(_messages, _opts), do: {:ok, [{:chunk, "half an ans"}]}
+
+  @impl true
+  def available?, do: true
+
+  @impl true
+  def name, do: "Truncated Backend"
+
+  @impl true
+  def capabilities, do: [:streaming]
+end
+
 defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest do
   @moduledoc """
   Verifies per-turn error propagation.
@@ -145,6 +169,117 @@ defmodule Raxol.Symphony.Runners.RaxolAgentTurnErrorTest do
                  attempt: nil
                )
     end
+  end
+
+  describe "a turn whose stream never completes" do
+    test "a backend error surfaces as {:error, reason}, not a clean turn" do
+      state = turn_state(backend_opts: [error: {:http_status, 401}])
+
+      assert {:error, {:http_status, 401}} =
+               RaxolAgent.__workflow_collect_turn__(state)
+
+      # The failure is still forwarded, so the run feed shows what happened.
+      assert_received {:run_event, "issue-1", %{event: :turn_failed}}
+    end
+
+    test "a stream that ends without :done surfaces as {:error, :no_done}" do
+      state =
+        turn_state(
+          backend: Raxol.Symphony.Runners.RaxolAgentTurnErrorTest.TruncatedBackend,
+          backend_opts: []
+        )
+
+      assert {:error, :no_done} = RaxolAgent.__workflow_collect_turn__(state)
+    end
+
+    test "a queued pause still wins over a stream error" do
+      state =
+        turn_state(
+          backend_opts: [error: :boom],
+          pause_detector: fn _event -> {:pause, :awaiting_review, :tok} end
+        )
+
+      assert {:ok, _events, {:pause, :awaiting_review, :tok}} =
+               RaxolAgent.__workflow_collect_turn__(state)
+    end
+  end
+
+  describe "policies see a failed turn as a failure" do
+    test "Retry re-attempts a stream error" do
+      state =
+        turn_state(
+          backend_opts: [error: {:http_status, 429}],
+          policies: [Policy.Retry.exponential(max_attempts: 3, base_ms: 0)]
+        )
+
+      assert {:error, {:http_status, 429}} =
+               RaxolAgent.__workflow_collect_turn__(state)
+
+      # One forwarded failure per attempt: the provider was called three
+      # times, not once with two silent successes.
+      assert length(forwarded_turn_failures()) == 3
+    end
+
+    test "Cache does not memoize a failed turn" do
+      table = :"sym_test_policy_cache_#{:erlang.unique_integer([:positive])}"
+
+      on_exit(fn ->
+        if :ets.whereis(table) != :undefined, do: :ets.delete(table)
+      end)
+
+      policy =
+        Policy.Cache.ets(ttl_ms: 60_000, key_fn: fn _params -> :turn end, table: table)
+
+      state =
+        turn_state(
+          backend_opts: [error: {:http_status, 429}],
+          policies: [policy]
+        )
+
+      assert {:error, {:http_status, 429}} =
+               RaxolAgent.__workflow_collect_turn__(state)
+
+      assert :miss = Raxol.Agent.Cache.get(policy.storage, :turn)
+
+      # A memoized failure would short-circuit the second turn without
+      # reaching the provider, so the retry could never recover.
+      assert {:error, {:http_status, 429}} =
+               RaxolAgent.__workflow_collect_turn__(state)
+
+      assert length(forwarded_turn_failures()) == 2
+    end
+  end
+
+  defp forwarded_turn_failures do
+    receive do
+      {:run_event, "issue-1", %{event: :turn_failed}} ->
+        [:turn_failed | forwarded_turn_failures()]
+    after
+      0 -> []
+    end
+  end
+
+  # The turn body reads its backend straight off the workflow state, so a
+  # failing provider is expressible without one. Mirrors the map
+  # `build_workflow_state/5` hands to `AgentWorkflow.run_turn/1`.
+  defp turn_state(overrides) do
+    %{
+      issue: issue(),
+      config: config(%{}),
+      parent: self(),
+      attempt: nil,
+      backend: Raxol.Agent.Backend.Mock,
+      backend_opts: [response: "ok"],
+      system_prompt: nil,
+      pause_detector: nil,
+      turn: 1,
+      max_turns: 1,
+      policies: [],
+      sandboxes: [],
+      thread_log: nil,
+      thread_id: "symphony-agent-issue-1-0"
+    }
+    |> Map.merge(Map.new(overrides))
   end
 
   describe "ThreadLog audit on error" do

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_workflow_envelope_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_workflow_envelope_test.exs
@@ -62,6 +62,15 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
     }
   end
 
+  # A detector under workflow_mode needs a saver whose store outlives
+  # the process that writes the checkpoint. Creating the table here
+  # makes the test process its owner.
+  defp workflow_saver do
+    table = :sym_test_envelope_saver
+    Raxol.Workflow.Checkpoint.Saver.Ets.ensure_table(%{table: table})
+    {Raxol.Workflow.Checkpoint.Saver.Ets, %{table: table}}
+  end
+
   describe "workflow_mode: true happy path" do
     test ":ok when the tracker reports terminal mid-loop" do
       # State Done at start -> after turn 1 the tracker check returns :done,
@@ -107,7 +116,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
         {:pause, :awaiting_buyer_payment, pause_token}
       end
 
-      cfg = config(%{pause_detector: detector})
+      cfg = config(%{pause_detector: detector, workflow_saver: workflow_saver()})
 
       assert {:pause, :awaiting_buyer_payment, token} =
                RaxolAgent.run(issue(), cfg,
@@ -138,7 +147,7 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowEnvelopeTest do
         end
       end
 
-      cfg = config(%{pause_detector: detector})
+      cfg = config(%{pause_detector: detector, workflow_saver: workflow_saver()})
 
       # First pass pauses.
       assert {:pause, :awaiting_external, pause_token} =

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_workflow_saver_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_workflow_saver_test.exs
@@ -1,0 +1,112 @@
+defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowSaverTest do
+  @moduledoc """
+  A paused workflow-mode run pauses in one worker task and resumes in
+  another, so its checkpoints have to outlive the process that wrote
+  them.
+  """
+
+  use ExUnit.Case, async: false
+
+  alias Raxol.Symphony.{Config, Issue}
+  alias Raxol.Symphony.Runners.RaxolAgent
+  alias Raxol.Symphony.Trackers.Memory
+  alias Raxol.Workflow.Checkpoint.Saver
+
+  setup do
+    start_supervised!({Memory, []})
+    :ok
+  end
+
+  defp config(agent_overrides) do
+    base = %{backend: "mock", response: "ok", workflow_mode: true}
+
+    Config.from_workflow(%{
+      config: %{
+        tracker: %{
+          kind: "memory",
+          active_states: ["Todo", "In Progress"],
+          terminal_states: ["Done", "Cancelled"]
+        },
+        agent: %{max_turns: 1},
+        runner: %{
+          kind: "raxol_agent",
+          agent: Map.merge(base, agent_overrides)
+        }
+      },
+      prompt_template: "Working on {{ issue.identifier }}"
+    })
+  end
+
+  defp issue do
+    %Issue{id: "issue-1", identifier: "MT-1", title: "T", state: "Todo"}
+  end
+
+  # Pauses on the first event, then passes through, so the resumed run
+  # finishes instead of pausing again.
+  defp pause_once_detector do
+    {:ok, ref} = Agent.start_link(fn -> :first end)
+
+    fn _event ->
+      pause_on_first(Agent.get_and_update(ref, fn seen -> {seen, :later} end), ref)
+    end
+  end
+
+  defp pause_on_first(:first, ref), do: {:pause, :awaiting_review, %{ref: ref}}
+  defp pause_on_first(_later, _ref), do: :continue
+
+  defp run_in_task(cfg, opts) do
+    parent = self()
+
+    Task.async(fn ->
+      RaxolAgent.run(issue(), cfg, Keyword.merge([parent: parent, attempt: nil], opts))
+    end)
+    |> Task.await(5_000)
+  end
+
+  describe "no agent.workflow_saver" do
+    test "a run that can pause is refused rather than left unresumable" do
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      cfg = config(%{pause_detector: pause_once_detector()})
+
+      assert {:error, :no_durable_workflow_saver} =
+               RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+    end
+
+    test "a run that cannot pause keeps the default saver" do
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      assert :ok = RaxolAgent.run(issue(), config(%{}), parent: self(), attempt: nil)
+    end
+  end
+
+  describe "an agent.workflow_saver whose store outlives the worker" do
+    # This covers the configuration the refusal above steers operators
+    # towards, not the hazard itself: the default saver's table dying
+    # with its first writer is a property of the worker task the
+    # orchestrator spawns, which this suite does not stand up.
+    test "a pause in one task resumes from another" do
+      Memory.put_issue(%{issue() | state: "Done"})
+
+      table = :sym_test_workflow_saver
+      # Creating the table here makes the test process its owner, so it
+      # outlives both worker tasks and goes away with the test. A table
+      # created by the first writer instead dies with that writer.
+      Saver.Ets.ensure_table(%{table: table})
+
+      cfg =
+        config(%{
+          pause_detector: pause_once_detector(),
+          workflow_saver: {Saver.Ets, %{table: table}}
+        })
+
+      assert {:pause, :awaiting_review, pause_token} = run_in_task(cfg, [])
+
+      assert :ok =
+               run_in_task(cfg,
+                 resume_token: pause_token,
+                 resume_value: :approved
+               )
+    end
+  end
+end

--- a/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_workflow_saver_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/raxol_agent_workflow_saver_test.exs
@@ -12,6 +12,8 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowSaverTest do
   alias Raxol.Symphony.Trackers.Memory
   alias Raxol.Workflow.Checkpoint.Saver
 
+  @workspace "/tmp/raxol-symphony-test-workspace"
+
   setup do
     start_supervised!({Memory, []})
     :ok
@@ -58,7 +60,11 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowSaverTest do
     parent = self()
 
     Task.async(fn ->
-      RaxolAgent.run(issue(), cfg, Keyword.merge([parent: parent, attempt: nil], opts))
+      RaxolAgent.run(
+        issue(),
+        cfg,
+        Keyword.merge([parent: parent, workspace_path: @workspace, attempt: nil], opts)
+      )
     end)
     |> Task.await(5_000)
   end
@@ -70,13 +76,22 @@ defmodule Raxol.Symphony.Runners.RaxolAgentWorkflowSaverTest do
       cfg = config(%{pause_detector: pause_once_detector()})
 
       assert {:error, :no_durable_workflow_saver} =
-               RaxolAgent.run(issue(), cfg, parent: self(), attempt: nil)
+               RaxolAgent.run(issue(), cfg,
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
 
     test "a run that cannot pause keeps the default saver" do
       Memory.put_issue(%{issue() | state: "Done"})
 
-      assert :ok = RaxolAgent.run(issue(), config(%{}), parent: self(), attempt: nil)
+      assert :ok =
+               RaxolAgent.run(issue(), config(%{}),
+                 parent: self(),
+                 workspace_path: @workspace,
+                 attempt: nil
+               )
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/runners/review_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/runners/review_test.exs
@@ -39,6 +39,47 @@ defmodule Raxol.Symphony.Runners.ReviewTest do
     end
   end
 
+  # Pauses on its own behalf the first time (as Codex does on an approval
+  # request) and finishes once the operator's decision reaches it.
+  defmodule PausingImplementer do
+    @behaviour Raxol.Symphony.Runner
+    @impl true
+    def run(_issue, _config, opts) do
+      case Keyword.get(opts, :resume_value) do
+        nil ->
+          {:pause, :awaiting_approval, %{decision: "acceptForSession", turn: 1}}
+
+        decision ->
+          send(Keyword.fetch!(opts, :parent), {:implementer_resumed, decision})
+          :ok
+      end
+    end
+  end
+
+  # Reports every dispatch so a test can prove the implementer did NOT re-run.
+  defmodule ReportingImplementer do
+    @behaviour Raxol.Symphony.Runner
+    @impl true
+    def run(_issue, _config, opts) do
+      send(Keyword.fetch!(opts, :parent), {:implementer_ran, opts})
+      :ok
+    end
+  end
+
+  # The same, on the reviewer side of the pause.
+  defmodule PausingReviewer do
+    @behaviour Raxol.Symphony.Runner
+    @impl true
+    def run(_issue, _config, opts) do
+      send(Keyword.fetch!(opts, :parent), {:reviewer_opts, opts})
+
+      case Keyword.get(opts, :resume_value) do
+        nil -> {:pause, :awaiting_approval, %{decision: "acceptForSession", turn: 1}}
+        _ -> :ok
+      end
+    end
+  end
+
   # -- Fixtures ---------------------------------------------------------------
 
   defp issue, do: %Issue{id: "i-1", identifier: "MT-1", title: "Do thing", state: "Todo"}
@@ -215,7 +256,11 @@ defmodule Raxol.Symphony.Runners.ReviewTest do
     defp human_opts(decision) do
       [
         parent: self(),
-        resume_token: %{implementer_kind: "impl", reason: :insufficient_vendors},
+        resume_token: %{
+          contract: %Contract{issue_identifier: "MT-1"},
+          implementer_kind: "impl",
+          reason: :insufficient_vendors
+        },
         resume_value: decision
       ]
     end
@@ -227,6 +272,100 @@ defmodule Raxol.Symphony.Runners.ReviewTest do
     test "a :rejected decision requests changes" do
       assert {:error, {:changes_requested, :rejected_by_human}} =
                ReviewRunner.run(issue(), config(%{}), human_opts(:rejected))
+    end
+
+    test "a decision arriving as a string from the MCP surface is honoured" do
+      assert :ok = ReviewRunner.run(issue(), config(%{}), human_opts("approved"))
+
+      assert {:error, {:changes_requested, :rejected_by_human}} =
+               ReviewRunner.run(issue(), config(%{}), human_opts("rejected"))
+    end
+
+    test "an unrecognised decision is reported, not guessed at" do
+      assert {:error, {:unexpected_human_decision, :maybe}} =
+               ReviewRunner.run(issue(), config(%{}), human_opts(:maybe))
+    end
+  end
+
+  # -- Pauses raised by the inner agents, not by this module -------------------
+
+  describe "delegated pause" do
+    test "an implementer pause resumes back into the implementer" do
+      res = resolver(%{"impl" => PausingImplementer, "rev" => ApproveReviewer})
+
+      opts = [
+        parent: self(),
+        workspace_path: "/tmp/ws",
+        review_runner_resolver: res,
+        review_vendor_availability: fn _ -> true end,
+        review_git_runner: fn _args, _cwd -> {:ok, "DIFF"} end
+      ]
+
+      assert {:pause, :awaiting_approval, token} =
+               ReviewRunner.run(issue(), config(%{}), opts)
+
+      assert token.review_delegate == :implementer
+
+      resume = [resume_token: token, resume_value: :approved] ++ opts
+
+      assert {:pause, :awaiting_review, review_token} =
+               ReviewRunner.run(issue(), config(%{}), resume)
+
+      assert_receive {:implementer_resumed, :approved}
+      assert review_token.reviewer_kind == "rev"
+    end
+
+    # The dangerous misroute: a decision the operator gave about the REVIEWER's
+    # request must not start a fresh implementer run against the real worktree.
+    test "a reviewer pause resumes back into the reviewer, never the implementer" do
+      res = resolver(%{"impl" => ReportingImplementer, "rev" => PausingReviewer})
+
+      opts = [
+        parent: self(),
+        workspace_path: "/tmp/ws",
+        review_runner_resolver: res,
+        review_vendor_availability: fn _ -> true end,
+        review_git_runner: fn _args, _cwd -> {:ok, "DIFF"} end
+      ]
+
+      assert {:pause, :awaiting_review, review_token} =
+               ReviewRunner.run(issue(), config(%{}), opts)
+
+      assert_receive {:implementer_ran, _}
+
+      resume = [resume_token: review_token, resume_value: :proceed] ++ opts
+      assert {:pause, :awaiting_approval, token} = ReviewRunner.run(issue(), config(%{}), resume)
+      assert token.review_delegate == :reviewer
+
+      assert :ok =
+               ReviewRunner.run(
+                 issue(),
+                 config(%{}),
+                 [resume_token: token, resume_value: :approved] ++ opts
+               )
+
+      # Both reviewer dispatches got the Contract in their own isolated
+      # workspace, and the implementer never ran a second time.
+      for _ <- 1..2 do
+        assert_receive {:reviewer_opts, ropts}
+        assert %Contract{} = ropts[:review_contract]
+        assert ropts[:workspace_path] != "/tmp/ws"
+      end
+
+      refute_received {:implementer_ran, _}
+    end
+
+    test "a token from neither phase is reported, not run as an implement" do
+      opts = [
+        parent: self(),
+        workspace_path: "/tmp/ws",
+        review_runner_resolver: resolver(%{"impl" => OkRunner}),
+        resume_token: %{who_knows: true},
+        resume_value: :approved
+      ]
+
+      assert {:error, {:unroutable_resume_token, %{who_knows: true}}} =
+               ReviewRunner.run(issue(), config(%{}), opts)
     end
   end
 end

--- a/packages/raxol_symphony/test/raxol/symphony/surfaces/telegram/formatter_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/surfaces/telegram/formatter_test.exs
@@ -219,7 +219,7 @@ defmodule Raxol.Symphony.Surfaces.Telegram.FormatterTest do
       assert :skip = Formatter.event_message(:something_weird, empty_snapshot())
     end
 
-    test ":worker_paused surfaces Approve/Reject buttons for the head paused" do
+    test ":worker_paused surfaces Approve/Reject buttons for the paused run" do
       snap =
         empty_snapshot(%{
           counts: %{running: 0, retrying: 0, paused: 1},
@@ -234,6 +234,25 @@ defmodule Raxol.Symphony.Surfaces.Telegram.FormatterTest do
       assert approve.callback_data == "sym:resume:iss_p:approved"
       assert reject.callback_data == "sym:resume:iss_p:rejected"
       assert refresh.callback_data == "sym:refresh"
+    end
+
+    test ":worker_paused announces the run that just paused" do
+      snap =
+        empty_snapshot(%{
+          counts: %{running: 0, retrying: 0, paused: 2},
+          paused: [
+            paused(issue_id: "iss_1", issue_identifier: "MT-1", paused_ms_ago: 600_000),
+            paused(issue_id: "iss_2", issue_identifier: "MT-2", paused_ms_ago: 500)
+          ]
+        })
+
+      assert {text, [[approve, reject], [_refresh]]} =
+               Formatter.event_message(:worker_paused, snap)
+
+      assert text =~ "MT-2"
+      refute text =~ "MT-1"
+      assert approve.callback_data == "sym:resume:iss_2:approved"
+      assert reject.callback_data == "sym:resume:iss_2:rejected"
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/surfaces/watch/formatter_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/surfaces/watch/formatter_test.exs
@@ -151,6 +151,26 @@ defmodule Raxol.Symphony.Surfaces.Watch.FormatterTest do
       assert "sym:dismiss" in action_ids
     end
 
+    test "announces the run that just paused, not the first by issue-id order" do
+      snap =
+        snapshot(%{
+          counts: %{running: 0, retrying: 0, paused: 2},
+          paused: [
+            paused(issue_id: "iss_1", issue_identifier: "MT-1", paused_ms_ago: 600_000),
+            paused(issue_id: "iss_2", issue_identifier: "MT-2", paused_ms_ago: 500)
+          ]
+        })
+
+      n = Formatter.event_notification(:worker_paused, snap)
+
+      assert n.body =~ "MT-2"
+      refute n.body =~ "MT-1"
+
+      action_ids = Enum.map(n.actions, & &1.id)
+      assert "sym:resume:iss_2:approved" in action_ids
+      assert "sym:resume:iss_2:rejected" in action_ids
+    end
+
     test "falls back to refresh + dismiss when paused list is empty" do
       snap = snapshot(%{counts: %{running: 0, retrying: 0, paused: 0}})
       n = Formatter.event_notification(:worker_paused, snap)

--- a/packages/raxol_symphony/test/raxol/symphony/trackers/github_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/trackers/github_test.exs
@@ -201,6 +201,39 @@ defmodule Raxol.Symphony.Trackers.GitHubTest do
                Tracker.fetch_issues_by_states(config(), ["Done"])
     end
 
+    # The moduledoc promises label slugs are matched case-insensitively, and
+    # the suffix is (`slugify_state/1` downcases it). The PREFIX was matched
+    # against two hand-written spellings, so a repo that labels its issues
+    # `STATE/todo` had every issue read as stateless and silently skipped --
+    # the orchestrator would poll a correctly-labelled repo forever and claim
+    # nothing, with no error to explain why.
+    test "the state/ label prefix is matched case-insensitively" do
+      install_handler(fn _conn ->
+        {:list,
+         [
+           issue_node(%{"number" => 1, "labels" => [%{"name" => "STATE/todo"}]}),
+           issue_node(%{"number" => 2, "labels" => [%{"name" => "State/Todo"}]}),
+           issue_node(%{"number" => 3, "labels" => [%{"name" => "sTaTe/TODO"}]})
+         ]}
+      end)
+
+      assert {:ok, issues} = Tracker.fetch_candidate_issues(config())
+      assert issues |> Enum.map(& &1.identifier) |> Enum.sort() == ["#1", "#2", "#3"]
+      assert Enum.map(issues, & &1.state) == ["Todo", "Todo", "Todo"]
+    end
+
+    test "a label that merely starts with the word state is not a state label" do
+      install_handler(fn _conn ->
+        {:list,
+         [
+           issue_node(%{"number" => 1, "labels" => [%{"name" => "stateful"}]}),
+           issue_node(%{"number" => 2, "labels" => [%{"name" => "state-todo"}]})
+         ]}
+      end)
+
+      assert {:ok, []} = Tracker.fetch_candidate_issues(config())
+    end
+
     test "skips pull requests (issues with pull_request key)" do
       install_handler(fn _conn ->
         {:list,
@@ -368,6 +401,49 @@ defmodule Raxol.Symphony.Trackers.GitHubTest do
 
       assert {:ok, [%Issue{identifier: "#1"}]} =
                Tracker.fetch_issue_states_by_ids(config(), ["1", "999"])
+    end
+
+    # A 404 means the issue is gone, which is knowledge. Every other failure
+    # means we do not know, and the two must not arrive at the caller looking
+    # the same: `Orchestrator.retry_with_fresh_state/3` releases the issue on
+    # `{:ok, []}` and requeues the retry on `{:error, _}`, and the runners'
+    # `still_active?/2` ends the run on `{:ok, []}`. Collapsing a 500 into an
+    # empty list picks the destructive branch of both on a transient blip.
+    #
+    # `Trackers.Linear` already propagates transport failures, so this is also
+    # what stops the two trackers disagreeing about what silence means.
+    test "a 5xx on one ID fails the batch instead of dropping that issue" do
+      install_handler(fn conn ->
+        case conn.request_path do
+          "/repos/owner/repo/issues/1" -> {:list, issue_node(%{"number" => 1})}
+          _ -> {:status, 500, %{"message" => "Server Error"}}
+        end
+      end)
+
+      assert {:error, {:github_api_status, 500}} =
+               Tracker.fetch_issue_states_by_ids(config(), ["1", "2"])
+    end
+
+    test "a rate-limit response fails the batch" do
+      install_handler(fn _conn -> {:status, 429, %{"message" => "rate limited"}} end)
+
+      assert {:error, {:github_api_status, 429}} =
+               Tracker.fetch_issue_states_by_ids(config(), ["1"])
+    end
+
+    test "an auth failure fails the batch rather than reading as no issues" do
+      install_handler(fn _conn -> {:status, 401, %{"message" => "Bad credentials"}} end)
+
+      assert {:error, {:github_api_status, 401}} =
+               Tracker.fetch_issue_states_by_ids(config(), ["1", "2"])
+    end
+
+    test "a transport error on one ID fails the batch" do
+      adapter = fn req -> {req, %Req.TransportError{reason: :econnrefused}} end
+      Application.put_env(:raxol_symphony, :github, adapter: adapter)
+
+      assert {:error, {:github_api_request, %Req.TransportError{reason: :econnrefused}}} =
+               Tracker.fetch_issue_states_by_ids(config(), ["1"])
     end
   end
 

--- a/packages/raxol_symphony/test/raxol/symphony/workflow_store_test.exs
+++ b/packages/raxol_symphony/test/raxol/symphony/workflow_store_test.exs
@@ -31,6 +31,16 @@ defmodule Raxol.Symphony.WorkflowStoreTest do
   No api key, no project slug -- schema validation must reject.
   """
 
+  @workflow_malformed_section """
+  ---
+  tracker:
+    kind: memory
+  agent:
+  max_concurrent_agents: 4
+  ---
+  The agent section lost its body to a mis-indented edit.
+  """
+
   setup do
     dir =
       Path.join(
@@ -136,6 +146,23 @@ defmodule Raxol.Symphony.WorkflowStoreTest do
       # Cached config is unchanged
       assert WorkflowStore.get(pid) == good_cfg
       assert WorkflowStore.last_error(pid) != nil
+    end
+
+    test "keeps last-known-good when a section is mis-indented", %{dir: dir} do
+      path = write_workflow(dir, @workflow)
+
+      pid =
+        start_supervised!(
+          {WorkflowStore, path: path, watch?: false, name: :"#{__MODULE__}_reload3"}
+        )
+
+      good_cfg = WorkflowStore.get(pid)
+
+      File.write!(path, @workflow_malformed_section)
+      assert {:error, {:workflow_section_not_a_map, [:agent]}} = WorkflowStore.reload(pid)
+
+      assert Process.alive?(pid)
+      assert WorkflowStore.get(pid) == good_cfg
     end
 
     test "keeps last-known-good when the file disappears", %{dir: dir} do

--- a/packages/raxol_symphony/test/support/fake_codex.sh
+++ b/packages/raxol_symphony/test/support/fake_codex.sh
@@ -7,6 +7,7 @@
 #   multi     -- emits two turn/completed events (for continuation tests)
 #   tool      -- emits an item/tool/call mid-turn
 #   approval  -- emits item/commandExecution/requestApproval mid-turn
+#   approval2 -- emits two approval requests in the same turn
 #   fail      -- emits turn/failed instead of turn/completed
 #   hang      -- never responds after thread/start (timeout tests)
 #
@@ -64,6 +65,13 @@ while true; do
     approval)
       printf '%s\n' '{"method":"item/commandExecution/requestApproval","id":555}'
       IFS= read -r _approval_reply
+      printf '%s\n' '{"method":"turn/completed"}'
+      ;;
+    approval2)
+      printf '%s\n' '{"method":"item/commandExecution/requestApproval","id":555}'
+      IFS= read -r _approval_reply
+      printf '%s\n' '{"method":"item/fileChange/requestApproval","id":556}'
+      IFS= read -r _approval_reply2
       printf '%s\n' '{"method":"turn/completed"}'
       ;;
     fail)


### PR DESCRIPTION
Twenty-two confirmed defects in `raxol_symphony`, found by an adversarial audit of
the package and fixed test-first. Every finding survived a verifier whose job was
to refute it, and every lane was adversarially reviewed before it was allowed to
commit.

The entry point was the GitHub tracker, which is the code path the GitHub
Developer Program application points at. Fixing it surfaced the rest.

## The defect that started it

`Trackers.GitHub.fetch_issue_states_by_ids/2` folded every per-ID failure --
500, 429, 401, timeout, connection refused -- into `{:ok, []}`. Callers read a
short list as authoritative "this issue is gone":

    {:ok, [issue]} -> retry_with_refreshed_issue(...)
    {:ok, []}      -> release_issue(state, issue_id)   # a 500 landed here
    {:error, _}    -> requeue_retry(...)               # unreachable on GitHub

`release_issue/2` un-claims the issue and flushes its prompt cache, and its own
comment says to call it "ONLY at genuinely-terminal release sites". So one
transient GitHub blip permanently dropped an issue from the orchestrator, and
the `{:error, _}` clause written to handle exactly that was dead code on this
tracker. `Trackers.Linear` propagated transport errors already, so the two
trackers disagreed about what silence means.

404/410 now means gone (the issue really is deleted, transferred, or invisible
to the token). Everything else fails the call.

## What that exposed

Making the error path reachable exposed a live orchestrator defect: the
`{:error, _}` branch requeued on a flat 1s continuation delay with the attempt
counter frozen, so exponential backoff was never reached and nothing capped the
loop. A GitHub 429 would have produced roughly one request per second per
claimed issue for the whole rate-limit window, escalating exactly the limit it
was hitting -- while the recorded error term nested one level deeper each pass
and was broadcast to every surface.

This was **not introduced here**. Linear reaches the same loop today. The
tracker fix widened it to a second tracker, which is why both ship together.

## The rest

**Orchestrator** -- retry backoff now grows across tracker outages; superseded
tick timers no longer duplicate the timer chain; retry and resume dispatch are
capped by the same concurrency accounting the poll path uses (a resume that
cannot get a slot is deferred and re-offered, not refused, so it cannot strand);
a retry that fires with no free host re-arms instead of staying claimed forever;
a graph-mode runner pause is parked rather than converted into an abnormal exit
and retried forever; a running entry's state moves with its issue.

**Codex runner** -- an approval pause could never be resolved, because the
operator's decision never reached Codex and every resume re-paused at the same
point. Approvals cleared are now counted, a rejected approval no longer claims
to stop the run, and a delegated pause routes back to the agent that asked.

**Agent runner** -- a failed agent stream was reported to the orchestrator as a
clean finish (`collect_with_detector/4` was the only forwarding path in the file
that did not halt on error). A pausing run with no durable saver is now refused
outright rather than checkpointing into an ETS table owned by the worker task,
which died before resume could read it.

**Config** -- a malformed `WORKFLOW.md` raised `BadMapError` from inside the
section builders, defeating `WorkflowStore`'s last-known-good fallback and
taking the supervisor down. Shape is now validated over the raw front matter and
returns a structured error the store can fall back on. Covers `runner.agent`,
which is stored raw and raised later, once per dispatched run, inside a
supervised task with only a stacktrace as signal.

**Evidence** -- cast truncation byte-sliced UTF-8 mid-codepoint, so `Jason`
raised and the linked `Capture` took the orchestrator with it; capture is now
unlinked from the run it records, and truncation cuts on a codepoint boundary.
The cast file was opened with `:write` while its moduledoc claimed `:append`, so
every continuation retry wiped the recording. Both the Watch and Telegram
surfaces announced `List.first(paused)`, so a second concurrent pause was
reported under the first run's id.

## Retry refresh path (follow-up)

Three of the four items this PR originally deferred turned out to belong here
rather than in their own issues, because all three live in the per-ID refresh a
retry does before it re-dispatches.

**A tracker outage no longer inflates the execution attempt.** The backoff has
to grow across an outage, but growing it by incrementing `attempt` conflated two
numbers: `attempt` counts executions and reaches the prompt template and the
cast filename, so after a long outage an agent was told it was on attempt 47 of
a run that never executed once. Retry entries now carry `requeues` alongside
`attempt`; the backoff and the dashboard escalate on that, and it resets
whenever a refresh succeeds. This one was a consequence of this PR's own backoff
fix, so it should not have shipped deferred.

**The requeue loop is bounded.** An unbounded one is its own strand: a tracker
that never comes back held the claim forever, with the issue in no running,
batch or paused map and no timer left to fire. After
`agent.max_tracker_requeues` (new, default 10 -- roughly half an hour at the
default backoff) the claim is released back to the poll path, which re-claims it
from scratch once the tracker answers again.

**An ambiguous answer no longer crashes the orchestrator.**
`retry_with_fresh_state/3` had no clause for `{:ok, [_, _ | _]}`, so a tracker
answering a single-ID query with two rows raised CaseClauseError inside the
orchestrator's own callback. Fixing it exposed the adjacent hole: the
single-row clause matched positionally and never checked the id, so a row for a
DIFFERENT issue was dispatched as if it were ours and released the wrong claim.
The answer is now searched for the id we asked for. An empty answer still means
gone; an answer that never mentions our issue is requeued rather than read as
absence.

The fourth deferred item was a doc contradiction this PR created: the RUNBOOK
mode reference still said `graph_parallel` has no pause support, which
a58627edb had already made false. It now says a paused branch is parked as
resumable and names per-branch compensate (#517) as the part still open.

## Verification

- `MIX_ENV=test mix test` -- **1046 passed**, 6 excluded. Run four times across
  different seeds; no flake reproduced.
- `mix format --check-formatted` clean; `mix compile --warnings-as-errors` clean.
- `mix credo` -- zero findings in any file this PR touches.
- Every fix is test-first: each carries the failure message its new test produced
  before the fix existed.
- Scoped entirely to `packages/raxol_symphony`; no main-raxol changes.

## Manual testing

- [ ] Point a `WORKFLOW.md` at a real repo with `state/todo` labels and confirm
      issues are claimed and driven to handoff.
- [ ] Revoke the token mid-run and confirm the orchestrator backs off rather
      than hammering, and that the issue is retried rather than released.
- [ ] Save a deliberately malformed `WORKFLOW.md` and confirm the running
      orchestrator keeps serving last-known-good instead of crashing.
- [ ] Pause a Codex run, approve from a surface, and confirm it resumes past the
      approval point instead of re-pausing.
- [ ] Confirm a run's `.cast` recording survives a continuation retry.

## Not addressed

Left deliberately, each worth its own issue:

- No terminal give-up existed on the requeue path. Now bounded by
  `agent.max_tracker_requeues`, but the give-up RELEASES the claim rather than
  parking the issue as failed, so an operator gets no signal beyond a log line.
  Surfacing it is its own change.
- Open issues #517, #518, #889 (graph_parallel compensate, SSH worker dispatch,
  remote worker validation against a real sshd).
