### PR TITLE
Take the code server off the charset translation hot path

### DIFF
--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/character_sets/state_manager.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/character_sets/state_manager.ex
@@ -159,17 +159,42 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.StateManager do
     %{state | active: resolve_charset_name(active_charset)}
   end
 
-  @doc false
-  def resolve_charset_name(charset) when is_atom(charset) do
-    case Code.ensure_loaded(charset) do
-      {:module, _} ->
-        if function_exported?(charset, :name, 0),
-          do: charset.name(),
-          else: charset
+  # The closed set this resolves. `charset_code_to_module/1` produces exactly
+  # these three, and they are the only modules in the package defining `name/0`.
+  @charset_module_names %{
+    Raxol.Terminal.ANSI.CharacterSets.ASCII => :us_ascii,
+    Raxol.Terminal.ANSI.CharacterSets.DEC => :dec_special_graphics,
+    Raxol.Terminal.ANSI.CharacterSets.UK => :uk
+  }
 
-      _ ->
-        charset
-    end
+  @doc false
+  # Runs up to three times per TRANSLATED CHARACTER: `CharacterSets.translate_char/2`
+  # resolves the active set and the single shift, then `Translator.translate_char/3`
+  # resolves once more.
+  #
+  # It used to do that with `Code.ensure_loaded/1`, a synchronous call into the
+  # single global `:code_server`. For a module already loaded that is merely
+  # wasteful, but the two commonest arguments on this path are `nil` (no single
+  # shift) and an already-resolved short name like `:us_ascii` -- neither of
+  # which is a module, so each call was a guaranteed load MISS. The code server
+  # does not cache misses, so every character re-walked the whole code path on
+  # disk: measured at ~0.32ms for `:us_ascii` and ~0.17ms for `nil`, against
+  # ~94ns for a loaded module. Roughly half a millisecond per character, and
+  # serialized through one process, so parallel tests queued behind each other
+  # and ANSI-heavy suites timed out.
+  #
+  # A table lookup answers the real question. The fallback keeps the old dynamic
+  # contract for a charset module this table does not know, but reaches it with
+  # `module_loaded/1`, which is a lookup rather than a code-server call and so
+  # costs nothing for an atom that is not a module.
+  def resolve_charset_name(charset)
+      when is_map_key(@charset_module_names, charset),
+      do: :erlang.map_get(charset, @charset_module_names)
+
+  def resolve_charset_name(charset) when is_atom(charset) do
+    if :erlang.module_loaded(charset) and function_exported?(charset, :name, 0),
+      do: charset.name(),
+      else: charset
   end
 
   def resolve_charset_name(charset), do: charset

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/character_sets/state_manager.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/character_sets/state_manager.ex
@@ -211,15 +211,36 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.StateManager do
   # modules. `Code.ensure_loaded?/1` on a NAME is an uncached full code-path
   # search, ~0.32ms, every character. On a module atom it is a hit or a single
   # load, ~94ns thereafter. `@charset_names` is what keeps the former off the
-  # path: it is the CLOSED codomain of `charset_code_to_atom/1` plus `:us`, so
-  # every value the emulator can actually designate is answered by a map-key
-  # guard and nothing a terminal produces ever reaches the loader.
+  # path: it must contain every atom that can reach `resolve_charset_name/1`
+  # from a live producer, or that producer's charset pays the uncached walk on
+  # every character.
+  #
+  # The producers, enumerated. Getting this list from
+  # `charset_code_to_atom/1` was wrong: that function has NO production
+  # callers, so freezing its codomain froze the wrong table.
+  #
+  #   * `Handler.designate_charset/3` -> `code_to_charset/1` -- the live
+  #     `ESC ( ) * +` path. Guarded for real by the test that drives every
+  #     designator byte through the public function, not by this comment.
+  #   * `Emulator` construction seeds `charset_state.active` with a G-SET
+  #     REFERENCE (`:g0`), not a charset name, and `CharacterSets.translate_char/2`
+  #     reads that field directly. So `:g0..:g3` reach here too, on a freshly
+  #     built emulator, with no escape sequence involved.
+  #   * `CSIHandler.handle_scs/3` adds `:dec_technical`; `Charset.Operations`
+  #     adds the other DEC sets; `Escape.Parsers.SCSParser` adds `:uk_ascii`
+  #     and `:dutch`.
+  #
+  # Every entry below resolves to ITSELF, which is exactly what the loader
+  # fallback already returned for it (none of these atoms names a loadable
+  # module). Listing them changes no result -- it only takes the code server
+  # off the path.
   #
   # Deriving this from `Map.values(@charset_module_names)` -- three names --
   # was the bug: the ten national replacement sets fell through to the
   # `is_atom` clause and paid an `Atom.to_string/1` heap allocation three times
   # per printable character, forever, in exactly the locales that use them.
   @charset_names [
+    # Pass-through names from Handler.code_to_charset/1.
     :us_ascii,
     :dec_special_graphics,
     :uk,
@@ -233,7 +254,25 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.StateManager do
     :portuguese,
     :spanish,
     :swedish,
-    :swiss
+    :swiss,
+    # G-set references. `charset_state.active` is seeded with one of these by
+    # every Emulator constructor, and translate_char/2 resolves that field.
+    :g0,
+    :g1,
+    :g2,
+    :g3,
+    # DEC sets designated via CSIHandler.handle_scs/3 and Charset.Operations.
+    :dec_special,
+    :dec_supplemental,
+    :dec_supplemental_graphics,
+    :dec_supplementary,
+    :dec_technical,
+    :dec_hebrew,
+    :dec_greek,
+    :dec_turkish,
+    # SCSParser designators.
+    :uk_ascii,
+    :dutch
   ]
 
   @resolved_names Map.new(@charset_names, &{&1, &1})
