### PR TITLE
Keep animation state if a renderer dies

### DIFF
--- a/lib/raxol/animation/state_manager.ex
+++ b/lib/raxol/animation/state_manager.ex
@@ -24,11 +24,21 @@ defmodule Raxol.Animation.StateManager do
   @doc """
   Ensures the Animation StateServer is started.
   Called automatically when using any function.
+
+  The singleton is started unlinked. The first caller is often a rendering
+  engine or an ExUnit process; `start_link` made their exit take every
+  in-flight animation in the VM with them.
   """
   def ensure_started do
-    case StateServer.start_link(name: StateServer) do
-      {:ok, _pid} -> :ok
-      {:error, {:already_started, _pid}} -> :ok
+    case Process.whereis(StateServer) do
+      pid when is_pid(pid) ->
+        :ok
+
+      nil ->
+        case GenServer.start(StateServer, [], name: StateServer) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+        end
     end
   end
 

--- a/lib/raxol/core/runtime/rendering/engine.ex
+++ b/lib/raxol/core/runtime/rendering/engine.ex
@@ -426,7 +426,7 @@ defmodule Raxol.Core.Runtime.Rendering.Engine do
 
   defp resolve_view_result(nil), do: {:ok, nil}
 
-  defp resolve_view_result(view) do
+  defp resolve_view_result(view) when is_map(view) do
     resolved = resolve_process_components(view)
 
     Raxol.Core.Runtime.Log.debug(
@@ -435,6 +435,8 @@ defmodule Raxol.Core.Runtime.Rendering.Engine do
 
     {:ok, resolved}
   end
+
+  defp resolve_view_result(_other), do: {:error, :invalid_view}
 
   # Safe layout application using functional error handling
   defp safe_apply_layout(view, state, prepared_tree) do

--- a/lib/raxol/ui/layout/preparer.ex
+++ b/lib/raxol/ui/layout/preparer.ex
@@ -149,6 +149,8 @@ defmodule Raxol.UI.Layout.Preparer do
     }
   end
 
+  def prepare(_other), do: nil
+
   @doc """
   Re-prepares only elements whose content has changed.
 

--- a/test/raxol/animation/state_settings_contract_test.exs
+++ b/test/raxol/animation/state_settings_contract_test.exs
@@ -4,11 +4,9 @@ defmodule Raxol.Animation.StateSettingsContractTest do
   on every path, including the one where the server was started by
   `ensure_started/0` rather than by `Framework.init/2`.
 
-  That path is not hypothetical. `ensure_started/0` uses `start_link/1`, so the
-  server is linked to whichever process happened to start it. An ExUnit test
-  process exits with a non-normal reason, which kills the linked server, so the
-  next `StateManager` call anywhere -- including one inside a `Task` in the
-  middle of a later test -- starts a fresh server carrying no settings.
+  `ensure_started/0` starts the singleton unlinked. A rendering engine or
+  ExUnit process that happens to be the first caller can still exit; the
+  server, and any in-flight animations, must outlive that.
   """
 
   use ExUnit.Case, async: false
@@ -69,7 +67,8 @@ defmodule Raxol.Animation.StateSettingsContractTest do
       Framework.init(%{default_duration: 111}, prefs)
       assert StateManager.get_settings().default_duration == 111
 
-      # Mimic the linked server dying with the process that started it.
+      # Explicit stop, not a linked-caller exit: the server can still die
+      # (supervisor restart, test cleanup) and the next call must recreate it.
       stop_state_server()
 
       animation =
@@ -81,6 +80,61 @@ defmodule Raxol.Animation.StateSettingsContractTest do
         })
 
       assert animation.duration == Raxol.Core.Defaults.animation_duration_ms()
+    end
+
+    test "killing the process that called ensure_started does not drop the server" do
+      parent = self()
+
+      starter =
+        spawn(fn ->
+          StateManager.ensure_started()
+          send(parent, {:started, Process.whereis(StateServer)})
+          Process.sleep(:infinity)
+        end)
+
+      assert_receive {:started, pid}, 500
+      assert is_pid(pid)
+      ref = Process.monitor(pid)
+
+      Process.exit(starter, :kill)
+
+      refute_receive {:DOWN, ^ref, :process, ^pid, _}, 100
+      assert Process.alive?(pid)
+      assert Process.whereis(StateServer) == pid
+    end
+
+    test "an unrelated process exit does not drop in-flight animations", %{
+      prefs: prefs
+    } do
+      Framework.init(%{}, prefs)
+
+      Framework.create_animation(:keep_alive, %{
+        type: :fade,
+        from: 0.0,
+        to: 1.0,
+        duration: 50,
+        easing: :linear,
+        target_path: [:opacity]
+      })
+
+      assert :ok = Framework.start_animation(:keep_alive, "box", %{}, prefs)
+
+      starter =
+        spawn(fn ->
+          StateManager.ensure_started()
+          Process.sleep(:infinity)
+        end)
+
+      Process.exit(starter, :kill)
+      Process.sleep(10)
+
+      assert StateManager.get_active_animation("box", :keep_alive)
+
+      Process.sleep(60)
+
+      model = %{elements: %{"box" => %{opacity: 0.0}}}
+      animated = Framework.apply_animations_to_state(model, prefs)
+      assert_in_delta get_in(animated, [:elements, "box", :opacity]), 1.0, 0.01
     end
 
     test "start_animation/2 reads accessibility flags off a self-started server" do

