### PR TITLE
Repair web deployment image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,7 +26,9 @@ deps/
 **/test/
 !**/lib/**/test/
 bench/
-scripts/
+# InstallController embeds this one script at compile time.
+scripts/*
+!scripts/install.sh
 
 # Documentation
 docs/
@@ -35,6 +37,7 @@ docs/
 # IDE files
 .vscode/
 .idea/
+.claude/
 *.swp
 *.swo
 *~

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -3,7 +3,7 @@
 
 ARG ELIXIR_VERSION=1.17.1
 ARG OTP_VERSION=27.0
-ARG DEBIAN_VERSION=bullseye-20240701-slim
+ARG DEBIAN_VERSION=bookworm-20240701-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
@@ -53,7 +53,7 @@ RUN mix release --overwrite
 FROM ${RUNNER_IMAGE} AS runner
 
 RUN apt-get update -y && \
-  apt-get install -y libstdc++6 openssl libncurses5 locales ca-certificates \
+  apt-get install -y libstdc++6 openssl libncurses6 locales ca-certificates \
   && apt-get clean && rm -f /var/lib/apt/lists/*_*
 
 # Set the locale

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -29,7 +29,7 @@ printf "Smoke testing %s\n\n" "$HOST"
 check "/health"
 check "/"
 check "/playground"
-check "/demos"
+check "/demos" "301"
 check "/gallery"
 
 printf "\nResults: %d passed, %d failed\n" "$pass" "$fail"


### PR DESCRIPTION
## Summary

- move the web builder and runner from expired Bullseye repositories to Bookworm
- install the matching `libncurses6` runtime package
- include `scripts/install.sh` in the Docker build context
- exclude local `.claude/` data from future build contexts
- align the production smoke test with the intentional `/demos` redirect

## Manual testing

- [x] Built and deployed the production image with `flyctl deploy --ha=false`
- [x] Launched one healthy `raxol` app machine
- [x] Passed all five checks in `scripts/smoke-test.sh https://raxol.io`
- [x] Visually verified the deployed settlement and ACP lifecycle heroes