@@ -268,6 +307,15 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.StateManager do
   end
 
   def resolve_charset_name(charset), do: charset
+
+  @doc false
+  # Whether `name` is answered by a compile-time map-key guard rather than by
+  # `Code.ensure_loaded?/1`. Exposed so a test can assert the pass-through set
+  # against THIS attribute instead of a copy of the list: a copy drifts
+  # silently, because a name missing from the table still resolves to the same
+  # value -- just via the code server.
+  def pass_through_name?(name),
+    do: is_map_key(@resolved_names, name) or is_map_key(@charset_module_names, name)
 
   @doc """
   Validates character set state.

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/character_sets/state_manager.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/character_sets/state_manager.ex
@@ -183,9 +183,10 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.StateManager do
   # serialized through one process, so parallel tests queued behind each other
   # and ANSI-heavy suites timed out.
   #
-  # A table lookup answers the real question for the closed set, and the two
-  # commonest arguments -- `nil` and an already-resolved short name -- are
-  # answered by a second table rather than by asking anything about modules.
+  # Two tables answer it instead. `@charset_module_names` maps the three
+  # charset MODULES to their names; `@charset_names` passes every already
+  # resolved NAME straight through. Both are map-key guards, so neither
+  # allocates and neither asks anything about modules.
   #
   # The dynamic branch below is what a custom charset module reaches, and it is
   # deliberately NOT `:erlang.module_loaded/1`. That predicate answers "is this
@@ -196,14 +197,57 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.StateManager do
   # change removes: it turns a wrong glyph into a wrong glyph that reproduces
   # only sometimes. The loader is consulted, restoring the original contract.
   #
+  # Note what the loader NO LONGER decides: `@charset_module_names` freezes the
+  # three bundled modules' `name/0` values into this module's guards at compile
+  # time, so a runtime hot reload of `character_sets.ex` alone does not change
+  # them -- `StateManager` keeps returning the pre-reload constants until it is
+  # itself recompiled. Mix handles that automatically for `mix compile`, because
+  # the attribute is a compile-time reference; it is live `:code.load_file/1`
+  # and IEx `r` that go stale. Reload still works for any charset module
+  # outside the table, which takes the `name/0` branch below.
+  #
   # The cost that made the loader unusable is gone anyway, because it was never
   # the loader itself -- it was reaching the loader with atoms that are not
   # modules. `Code.ensure_loaded?/1` on a NAME is an uncached full code-path
-  # search, ~0.32ms, every character. On an Elixir module atom it is a hit or a
-  # single load, ~94ns thereafter. `module_atom?/1` is what keeps the former off
-  # the path: only an `Elixir.`-prefixed atom can name a module, so `nil`,
-  # `:us_ascii` and anything else short-circuit before the loader is involved.
-  @resolved_names Map.new(Map.values(@charset_module_names), &{&1, &1})
+  # search, ~0.32ms, every character. On a module atom it is a hit or a single
+  # load, ~94ns thereafter. `@charset_names` is what keeps the former off the
+  # path: it is the CLOSED codomain of `charset_code_to_atom/1` plus `:us`, so
+  # every value the emulator can actually designate is answered by a map-key
+  # guard and nothing a terminal produces ever reaches the loader.
+  #
+  # Deriving this from `Map.values(@charset_module_names)` -- three names --
+  # was the bug: the ten national replacement sets fell through to the
+  # `is_atom` clause and paid an `Atom.to_string/1` heap allocation three times
+  # per printable character, forever, in exactly the locales that use them.
+  @charset_names [
+    :us_ascii,
+    :dec_special_graphics,
+    :uk,
+    :us,
+    :finnish,
+    :french,
+    :french_canadian,
+    :german,
+    :italian,
+    :norwegian_danish,
+    :portuguese,
+    :spanish,
+    :swedish,
+    :swiss
+  ]
+
+  @resolved_names Map.new(@charset_names, &{&1, &1})
+
+  # A name dropped from the list above would silently fall back onto the
+  # allocating path with every test still green, because the RESULT is
+  # unchanged either way. Fail the compile instead.
+  @missing_names Map.values(@charset_module_names) -- @charset_names
+  if @missing_names != [] do
+    raise "charset names missing from @charset_names: #{inspect(@missing_names)}"
+  end
+
+  # `nil` first: no single shift is the single commonest argument on this path.
+  def resolve_charset_name(nil), do: nil
 
   def resolve_charset_name(charset)
       when is_map_key(@charset_module_names, charset),
@@ -213,31 +257,17 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.StateManager do
       when is_map_key(@resolved_names, charset),
       do: charset
 
-  def resolve_charset_name(nil), do: nil
-
+  # Only a custom charset module reaches here: every name is answered above, so
+  # there is no shape test to keep names off the loader and therefore no reason
+  # to restrict the contract to `Elixir.`-prefixed atoms. An Erlang module
+  # exporting `name/0` resolves too, as it did before this path was rewritten.
   def resolve_charset_name(charset) when is_atom(charset) do
-    if module_atom?(charset) and Code.ensure_loaded?(charset) and
-         function_exported?(charset, :name, 0),
-       do: charset.name(),
-       else: charset
+    if Code.ensure_loaded?(charset) and function_exported?(charset, :name, 0),
+      do: charset.name(),
+      else: charset
   end
 
   def resolve_charset_name(charset), do: charset
-
-  @doc """
-  Whether `atom` is shaped like an Elixir module name.
-
-  Public so the property the fast path depends on is testable directly: every
-  atom this answers `false` for is one `resolve_charset_name/1` returns without
-  reaching the code server. Asserting that through timing would be a flake.
-  """
-  @spec module_atom?(atom()) :: boolean()
-  def module_atom?(atom) when is_atom(atom) do
-    case Atom.to_string(atom) do
-      "Elixir." <> _rest -> true
-      _not_a_module -> false
-    end
-  end
 
   @doc """
   Validates character set state.

