### PR TITLE
Add CLI version flag

### DIFF
--- a/packages/raxol_cli/lib/raxol/cli.ex
+++ b/packages/raxol_cli/lib/raxol/cli.ex
@@ -38,6 +38,12 @@ defmodule Raxol.CLI do
   def main(["update" | rest]), do: Raxol.CLI.Update.run(rest)
   def main(["playground" | _rest]), do: run_playground()
   def main(["new" | rest]), do: Raxol.CLI.New.run(rest)
+
+  def main(["--version"]) do
+    IO.puts("raxol #{version()}")
+    0
+  end
+
   def main([help]) when help in ~w(help --help -h), do: help()
 
   def main([unknown | _]) do
@@ -353,6 +359,10 @@ defmodule Raxol.CLI do
       playground    Browse the interactive component catalog
       new [name]    Scaffold an Elixir/Mix Raxol application
       help          Show this help
+
+    Options:
+      --version     Show the installed Raxol version
+      -h, --help    Show this help
 
     Run `raxol` with no command to start the agent.
     """)

--- a/packages/raxol_cli/test/raxol/cli_test.exs
+++ b/packages/raxol_cli/test/raxol/cli_test.exs
@@ -14,6 +14,12 @@ defmodule Raxol.CLITest do
       assert out =~ "playground"
     end
 
+    test "--version prints the CLI version and returns 0" do
+      out = capture_io(fn -> assert CLI.main(["--version"]) == 0 end)
+
+      assert out == "raxol #{CLI.version()}\n"
+    end
+
     test "help lists acp, and it is a declared command" do
       out = capture_io(fn -> assert CLI.main(["help"]) == 0 end)
 


### PR DESCRIPTION
## Summary

- accept `raxol --version` at the top-level CLI dispatcher
- print only the installed version and build stamp, then exit successfully
- document the version flag in top-level help
- cover the behavior with a CLI regression test

## Manual testing

- [x] `mix test test/raxol/cli_test.exs` — 21 passed
- [x] `raxol --version` equivalent printed `raxol 0.2.7+2ab2cc035` and exited 0
- [x] `raxol --help` equivalent still printed the full command and option reference
