### PR TITLE
Create plugin registry ETS tables atomically

### DIFF
--- a/packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_registry.ex
+++ b/packages/raxol_core/lib/raxol/core/runtime/plugins/plugin_registry.ex
@@ -55,25 +55,21 @@ defmodule Raxol.Core.Runtime.Plugins.PluginRegistry do
   def init do
     # Main registry table
     _ =
-      if :ets.whereis(@table_name) == :undefined do
-        :ets.new(@table_name, [
-          :named_table,
-          :public,
-          :set,
-          read_concurrency: true
-        ])
-      end
+      create_table!(@table_name, [
+        :named_table,
+        :public,
+        :set,
+        read_concurrency: true
+      ])
 
     # Commands lookup table (command -> plugin_id)
     _ =
-      if :ets.whereis(@commands_table) == :undefined do
-        :ets.new(@commands_table, [
-          :named_table,
-          :public,
-          :bag,
-          read_concurrency: true
-        ])
-      end
+      create_table!(@commands_table, [
+        :named_table,
+        :public,
+        :bag,
+        read_concurrency: true
+      ])
 
     :ok
   end
@@ -317,6 +313,57 @@ defmodule Raxol.Core.Runtime.Plugins.PluginRegistry do
   defp ensure_initialized! do
     unless initialized?() do
       init()
+    end
+  end
+
+  # Table creation is act-then-verify on purpose. Do not "simplify" this back
+  # to `if :ets.whereis(name) == :undefined, do: :ets.new(name, options)`.
+  #
+  # These tables are owned by whichever process happens to call init/0 --
+  # raxol_core's mix.exs declares no `mod:`, so no supervision tree creates
+  # them at boot and the owner is usually a test process or the caller of
+  # PluginManager.start_link/1. Deciding whether to create from an earlier
+  # :ets.whereis/1 answer loses two ways:
+  #
+  #   * Two callers both read :undefined, both call :ets.new/2, and the loser
+  #     crashes with ArgumentError "table name already exists".
+  #   * :ets.whereis/1 can resolve a table whose owner has already exited but
+  #     whose reap has not landed. Skipping creation on that stale answer
+  #     hands the caller a table that vanishes under it, so the following
+  #     :ets.insert_new/2 raises instead.
+  #
+  # :ets.new/2 is atomic, so attempt it and tolerate exactly one outcome: the
+  # name is already held by a table with a live owner, which is the state we
+  # wanted anyway. A name held by a dead owner is retried until the reap frees
+  # it. Anything else is reraised -- a failed create is never reported as :ok.
+  @create_attempts 100
+
+  defp create_table!(name, options, attempts \\ @create_attempts) do
+    :ets.new(name, options)
+  rescue
+    error in ArgumentError ->
+      owner = existing_table_owner(name)
+
+      cond do
+        is_pid(owner) and Process.alive?(owner) ->
+          name
+
+        attempts > 0 ->
+          # Either the owner is gone and the reap is still in flight, or the
+          # name was freed between our failed create and this check. Yield so
+          # the reap can finish, then try to create the table again.
+          _ = :erlang.yield()
+          create_table!(name, options, attempts - 1)
+
+        true ->
+          reraise error, __STACKTRACE__
+      end
+  end
+
+  defp existing_table_owner(name) do
+    case :ets.whereis(name) do
+      :undefined -> :undefined
+      tid -> :ets.info(tid, :owner)
     end
   end
 

--- a/packages/raxol_core/test/raxol/core/runtime/plugins/plugin_registry_test.exs
+++ b/packages/raxol_core/test/raxol/core/runtime/plugins/plugin_registry_test.exs
@@ -47,6 +47,77 @@ defmodule Raxol.Core.Runtime.Plugins.PluginRegistryTest do
       assert :ok = PluginRegistry.init()
       assert :ets.whereis(:raxol_plugin_registry) != :undefined
     end