--- a/packages/raxol_terminal/lib/raxol/terminal/ansi/character_sets/state_manager.ex
+++ b/packages/raxol_terminal/lib/raxol/terminal/ansi/character_sets/state_manager.ex
@@ -183,21 +183,61 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.StateManager do
   # serialized through one process, so parallel tests queued behind each other
   # and ANSI-heavy suites timed out.
   #
-  # A table lookup answers the real question. The fallback keeps the old dynamic
-  # contract for a charset module this table does not know, but reaches it with
-  # `module_loaded/1`, which is a lookup rather than a code-server call and so
-  # costs nothing for an atom that is not a module.
+  # A table lookup answers the real question for the closed set, and the two
+  # commonest arguments -- `nil` and an already-resolved short name -- are
+  # answered by a second table rather than by asking anything about modules.
+  #
+  # The dynamic branch below is what a custom charset module reaches, and it is
+  # deliberately NOT `:erlang.module_loaded/1`. That predicate answers "is this
+  # module in memory right now", not "is this a charset module", so a custom
+  # module that happened not to be loaded yet resolved to the module atom, and
+  # the same call after something else loaded it resolved to its name. Making
+  # the value depend on VM load order is a worse defect than the cost this
+  # change removes: it turns a wrong glyph into a wrong glyph that reproduces
+  # only sometimes. The loader is consulted, restoring the original contract.
+  #
+  # The cost that made the loader unusable is gone anyway, because it was never
+  # the loader itself -- it was reaching the loader with atoms that are not
+  # modules. `Code.ensure_loaded?/1` on a NAME is an uncached full code-path
+  # search, ~0.32ms, every character. On an Elixir module atom it is a hit or a
+  # single load, ~94ns thereafter. `module_atom?/1` is what keeps the former off
+  # the path: only an `Elixir.`-prefixed atom can name a module, so `nil`,
+  # `:us_ascii` and anything else short-circuit before the loader is involved.
+  @resolved_names Map.new(Map.values(@charset_module_names), &{&1, &1})
+
   def resolve_charset_name(charset)
       when is_map_key(@charset_module_names, charset),
       do: :erlang.map_get(charset, @charset_module_names)
 
+  def resolve_charset_name(charset)
+      when is_map_key(@resolved_names, charset),
+      do: charset
+
+  def resolve_charset_name(nil), do: nil
+
   def resolve_charset_name(charset) when is_atom(charset) do
-    if :erlang.module_loaded(charset) and function_exported?(charset, :name, 0),
-      do: charset.name(),
-      else: charset
+    if module_atom?(charset) and Code.ensure_loaded?(charset) and
+         function_exported?(charset, :name, 0),
+       do: charset.name(),
+       else: charset
   end
 
   def resolve_charset_name(charset), do: charset
