### PR TITLE
Prepare 2.7.0 release

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -187,20 +187,40 @@ jobs:
       # check", and narrowing the scan at the same commit it became
       # authoritative would hide that difference silently. The second run
       # below keeps unverified hits on the record without gating on them.
+      # Incremental events must compare two distinct revisions. On a push to
+      # the default branch, using the branch name as the base resolves to HEAD
+      # after checkout and TruffleHog aborts without scanning anything.
       - name: TruffleHog OSS (verified only, blocking)
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
+          base: ${{ github.event_name == 'push' && github.event.before || github.event.repository.default_branch }}
           head: HEAD
           extra_args: --only-verified
 
-      - name: TruffleHog OSS (all findings, advisory)
+      - name: TruffleHog OSS (verified only, full history)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: ${{ github.event.repository.default_branch }}
+          extra_args: --only-verified
+
+      - name: TruffleHog OSS (all findings, advisory)
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event_name == 'push' && github.event.before || github.event.repository.default_branch }}
           head: HEAD
+          extra_args: --results=verified,unknown
+        continue-on-error: true
+
+      - name: TruffleHog OSS (all findings, full history)
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
           extra_args: --results=verified,unknown
         continue-on-error: true
 

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -2,6 +2,7 @@
 # Fingerprints bind each exception to one commit, path, rule, and line; a new
 # key-shaped value in the same test tree is not exempt.
 
+056f6d50a85391e71022c4ebd56fad04d200af98:priv/static/assets/vendor/xterm/xterm.min.js:generic-api-key:7
 0e7791d96519e5fa999c31ee91c0c1261f45ede8:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:566
 0e7791d96519e5fa999c31ee91c0c1261f45ede8:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:567
 0fd7f96f888022cd9880e6c840cdd6dd58305f62:packages/raxol_payments/test/raxol/payments/eip712_golden_test.exs:generic-api-key:55
@@ -19,6 +20,9 @@
 196bb0ccc22c3c20f40c856359b8aabe3ec53065:packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs:generic-api-key:81
 1be84a0f499bf80ec7eb0083bdbc48e8012d8b21:test/raxol/core/runtime/debug_test.exs:generic-api-key:18
 1ea47e574e94cff4a2f9d71938bc4b3a1d4643eb:packages/raxol_payments/lib/raxol/payments/wallets/env.ex:generic-api-key:11
+2daeead650088f8d11194fde22d91954cb1e76fe:packages/raxol_acp/test/raxol/acp/asset_token_test.exs:generic-api-key:13
+316b71bd26c342173dc90f4f5683e254f6eddbcd:scripts/run_live_gates.sh:generic-api-key:338
+316b71bd26c342173dc90f4f5683e254f6eddbcd:scripts/run_live_gates.sh:generic-api-key:339
 444b8ac9ce642d840c063b5e1afe7a59e58c7660:packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs:generic-api-key:110
 444b8ac9ce642d840c063b5e1afe7a59e58c7660:packages/raxol_payments/test/raxol/payments/xochi/live_xochi_test.exs:generic-api-key:112
 4dbd11fa0b8388beefb51279257803f45a9b8ee2:packages/raxol_earn/test/raxol/earn/xochi/pull_preflight_test.exs:generic-api-key:112
@@ -41,10 +45,13 @@
 644e52cb8206223910c7eff177e864d1eb64487a:packages/raxol_payments/test/raxol/payments/eip712_test.exs:generic-api-key:315
 644e52cb8206223910c7eff177e864d1eb64487a:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:182
 644e52cb8206223910c7eff177e864d1eb64487a:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:183
+67abb0909d97d3229e3ee5ba89831445368b5924:packages/raxol_acp/examples/buyer_signed_intent.exs:generic-api-key:34
 67abb0909d97d3229e3ee5ba89831445368b5924:packages/raxol_acp/examples/buyer_signed_intent.exs:generic-api-key:35
 68e1456b1dd58e252fc25955600395e7809ec608:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:680
 68e1456b1dd58e252fc25955600395e7809ec608:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:681