+
+    test "registration still works after a repeated init/0" do
+      assert :ok = PluginRegistry.init()
+      assert :ok = PluginRegistry.register(:after_reinit, PluginWithCommands)
+      assert {:ok, entry} = PluginRegistry.get(:after_reinit)
+      assert entry.module == PluginWithCommands
+      assert :after_reinit in PluginRegistry.find_by_command(:help)
+    end
+
+    test "adopts tables owned by another process" do
+      drop_tables()
+
+      owner = spawn_table_owner()
+
+      assert :ok = PluginRegistry.init()
+      assert :ok = PluginRegistry.register(:foreign_owner, PluginWithCommands)
+      assert {:ok, _entry} = PluginRegistry.get(:foreign_owner)
+      assert :foreign_owner in PluginRegistry.find_by_command(:help)
+
+      stop_and_await(owner)
+    end
+
+    # Regression: init/0 used to be check-then-act
+    # (`if :ets.whereis(t) == :undefined, do: :ets.new(t, ...)`), so callers
+    # racing to create the tables could all observe :undefined and then all
+    # call :ets.new/2. Every loser crashed with ArgumentError "table name
+    # already exists". Creation is attempted directly now, so no caller can
+    # lose. The callers are released from a spin barrier rather than by
+    # sequential sends so that they reach :ets.new/2 together, and several
+    # rounds are run because one round only samples one interleaving.
+    test "concurrent callers never crash creating the tables" do
+      for _round <- 1..10 do
+        drop_tables()
+
+        parent = self()
+        barrier = :atomics.new(1, [])
+
+        callers =
+          for _ <- 1..32 do
+            spawn(fn ->
+              send(parent, {self(), :waiting})
+              await_barrier(barrier)
+
+              result =
+                try do
+                  {:ok, PluginRegistry.init()}
+                rescue
+                  error -> {:raised, error}
+                end
+
+              send(parent, {self(), result})
+              # Stay alive so the created tables outlive the assertions.
+              receive do: (:stop -> :ok)
+            end)
+          end
+
+        for caller <- callers, do: assert_receive({^caller, :waiting}, 5_000)
+        :atomics.put(barrier, 1, 1)
+
+        for caller <- callers do
+          assert_receive {^caller, result}, 5_000
+          assert result == {:ok, :ok}
+        end
+
+        assert PluginRegistry.initialized?()
+        assert :ok = PluginRegistry.register(:raced, PluginWithCommands)
+        assert {:ok, _entry} = PluginRegistry.get(:raced)
+
+        Enum.each(callers, &stop_and_await/1)
+      end
+    end
   end
 
   describe "initialized?/0" do
@@ -348,5 +419,49 @@ defmodule Raxol.Core.Runtime.Plugins.PluginRegistryTest do
     test "returns empty list for no matches" do
       assert [] = PluginRegistry.find_by_metadata(:category, :nonexistent)
     end
+  end
+
+  # Removes the tables created by setup/0 (owned by this process) so that the
+  # code under test has to create them.
+  defp drop_tables do
+    Enum.each([:raxol_plugin_registry, :raxol_plugin_commands], fn table ->
+      case :ets.whereis(table) do
+        :undefined -> :ok
+        _tid -> :ets.delete(table)
+      end
+    end)
+  end
+
+  # Spawns a process that creates the registry tables and then stays alive, so
+  # the tables are owned by somebody other than the test process.
+  defp spawn_table_owner do
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        PluginRegistry.init()
+        send(parent, {self(), :initialized})
+        receive do: (:stop -> :ok)
+      end)
+
+    assert_receive {^owner, :initialized}, 5_000
+    owner
+  end
+
+  # Spin (rather than block on a message) so that every caller leaves the
+  # barrier in the same scheduler slice; sequential sends stagger the wake-ups
+  # enough that the first caller usually wins uncontended.
+  defp await_barrier(barrier) do
+    if :atomics.get(barrier, 1) == 1 do
+      :ok
+    else
+      await_barrier(barrier)
+    end
+  end
+
+  defp stop_and_await(pid) do
+    ref = Process.monitor(pid)
+    send(pid, :stop)
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, 5_000
   end
 end


### PR DESCRIPTION
## Problem

`PluginRegistry.init/0` created its two ETS tables check-then-act:

```elixir
if :ets.whereis(@table_name) == :undefined do
  :ets.new(@table_name, [:named_table, :public, :set, read_concurrency: true])
end
```

### Ownership analysis