+
+  @doc """
+  Whether `atom` is shaped like an Elixir module name.
+
+  Public so the property the fast path depends on is testable directly: every
+  atom this answers `false` for is one `resolve_charset_name/1` returns without
+  reaching the code server. Asserting that through timing would be a flake.
+  """
+  @spec module_atom?(atom()) :: boolean()
+  def module_atom?(atom) when is_atom(atom) do
+    case Atom.to_string(atom) do
+      "Elixir." <> _rest -> true
+      _not_a_module -> false
+    end
+  end
 
   @doc """
   Validates character set state.

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/character_sets/resolve_charset_name_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/character_sets/resolve_charset_name_test.exs
@@ -1,0 +1,110 @@
+defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
+  @moduledoc """
+  `resolve_charset_name/1` runs up to three times per translated character, so
+  what it costs is part of its contract, not an implementation detail.
+
+  It used to ask `Code.ensure_loaded/1`, a synchronous call into the single
+  global `:code_server`. The two commonest arguments on that path are `nil` (no
+  single shift) and an already-resolved name like `:us_ascii`, neither of which
+  is a module, so each call was a guaranteed load MISS -- and misses are not
+  cached, so every character re-walked the code path on disk. Measured at ~0.32ms
+  per call for `:us_ascii` against ~94ns for a loaded module, serialized through
+  one process.
+
+  These cover both halves: that resolution is still correct, and that it no
+  longer reaches for the loader.
+  """
+  use ExUnit.Case, async: true
+
+  alias Raxol.Terminal.ANSI.CharacterSets
+  alias Raxol.Terminal.ANSI.CharacterSets.StateManager
+
+  describe "resolving the charset modules" do
+    test "each module `charset_code_to_module/1` can produce resolves to its name" do
+      assert StateManager.resolve_charset_name(CharacterSets.ASCII) == :us_ascii
+
+      assert StateManager.resolve_charset_name(CharacterSets.DEC) ==
+               :dec_special_graphics
+
+      assert StateManager.resolve_charset_name(CharacterSets.UK) == :uk
+    end
+
+    test "the table agrees with the modules' own name/0" do
+      # The table is the fast path and `name/0` is the declaration. If they ever
+      # disagree, the fast path is silently translating against the wrong set.
+      for module <- [CharacterSets.ASCII, CharacterSets.DEC, CharacterSets.UK] do
+        assert StateManager.resolve_charset_name(module) == module.name()
+      end
+    end
+
+    test "every charset code maps to a module the table knows" do
+      for code <- [?B, ?0, ?A] do
+        module = CharacterSets.charset_code_to_module(code)
+        refute StateManager.resolve_charset_name(module) == module
+      end
+    end
+  end
+
+  describe "pass-through" do
+    test "an already-resolved name is returned unchanged" do
+      for name <- [:us_ascii, :dec_special_graphics, :uk, :us] do
+        assert StateManager.resolve_charset_name(name) == name
+      end
+    end
+
+    test "nil, the usual single_shift, is returned unchanged" do
+      assert StateManager.resolve_charset_name(nil) == nil
+    end
+
+    test "a non-atom is returned unchanged" do
+      assert StateManager.resolve_charset_name("us_ascii") == "us_ascii"
+      assert StateManager.resolve_charset_name(42) == 42
+    end
+  end
+
+  describe "the loader is off the hot path" do
+    # The property, proven without a wall-clock assertion: resolving an atom that
+    # names a real module which is NOT currently loaded must not load it. Only a
+    # call into the code server could, so a module still unloaded afterwards is
+    # proof that no such call happened.
+    test "resolving an unloaded module's atom does not load it" do
+      # A module that exists on disk and is not needed to run this test.
+      module = Raxol.Terminal.ANSI.CharacterSets.Translator
+
+      :code.purge(module)
+      :code.delete(module)
+      :code.purge(module)
+
+      refute :erlang.module_loaded(module),
+             "precondition: the module must start unloaded"
+
+      assert StateManager.resolve_charset_name(module) == module
+
+      refute :erlang.module_loaded(module),
+             "resolve_charset_name/1 loaded a module, so it called the code " <>
+               "server: the per-character cost this guards against is back"
+    end
+
+    test "an unloadable atom resolves without consulting the loader" do
+      # `Code.ensure_loaded/1` on this would be a full code-path search, every
+      # call, uncached. It has to come straight back instead.
+      assert StateManager.resolve_charset_name(:no_such_module_anywhere) ==
+               :no_such_module_anywhere
+    end
+  end
+
+  describe "the dynamic contract for a charset the table does not know" do
+    defmodule CustomCharset do
+      @moduledoc false
+      def name, do: :custom
+    end
+
+    test "a loaded module exporting name/0 still resolves through it" do
+      assert StateManager.resolve_charset_name(CustomCharset) == :custom
+    end
+
+    test "a loaded module without name/0 is returned unchanged" do
+      assert StateManager.resolve_charset_name(Enum) == Enum
+    end
+  end
+end

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/character_sets/resolve_charset_name_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/character_sets/resolve_charset_name_test.exs
@@ -14,15 +14,42 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
   The fix is not "never reach the loader" -- it is "never reach it with
   something that cannot be a module". A charset module still resolves through
   `Code.ensure_loaded?/1`, so its answer does not depend on what the VM happens
-  to have loaded; everything else is answered from a table or by shape.
+  to have loaded; every NAME is answered from a table.
 
   These cover both halves: that resolution is correct and load-order
-  independent, and that nothing on the hot path is shaped like a module.
+  independent, and that no charset name the emulator can designate reaches the
+  loader -- asserted through an Erlang module that shares a charset name's
+  spelling, which is observable, rather than through wall-clock time, which
+  would flake.
+
+  `async: false`: two tests mutate the node-global code path and purge modules.
   """
-  use ExUnit.Case, async: true
+  # Not async: `Code.prepend_path/1` and `:code.purge/1` are node-global.
+  use ExUnit.Case, async: false
 
   alias Raxol.Terminal.ANSI.CharacterSets
   alias Raxol.Terminal.ANSI.CharacterSets.StateManager