+845ac374ab5b47a5af14fde1462ae8669b5ef1a9:packages/raxol_acp/examples/buyer_signed_intent.exs:generic-api-key:50
 845ac374ab5b47a5af14fde1462ae8669b5ef1a9:packages/raxol_acp/examples/buyer_signed_intent.exs:generic-api-key:51
+845ac374ab5b47a5af14fde1462ae8669b5ef1a9:packages/raxol_acp/examples/buyer_signed_intent.exs:generic-api-key:69
 845ac374ab5b47a5af14fde1462ae8669b5ef1a9:packages/raxol_acp/examples/buyer_signed_intent.exs:generic-api-key:70
 8f7ffc296c5b66d9671539e50829474ab7d387eb:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:316
 8f7ffc296c5b66d9671539e50829474ab7d387eb:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:317
@@ -89,6 +96,7 @@ c5a3ec150a72d8e5bce9f0023807ccbf49f3a4bc:packages/raxol_payments/test/raxol/paym
 c5a3ec150a72d8e5bce9f0023807ccbf49f3a4bc:packages/raxol_payments/test/raxol/payments/protocols/xochi_test.exs:generic-api-key:644
 d21e6c2c18e185c578f68a8d95599d388b44b682:packages/raxol_acp/test/fixtures/xochi/quote_fillable.json:generic-api-key:14
 d21e6c2c18e185c578f68a8d95599d388b44b682:packages/raxol_acp/test/fixtures/xochi/quote_fillable.json:generic-api-key:21
+d21e6c2c18e185c578f68a8d95599d388b44b682:packages/raxol_acp/test/raxol/acp/xochi/fixture_parity_test.exs:generic-api-key:22
 d21e6c2c18e185c578f68a8d95599d388b44b682:packages/raxol_acp/test/raxol/acp/xochi/fixture_parity_test.exs:generic-api-key:23
 d9873dd67426707c977c1bcf1ee3d55d4557d4e1:packages/raxol_agent/test/raxol/agent/sandbox_hook_test.exs:generic-api-key:168
 dfa45d5041c2de2f5865306683319efae5d633cb:packages/raxol_payments/test/raxol/payments/accounting_wiring_test.exs:generic-api-key:54

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [2.7.0] - 2026-09-09
 
 ### Added
 
@@ -48,6 +48,10 @@ These are public modules of published packages, so their removal is breaking and
 - **`raxol_terminal`: `Renderer.get_content/2`'s pid clause.** The clause matching a buffer-manager pid and returning `{:error, :deprecated_buffer_manager}` is gone with no catch-all behind it, so an external caller still passing a pid now gets a `FunctionClauseError` rather than the error tuple. Match on the buffer directly.
 
 ### Fixed
+
+- **`raxol --version` is a real top-level flag**. The packaged CLI now prints
+  its release version and build stamp, then exits successfully instead of
+  treating `--version` as an unknown command.
 
 - **A new `raxol_core` module shipped under a constraint that resolved without it.** `Raxol.Core.Colors.Ansi256` was added to `raxol_core`, but `raxol`, `raxol_terminal` and `raxol_liveview` all depended on `raxol_core "~> 2.6"`, which Hex resolves to the published 2.6.0, a version without the module. A consumer installing from Hex would have hit `UndefinedFunctionError` on any 256-color render (`Formats.ansi_to_rgb/1`, `SixelPalette`, `TerminalBridge.color_256_to_rgb/1`). Adding public API is a minor bump, so the framework family moves to 2.7.0 and the constraints to `"~> 2.7"`, which cannot resolve a `raxol_core` without the module. Neither guard could have caught this: `scripts/check-lockstep-deps.sh` compares only `X.Y`, and `Raxol.Release.PackageCheck` requires the constraint to be exactly `"~> major.minor"` of the sibling, so a patch-level API addition is invisible to both by construction.
 - **The 2.6.x family was split across two patch versions** (`raxol` and `raxol_terminal` at 2.6.1, the rest at 2.6.0), which is what allowed a dependent to resolve a sibling older than the code it was built against. The framework line (`raxol`, `raxol_core`, `raxol_terminal`, `raxol_agent`, `raxol_mcp`, `raxol_liveview`, `raxol_plugin`, `raxol_sensor`) is unified at 2.7.0.