--- a/test/raxol/headless/mcp_tools_test.exs
+++ b/test/raxol/headless/mcp_tools_test.exs
@@ -354,7 +354,7 @@ defmodule Raxol.Headless.McpToolsTest do
       defmodule #{name} do
         def init(_), do: %{}
         def update(_msg, model), do: model
-        def view(_), do: :ok
+        def view(_), do: nil
       end
       """)
 

--- a/test/raxol/ui/layout/preparer_test.exs
+++ b/test/raxol/ui/layout/preparer_test.exs
@@ -78,6 +78,11 @@ defmodule Raxol.UI.Layout.PreparerTest do
     test "prepares nil as nil" do
       assert Preparer.prepare(nil) == nil
     end
+
+    test "non-map views do not crash prepare" do
+      assert Preparer.prepare(:ok) == nil
+      assert Preparer.prepare("nope") == nil
+    end
   end
 
   describe "prepare_incremental/2" do
@@ -117,7 +122,9 @@ defmodule Raxol.UI.Layout.PreparerTest do
 
     test "prepares fresh when type changes" do
       old = Preparer.prepare(%{type: :text, content: "hello"})
-      result = Preparer.prepare_incremental(%{type: :button, text: "hello"}, old)
+
+      result =
+        Preparer.prepare_incremental(%{type: :button, text: "hello"}, old)
 
       assert result.type == :button
     end


### PR DESCRIPTION
Fixes #960.

The 2026-09-04 nightly failed on `Test Matrix (1.17.3/27.2/ubuntu-latest)` with
one failure:

```
test completed animation sets final value
  test/raxol/animation/e2e_animation_hints_test.exs:134
  Expected the difference between 0.0 and 1.0 (1.0) to be less than or equal to 0.01
```

The same test log showed `Raxol.UI.Layout.Preparer.prepare(:ok)` crashing a
rendering engine (`HeadlessUnloadedProbe`), then `[Animation] Re-adapting 0
active animations` immediately before the assertion. Isolated, the test is
green. In the full suite the animation singleton was already gone.

## Root cause

`StateManager.ensure_started/0` used `StateServer.start_link/1`. The first
caller in the VM owns that link. In this suite that caller is often a rendering
engine: `handle_cast(:render_frame)` calls `apply_animations_to_state/2`, which
ensure-starts the server.

`HeadlessUnloadedProbe` (compiled out-of-VM in `mcp_tools_test.exs`) exported
the TEA triple with `view/1` returning `:ok`. `nil` is the documented headless
view; `:ok` is not a tree. `Preparer.prepare/1` had no clause for it, so the
engine died with a `FunctionClauseError`. Because it had `start_link`ed
`StateServer`, the singleton died too. The next `apply_animations_to_state/2`
lazily recreated an empty server, so opacity stayed at `0.0`.

This is the same class as #859 (settings-as-`[]` after a linked restart). That
fix made the crash a map. It did not stop the singleton dying with its first
caller; the previous PR body called that out as deliberate leftover.

## The fix

- `ensure_started/0` starts the singleton with `GenServer.start/3` (unlinked).
  An engine or ExUnit process exiting no longer wipes in-flight animations.
- The rendering engine rejects a non-map `view/1` as `{:error, :invalid_view}`
  instead of handing it to Preparer.
- `Preparer.prepare/1` returns `nil` for non-maps, so a missed call site cannot
  `FunctionClauseError` the engine.
- The unloaded-module probe now returns `nil` from `view/1`.

Not changed: the supervisor child still uses `name: :animation_server` while
the code talks to `StateServer`. That unused child is a separate naming bug.

## Testing

137 passed across `test/raxol/animation/`, `animation_test.exs`,
`mcp_tools_test.exs`, and `preparer_hints_test.exs`. `mix compile
--warnings-as-errors` clean. Format clean on the touched files.

New contract tests:

- killing the process that called `ensure_started/0` leaves `StateServer` alive
- an unrelated process exit leaves an in-flight fade intact, and a later apply
  still writes the final opacity

Reverting only `ensure_started/0` back to `start_link` turns the first of those
red.

## Manual testing

- [ ] Confirm the next nightly `Test Matrix` cell is green, in particular
      `completed animation sets final value`.
- [ ] Start a headless session whose `view/1` returns `nil` and confirm it does
      not take down other sessions' animations.