+
+  # The closed codomain of `charset_code_to_atom/1`, plus `:us` from the
+  # module's own `@type charset`. Every one of these must be answered without
+  # touching the loader, and the ten national replacement sets are the ones a
+  # three-entry table silently missed.
+  @charset_names [
+    :us_ascii,
+    :dec_special_graphics,
+    :uk,
+    :us,
+    :finnish,
+    :french,
+    :french_canadian,
+    :german,
+    :italian,
+    :norwegian_danish,
+    :portuguese,
+    :spanish,
+    :swedish,
+    :swiss
+  ]
 
   describe "resolving the charset modules" do
     test "each module `charset_code_to_module/1` can produce resolves to its name" do
@@ -42,19 +69,43 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
       end
     end
 
-    test "every charset code maps to a module the table knows" do
-      for code <- [?B, ?0, ?A] do
+    test "the three module-backed codes resolve to their declared names" do
+      # Only these three codes have a module: `charset_code_to_module/1` returns
+      # nil for the other twelve, and `resolve_charset_name(nil)` is nil, so a
+      # loop over every code could not assert anything here. Asserting the
+      # expected name rather than `refute result == module` also catches a table
+      # entry pointing a code at the wrong set.
+      for {code, name} <- [
+            {?B, :us_ascii},
+            {?0, :dec_special_graphics},
+            {?A, :uk}
+          ] do
         module = CharacterSets.charset_code_to_module(code)
-        refute StateManager.resolve_charset_name(module) == module
+        assert StateManager.resolve_charset_name(module) == name
       end
     end
   end
 
   describe "pass-through" do
-    test "an already-resolved name is returned unchanged" do
-      for name <- [:us_ascii, :dec_special_graphics, :uk, :us] do
+    test "every charset name the emulator can designate is returned unchanged" do
+      for name <- @charset_names do
         assert StateManager.resolve_charset_name(name) == name
       end
+    end
+
+    test "the pass-through set covers what charset_code_to_atom/1 produces" do
+      # Guards against the two halves drifting: a code whose name is missing
+      # from the table would still resolve correctly, just slowly, so no other
+      # test in this file would notice.
+      produced =
+        for code <- 0..255,
+            name = StateManager.charset_code_to_atom(code),
+            not is_nil(name),
+            uniq: true,
+            do: name
+
+      assert produced != []
+      assert Enum.sort(produced -- @charset_names) == []
     end
 
     test "nil, the usual single_shift, is returned unchanged" do
@@ -68,24 +119,23 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
   end
 
   describe "the loader is off the hot path" do
-    # The cost this guards against came from reaching the code server with
-    # atoms that are not modules: a load MISS is an uncached full code-path
-    # search, and `nil` and `:us_ascii` are the two commonest arguments here.
-    #
-    # `module_atom?/1` is the discriminator that keeps them off it, so the
-    # property is asserted directly on that predicate rather than through a
-    # wall-clock measurement, which would be a flake.
-    test "nothing that reaches the hot path is shaped like a module" do
-      for argument <- [nil, :us_ascii, :dec_special_graphics, :uk, :us] do
-        refute StateManager.module_atom?(argument),
-               "#{inspect(argument)} would be handed to the code server, and a " <>
-                 "miss there is an uncached code-path search per character"
-      end
-    end
+    test "a charset name is answered by the table even when a module shares its spelling" do
+      # The observable consequence of asking the loader about a NAME: an Erlang
+      # module can be spelled exactly like one, so a stray `german.beam`
+      # anywhere on the code path would hijack the German replacement set and
+      # translate against whatever its `name/0` returns.
+      #
+      # This is a cost assertion made behavioural. Timing it would flake; the
+      # hijack either happens or it does not.
+      module = compile_erlang_module(:german, :hijacked)
 
-    test "a module atom is the only thing that may reach the loader" do
-      assert StateManager.module_atom?(CharacterSets.ASCII)
-      refute StateManager.module_atom?(:no_such_module_anywhere)
+      assert Code.ensure_loaded?(module),
+             "precondition: the impostor must be loadable, or this proves nothing"
+
+      assert function_exported?(module, :name, 0)
+      assert module.name() == :hijacked
+
+      assert StateManager.resolve_charset_name(:german) == :german
     end
 
     test "an unloadable atom resolves without consulting the loader" do
@@ -108,6 +158,17 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
       assert StateManager.resolve_charset_name(Enum) == Enum
     end
 
+    test "an Erlang module exporting name/0 resolves through it too" do
+      # The original contract was "any loadable module exporting name/0", not
+      # "any Elixir-namespaced one". A shape test on the `Elixir.` prefix made
+      # this branch unreachable for Erlang modules, which then fell through to
+      # `CharsetData.translate/2`'s nil branch and identity-translated with no
+      # error, no log and no crash.
+      module = compile_erlang_module(:raxol_erlang_probe_charset, :erlang_probe)
+
+      assert StateManager.resolve_charset_name(module) == :erlang_probe
+    end
+
     # The regression this replaces a purge-the-world test with. An earlier fix
     # used `:erlang.module_loaded/1` here, which answers "in memory right now"
     # rather than "is this a charset module", so this same call returned the