--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ them. In sandboxes where `HOME` is read-only, point `MIX_HOME` and
 
 Raxol started as two converging ideas: a terminal for AGI, where AI agents interact with a real terminal emulator the same way humans do; and an interface for the cockpit of a Gundam Wing Suit, where fault isolation, real-time responsiveness, and sensor fusion are survival-critical. The Gundam thing sounds like a joke. Then you look at the constraint set and it's exactly what OTP was built for: systems that can't go down, can't lose state, and have to hot-swap components while running.
 
+The longer vision is [Raxol: The Terminal For My Gundam](https://droo.foo/posts/raxol-terminal-for-the-gundam).
+
 ## Built with Raxol
 
 **[Xochi](https://xochi.fi)** is a private cross-chain DEX (intent-based swaps across 6 chains, sub-3s settlement, stealth addresses by default, ZKSAR compliance proofs) whose entire trading surface is raxol. One Component tree projects four ways: an SSH trader terminal, a LiveView web UI, a solver-agent surface for Riddler's sub-2ms solver, and an ops cockpit running sensor fusion on solver health. The solver executes behind a dedicated fail-closed stack (buyer-pre-signed intents, ledger-enforced spend gates, deployment guards that refuse to run unconfigured), kept deliberately off the MCP surface, so no fund-moving action is reachable as a generic tool call.

--- a/packages/raxol_payments/CHANGELOG.md
+++ b/packages/raxol_payments/CHANGELOG.md
@@ -5,7 +5,28 @@ All notable changes to `raxol_payments` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.1] - 2026-09-09
+
+### Added
+
+- Accounting, fee-schedule, settlement-ledger, and rebalance-policy primitives
+  for tracking and managing agent payment rails.
+- Runnable agent-payment and privacy-mode examples.
+
+### Changed
+
+- Separated stealth recipient routing from shielded settlement semantics.
+- Updated the `raxol_core` and `raxol_agent` requirements to the 2.7 release
+  line.
+
+### Fixed
+
+- Bound Xochi quote signatures to the served EIP-712 domain fields.
+- Corrected paymaster policy selection and tightened on-chain read boundaries.
+
+### Security
+
+- Bounded and redacted payment telemetry before durable persistence.
 
 ## [0.2.0] - 2026-07-11
 

--- a/packages/raxol_speech/CHANGELOG.md
+++ b/packages/raxol_speech/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `raxol_speech` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-05-21
+## [0.2.1] - 2026-09-09
 
 ### Added
 

--- a/packages/raxol_telegram/CHANGELOG.md
+++ b/packages/raxol_telegram/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `raxol_telegram` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-05-21
+## [0.2.1] - 2026-09-09
 
 ### Added
 

--- a/packages/raxol_watch/CHANGELOG.md
+++ b/packages/raxol_watch/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to `raxol_watch` are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - 2026-05-21
+## [0.2.1] - 2026-09-09
 
 ### Added
 


### PR DESCRIPTION
## Summary

- finalize the existing unpublished 2.7.0 framework and 0.2.1 surface/payment version lines
- date the root and package changelogs for the 2026-09-09 release
- link the Gundam vision post from the README
- give TruffleHog distinct base and head revisions on default-branch pushes
- fingerprint eight historical public chain constants and vendored bytes that Gitleaks misclassified

The six pre-alpha projects remain outside the public Hex train. The CLI ships separately as `raxol-cli-v0.2.7` and npm package `raxol@0.2.7`.

## Manual testing

- [x] `mix compile --warnings-as-errors`
- [x] `mix format --check-formatted`
- [x] `mix raxol.check_docs`
- [x] `mix raxol.release.check` — all 12 public Hex packages passed
- [x] `scripts/check-quality-ratchet.sh` — Credo held baseline; Dialyzer improved by 9
- [x] `actionlint -ignore 'shellcheck reported issue' .github/workflows/security.yml`
- [x] `gitleaks git . --config .gitleaks.toml --redact --exit-code 1` — 3,837 commits, no leaks
- [x] Full CI — all required checks passed on macOS, Windows, and Linux