`packages/raxol_core/mix.exs` declares no `mod:`, so raxol_core starts no
supervision tree and nothing creates `:raxol_plugin_registry` /
`:raxol_plugin_commands` at boot. The only creators are `PluginRegistry.init/0`,
called inline from test `setup` blocks, from `PluginManager.start_link/1`, from
`PluginManager.initialize/0` + `initialize_with_config/1`, and from
`PluginLifecycle`. All of those run in the *caller's* process, so both tables are
owned by the calling (usually test) process and die with it.

Two consequences:

1. **The teardown in #979 is inert for these two tables.** ExUnit runs `on_exit`
   in a separate process, after the owning test process is already down. By then
   the tables are gone, `:ets.delete_all_objects/1` raises, the (correctly
   narrowed) rescue returns `:ok`, and nothing is ever cleared. That teardown is
   still right for tables owned by a long-lived process; it just cannot do
   anything for these.
2. **The creation side races.** Because the check and the create are separate
   steps:
   - Two callers both read `:undefined`, both call `:ets.new/2`, and every loser
     crashes with `ArgumentError "table name already exists"`.
   - `:ets.whereis/1` can resolve a table whose owner has already exited but
     whose reap has not landed. Creation is skipped on that stale answer, the
     reap completes, and the caller is left holding a dead table;
     `register/3` -> `ensure_initialized!/0` re-checks with the same stale
     `initialized?/0`, also skips re-init, and `:ets.insert_new/2` raises.

## Fix

`:ets.new/2` is itself atomic, so creation is now act-then-verify: attempt the
create and tolerate exactly one failure -- the name is already held by a table
whose owner is alive, which is the state `init/0` wanted anyway. A name held by
a dead owner (reap in flight, or freed between the failed create and the check)
is retried until the create succeeds. Anything else is reraised, so a failed
create is never silently reported as `:ok`.

Table options, the `:set` / `:bag` split between the two tables, and the `:ok`
return contract of `init/0` are unchanged (`PluginManager.start_link/1` and the
tests only care about `:ok`). The `WHY` is spelled out in a comment at the
helper, because this is the kind of code a later reader "simplifies" back into a
`whereis` check.

`initialized?/0` and `ensure_initialized!/0` are deliberately untouched: they
only guard a call to `init/0`, and now that `init/0` is race-free a redundant
concurrent call is harmless. Making them owner-aware would add an `:ets.info/2`
to every read path for no behavioural gain.

`ResourceBudget` was checked and does **not** create ETS tables (it only counts
them for budget enforcement), so nothing there needed the same treatment.

## Evidence

`test/raxol/core/runtime/plugins/plugin_registry_test.exs` adds a regression test
that releases 32 callers from a spin barrier (sequential `send/2` staggers the
wake-ups enough that the first caller usually wins uncontended) and asserts none
of them crashes in `init/0`, repeated over 10 rounds.

With only the production file reverted, that test fails on **8 out of 8** runs:

```
  1) test init/0 concurrent callers never crash creating the tables
     Assertion with == failed
     code:  assert result == {:ok, :ok}
     left:  {:raised, %ArgumentError{message: "errors were found at the given
            arguments:\n\n  * 1st argument: table name already exists\n"}}
     right: {:ok, :ok}
```

With the fix in place the file is green on 6 consecutive runs (46 tests), and the
whole package suite passes: `984 passed`.

Two smaller property tests come along: `init/0` followed by a working
`register/3`, and `init/0` adopting tables owned by another live process.

Note: the stale-`whereis` reap window itself is *not* reproducible from a unit
test -- once the owner's `:DOWN` has been delivered the name is already free, and
polling for the intermediate state cannot be made deterministic. The concurrent
creation collision above is the same defect (acting on a `whereis` answer that is
no longer true) and it is reproducible on demand, so that is what the committed
test pins.

## Relationship to #979

Complementary, no overlap. #979 shares one ETS teardown helper across suites;
this PR fixes the creation path in product code. Neither change touches the
other's files, and #979's helper stays useful for tables that do have a
long-lived owner.

## Manual testing

- [x] `cd packages/raxol_core && MIX_ENV=test mix test test/raxol/core/runtime/plugins/plugin_registry_test.exs` -- 46 passed, 6 consecutive runs
- [x] Production file reverted, same file re-run 8 times -- fails every time with `table name already exists`
- [x] `cd packages/raxol_core && MIX_ENV=test mix test` -- 984 passed
- [x] `mix format --check-formatted` on both changed files
- [ ] CI green