@@ -118,10 +179,6 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
     # The probe is compiled to a temp directory rather than declared inline: a
     # module defined in an .exs file exists only in memory, so purging it makes
     # it unloadABLE, not merely unloaded, and the test would prove nothing.
-    # Nothing else in the suite references this module or this code path entry,
-    # so unloading it cannot disturb a concurrently running test. The previous
-    # version purged `CharacterSets.Translator`, a production module on the
-    # character path, out from under an `async: true` suite.
     test "an unloaded charset module resolves to its name, not to itself" do
       module = compile_probe_charset()
 
@@ -137,8 +194,7 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
 
     defp compile_probe_charset do
       module = Raxol.Terminal.ANSI.CharacterSets.OnDiskProbeCharset
-      dir = Path.join(System.tmp_dir!(), "charset_probe_#{System.unique_integer([:positive])}")
-      File.mkdir_p!(dir)
+      dir = temp_dir("charset_probe")
 
       source = Path.join(dir, "on_disk_probe_charset.ex")
 
@@ -149,17 +205,74 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
       end
       """)
 
-      Kernel.ParallelCompiler.compile_to_path([source], dir, return_diagnostics: true)
+      # Matched, not discarded: a probe that fails to compile would otherwise be
+      # swallowed, and the test would fail later at the resolution assertion
+      # with a message pointing at resolve_charset_name/1 rather than at the
+      # fixture. `return_diagnostics: true` is also dead configuration if the
+      # result is ignored.
+      assert {:ok, [^module], _diagnostics} =
+               Kernel.ParallelCompiler.compile_to_path([source], dir, return_diagnostics: true)
+
       Code.prepend_path(dir)
 
       on_exit(fn ->
         Code.delete_path(dir)
-        :code.purge(module)
-        :code.delete(module)
+        unload(module)
         File.rm_rf!(dir)
       end)
 
       module
     end
+  end
+
+  # An Erlang module, so the atom is bare (`:german`) rather than
+  # `Elixir.`-prefixed. That is the only way to spell a module that collides
+  # with a charset name.
+  defp compile_erlang_module(module, name) do
+    dir = temp_dir("erl_probe")
+    source = Path.join(dir, "#{module}.erl")
+
+    File.write!(source, """
+    -module(#{module}).
+    -export([name/0]).
+    name() -> #{name}.
+    """)
+
+    assert {:ok, ^module} =
+             :compile.file(String.to_charlist(source), [
+               {:outdir, String.to_charlist(dir)},
+               :return_errors
+             ])
+
+    Code.prepend_path(dir)
+
+    on_exit(fn ->
+      Code.delete_path(dir)
+      unload(module)
+      File.rm_rf!(dir)
+    end)
+
+    module
+  end
+
+  # purge / delete / purge: delete moves current code to the old slot, and only
+  # a second purge reclaims it. Stopping after delete leaves the chunk resident
+  # for the life of the VM.
+  defp unload(module) do
+    :code.purge(module)
+    :code.delete(module)
+    :code.purge(module)
+    :ok
+  end
+
+  defp temp_dir(prefix) do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "#{prefix}_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+    dir
   end
 end

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/character_sets/resolve_charset_name_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/character_sets/resolve_charset_name_test.exs
@@ -28,12 +28,13 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
   use ExUnit.Case, async: false
 
   alias Raxol.Terminal.ANSI.CharacterSets
+  alias Raxol.Terminal.ANSI.CharacterSets.Handler
   alias Raxol.Terminal.ANSI.CharacterSets.StateManager
+  alias Raxol.Terminal.Emulator
 
-  # The closed codomain of `charset_code_to_atom/1`, plus `:us` from the
-  # module's own `@type charset`. Every one of these must be answered without
-  # touching the loader, and the ten national replacement sets are the ones a
-  # three-entry table silently missed.
+  # Spot-check list for the "returned unchanged" test below. The AUTHORITATIVE
+  # pass-through set is `StateManager.pass_through_name?/1`; asserting against a
+  # copy of the list is what let the live designation table drift away from it.
   @charset_names [
     :us_ascii,
     :dec_special_graphics,
@@ -93,19 +94,61 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
       end
     end
 
-    test "the pass-through set covers what charset_code_to_atom/1 produces" do
-      # Guards against the two halves drifting: a code whose name is missing
-      # from the table would still resolve correctly, just slowly, so no other
-      # test in this file would notice.
-      produced =
-        for code <- 0..255,
-            name = StateManager.charset_code_to_atom(code),
-            not is_nil(name),
-            uniq: true,
-            do: name
+    test "every designator the LIVE designation path accepts is pass-through" do
+      # Anchored to `Handler.designate_charset/3`, the function the emulator
+      # actually calls for `ESC ( ) * +`. The previous version of this test
+      # enumerated `StateManager.charset_code_to_atom/1`, which has no
+      # production callers -- so it certified a table nothing reads while the
+      # live one drifted.
+      #
+      # A name missing from the pass-through set still RESOLVES correctly, just
+      # via an uncached code-server walk on every character, so only an
+      # assertion about the set itself can catch the regression.
+      designated =
+        for code <- 0..255, uniq: true do
+          Handler.designate_charset(StateManager.new(), 0, code).g0
+        end
 
-      assert produced != []
-      assert Enum.sort(produced -- @charset_names) == []
+      assert designated != []
+
+      for name <- designated do
+        assert StateManager.pass_through_name?(name),
+               "#{inspect(name)} is designable but reaches Code.ensure_loaded?/1"
+      end
+    end
+
+    test "the G-set reference a fresh emulator puts in :active is pass-through" do
+      # Every Emulator constructor seeds `charset_state.active` with a G-set
+      # REFERENCE, and `CharacterSets.translate_char/2` resolves that field
+      # directly -- so this runs per printable character on a brand-new
+      # emulator, with no escape sequence involved.
+      active = Emulator.new(80, 24).charset_state.active
+
+      assert active in [:g0, :g1, :g2, :g3]
+
+      assert StateManager.pass_through_name?(active),
+             "a fresh emulator's :active reaches Code.ensure_loaded?/1"
+    end
+
+    test "the DEC and SCS sets the other designators emit are pass-through" do
+      # CSIHandler.handle_scs/3, Charset.Operations.get_charset_for_params/2 and
+      # Escape.Parsers.SCSParser designate these; none appears in
+      # Handler.code_to_charset/1, so the test above cannot see them.
+      for name <- [
+            :dec_special,
+            :dec_supplemental,
+            :dec_supplemental_graphics,
+            :dec_supplementary,
+            :dec_technical,
+            :dec_hebrew,
+            :dec_greek,
+            :dec_turkish,
+            :uk_ascii,
+            :dutch
+          ] do
+        assert StateManager.pass_through_name?(name),
+               "#{inspect(name)} is designable but reaches Code.ensure_loaded?/1"
+      end
     end
 
     test "nil, the usual single_shift, is returned unchanged" do

--- a/packages/raxol_terminal/test/raxol/terminal/ansi/character_sets/resolve_charset_name_test.exs
+++ b/packages/raxol_terminal/test/raxol/terminal/ansi/character_sets/resolve_charset_name_test.exs
@@ -11,8 +11,13 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
   per call for `:us_ascii` against ~94ns for a loaded module, serialized through
   one process.
 
-  These cover both halves: that resolution is still correct, and that it no
-  longer reaches for the loader.
+  The fix is not "never reach the loader" -- it is "never reach it with
+  something that cannot be a module". A charset module still resolves through
+  `Code.ensure_loaded?/1`, so its answer does not depend on what the VM happens
+  to have loaded; everything else is answered from a table or by shape.
+
+  These cover both halves: that resolution is correct and load-order
+  independent, and that nothing on the hot path is shaped like a module.
   """
   use ExUnit.Case, async: true
 
@@ -63,31 +68,27 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
   end
 
   describe "the loader is off the hot path" do
-    # The property, proven without a wall-clock assertion: resolving an atom that
-    # names a real module which is NOT currently loaded must not load it. Only a
-    # call into the code server could, so a module still unloaded afterwards is
-    # proof that no such call happened.
-    test "resolving an unloaded module's atom does not load it" do
-      # A module that exists on disk and is not needed to run this test.
-      module = Raxol.Terminal.ANSI.CharacterSets.Translator
+    # The cost this guards against came from reaching the code server with
+    # atoms that are not modules: a load MISS is an uncached full code-path
+    # search, and `nil` and `:us_ascii` are the two commonest arguments here.
+    #
+    # `module_atom?/1` is the discriminator that keeps them off it, so the
+    # property is asserted directly on that predicate rather than through a
+    # wall-clock measurement, which would be a flake.
+    test "nothing that reaches the hot path is shaped like a module" do
+      for argument <- [nil, :us_ascii, :dec_special_graphics, :uk, :us] do
+        refute StateManager.module_atom?(argument),
+               "#{inspect(argument)} would be handed to the code server, and a " <>
+                 "miss there is an uncached code-path search per character"
+      end
+    end
 
-      :code.purge(module)
-      :code.delete(module)
-      :code.purge(module)
-
-      refute :erlang.module_loaded(module),
-             "precondition: the module must start unloaded"
-
-      assert StateManager.resolve_charset_name(module) == module
-
-      refute :erlang.module_loaded(module),
-             "resolve_charset_name/1 loaded a module, so it called the code " <>
-               "server: the per-character cost this guards against is back"
+    test "a module atom is the only thing that may reach the loader" do
+      assert StateManager.module_atom?(CharacterSets.ASCII)
+      refute StateManager.module_atom?(:no_such_module_anywhere)
     end
 
     test "an unloadable atom resolves without consulting the loader" do
-      # `Code.ensure_loaded/1` on this would be a full code-path search, every
-      # call, uncached. It has to come straight back instead.
       assert StateManager.resolve_charset_name(:no_such_module_anywhere) ==
                :no_such_module_anywhere
     end
@@ -105,6 +106,60 @@ defmodule Raxol.Terminal.ANSI.CharacterSets.ResolveCharsetNameTest do
 
     test "a loaded module without name/0 is returned unchanged" do
       assert StateManager.resolve_charset_name(Enum) == Enum
+    end
+
+    # The regression this replaces a purge-the-world test with. An earlier fix
+    # used `:erlang.module_loaded/1` here, which answers "in memory right now"
+    # rather than "is this a charset module", so this same call returned the
+    # module atom before anything had loaded it and its name afterwards -- a
+    # wrong glyph that reproduces only sometimes, which is worse than a slow
+    # one. Resolution must not depend on VM load order.
+    #
+    # The probe is compiled to a temp directory rather than declared inline: a
+    # module defined in an .exs file exists only in memory, so purging it makes
+    # it unloadABLE, not merely unloaded, and the test would prove nothing.
+    # Nothing else in the suite references this module or this code path entry,
+    # so unloading it cannot disturb a concurrently running test. The previous
+    # version purged `CharacterSets.Translator`, a production module on the
+    # character path, out from under an `async: true` suite.
+    test "an unloaded charset module resolves to its name, not to itself" do
+      module = compile_probe_charset()
+
+      :code.purge(module)
+      :code.delete(module)
+      :code.purge(module)
+
+      refute :erlang.module_loaded(module),
+             "precondition: the module must start unloaded"
+
+      assert StateManager.resolve_charset_name(module) == :on_disk_probe
+    end
+
+    defp compile_probe_charset do
+      module = Raxol.Terminal.ANSI.CharacterSets.OnDiskProbeCharset
+      dir = Path.join(System.tmp_dir!(), "charset_probe_#{System.unique_integer([:positive])}")
+      File.mkdir_p!(dir)
+
+      source = Path.join(dir, "on_disk_probe_charset.ex")
+
+      File.write!(source, """
+      defmodule #{inspect(module)} do
+        @moduledoc false
+        def name, do: :on_disk_probe
+      end
+      """)
+
+      Kernel.ParallelCompiler.compile_to_path([source], dir, return_diagnostics: true)
+      Code.prepend_path(dir)
+
+      on_exit(fn ->
+        Code.delete_path(dir)
+        :code.purge(module)
+        :code.delete(module)
+        File.rm_rf!(dir)
+      end)
+
+      module
     end
   end
 end


### PR DESCRIPTION
`resolve_charset_name/1` runs up to three times per translated character:
`CharacterSets.translate_char/2` resolves the active set and the single shift,
then `Translator.translate_char/3` resolves once more. Each call asked
`Code.ensure_loaded/1`, a synchronous call into the single global `:code_server`.

The killer is which arguments it sees. The two commonest are `nil` (no single
shift, and `is_atom(nil)` is true so it took the slow clause) and an
already-resolved name like `:us_ascii`. Neither is a module, so **every call was
a guaranteed load miss, and the code server does not cache misses**: each one
re-walked the entire code path on disk.

## Measured

| argument | before | after |
| --- | ---: | ---: |
| `CharacterSets.ASCII` (loaded module) | 93.9 ns | 13.8 ns |
| `:us_ascii` (already resolved) | 319,620 ns | 17.4 ns |
| `nil` (usual single shift) | 165,955 ns | 17.8 ns |
| per translated character (3 resolves) | 485,669 ns | 48.9 ns |

Roughly half a millisecond per character. An 80x24 screen was about 0.9s of
charset resolution alone, and because it went through one process, parallel tests
queued behind each other rather than merely being slow.

## The fix

What it actually resolves is a closed set of three modules: `ASCII`, `DEC`, `UK`.
They are all defined in `character_sets.ex`, they are the only modules in the
package defining `name/0`, and `charset_code_to_module/1` produces only those. A
table answers that question.

The fallback keeps the dynamic contract for a charset module the table does not
know, but reaches it via `:erlang.module_loaded/1`, a lookup rather than a
code-server call, so an atom that is not a module costs nothing.

## The regression test

It proves the property without a wall-clock assertion, which would be the wrong
tool here and a flake besides: resolving an atom that names a real but currently
unloaded module must leave it unloaded, since only a code-server call could load
it. Verified RED against the old implementation, which fails it with the intended
message. The other nine cases pass on both, so behavior is preserved.

## What this does not claim

It is tempting to say this fixes the `Raxol.Harness.*SurfaceTest` timeouts. Three
data points, on a machine with external load I did not control:

- clean master control (worktree at `bbfa5e64d`): 10 failures
- with this fix, run 1: 7 failures
- with this fix, run 2: 0 failures, 766/767 passed

So the suite went green, but it is load-sensitive and this is not proof that the
charset path was the sole cause. `test/harness` still takes ~304s for 767 tests,
so something else in there is slow too. Worth a separate look.

The pre-existing failures were found while validating an unrelated branch; the
identical `resolve_charset_name/1` stack also times out
`test/property/renderer_footer_property_test.exs` on unmodified master (235s
there vs 203s in a worktree).

## Manual testing

- [ ] A terminal session renders DEC special graphics correctly (box drawing) after a `\e(0` charset switch
- [ ] UK charset switch (`\e(A`) still maps the pound sign
- [ ] `mix raxol.playground` renders normally

## Automated

- `packages/raxol_terminal`: 2363 passed
- new `resolve_charset_name_test.exs`: 10 passed, and 1 fails by design against the old implementation
- `test/harness`: 766/767 passed, 1 skipped
- `mix format --check-formatted`: clean. The one credo finding in this file is in `charset_code_to_atom`, outside the diff
