### PR TITLE
Scope npm wrapper under @raxol

### DIFF
--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -1,7 +1,7 @@
-name: Release raxol npm package
+name: Release @raxol/cli npm package
 
-# Builds the self-contained `raxol` command binaries and assembles the `raxol`
-# npm package, so `npm i -g raxol` puts `raxol` on the PATH (no Erlang/Elixir).
+# Builds the self-contained `raxol` command binaries and assembles the
+# `@raxol/cli` npm package, so `npm i -g @raxol/cli` puts `raxol` on the PATH.
 # Every binary is built natively for its arch: Linux amd64/arm64 via Docker on
 # their own runners, macOS arm64 on a macOS runner (native builds avoid the
 # termbox NIF cross-compile hazard -- see docker/Dockerfile.raxol-cli).
@@ -187,7 +187,7 @@ jobs:
           path: packages/raxol_cli/burrito_out
 
       # Builds one @raxol/cli-<platform>-<arch> package per binary, each
-      # declaring os/cpu. The `raxol` wrapper lists them as optionalDependencies
+      # declaring os/cpu. The `@raxol/cli` wrapper lists them as optionalDependencies
       # so npm downloads only the matching one (~68MB, not ~270MB).
       - name: Build platform packages
         run: packages/raxol_cli/npm/scripts/pack.sh
@@ -209,25 +209,43 @@ jobs:
           if-no-files-found: error
 
       # npm publish is deliberately NOT wired to the tag. A `raxol-cli-v*` tag
-      # ships the release binaries (see the `release` job); claiming the `raxol`
-      # name on npm is a separate, deliberate act. Publish with a manual run:
+      # ships the release binaries (see the `release` job); publishing the
+      # `@raxol/cli` wrapper is a separate, deliberate act. Publish with:
       #   gh workflow run release-raxol-cli.yml -f publish=true
       #
       # Order matters: the platform packages go first. The wrapper pins them by
       # exact version, so publishing it against a registry that does not yet
-      # have them leaves a window where `npm i -g raxol` resolves nothing.
+      # have them leaves a window where `npm i -g @raxol/cli` resolves nothing.
       - name: Publish to npm
         if: inputs.publish == true
         working-directory: packages/raxol_cli/npm
         run: |
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+          set -euo pipefail
+
+          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
             echo "::error::publish=true but the NPM_TOKEN secret is unset or empty." >&2
             exit 1
           fi
+
+          publish_package() {
+            local directory="$1"
+            local manifest="$directory/package.json"
+            local name
+            local version
+            name="$(node -p "require(require('node:path').resolve(process.argv[1])).name" "$manifest")"
+            version="$(node -p "require(require('node:path').resolve(process.argv[1])).version" "$manifest")"
+
+            if npm view "$name@$version" version >/dev/null 2>&1; then
+              echo "$name@$version is already published; skipping"
+            else
+              (cd "$directory" && npm publish --access public)
+            fi
+          }
+
           for dir in platforms/*/; do
-            (cd "$dir" && npm publish --access public)
+            publish_package "$dir"
           done
-          npm publish --access public
+          publish_package "."
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,10 +138,10 @@ these need Elixir at run time:
 ```bash
 curl -fsSL https://raxol.io/install | bash   # scripts/install.sh, checksum-verified
 brew install droodotfoo/tap/raxol            # scripts/gen_homebrew_formula.sh emits the formula
-npm install -g raxol                         # wrapper + one per-platform binary
+npm install -g @raxol/cli                  # wrapper + one per-platform binary
 ```
 
-npm ships as a small `raxol` launcher plus per-platform packages
+npm ships as a small `@raxol/cli` launcher plus per-platform packages
 (`@raxol/cli-<platform>-<arch>`) declared as `optionalDependencies` with
 `os`/`cpu` set, so an install pulls one ~68MB binary instead of all four.
 `packages/raxol_cli/npm/scripts/pack.sh` builds them from `burrito_out` and

--- a/packages/raxol_cli/README.md
+++ b/packages/raxol_cli/README.md
@@ -1,8 +1,8 @@
 # RaxolCli
 
 The `raxol` command: an interactive AI agent and Raxol toolkit in your terminal.
-Ships as a self-contained binary (Burrito) wrapped in the `raxol` npm package
-(`npm/`), so `npm i -g raxol` puts `raxol` on your PATH. See docs/adr/0031 for the
+Ships as a self-contained binary (Burrito) wrapped in the `@raxol/cli` npm
+package (`npm/`), so `npm i -g @raxol/cli` puts `raxol` on your PATH. See docs/adr/0031 for the
 packaging approach.
 
 ## Commands

--- a/packages/raxol_cli/lib/raxol/cli/update.ex
+++ b/packages/raxol_cli/lib/raxol/cli/update.ex
@@ -396,7 +396,7 @@ defmodule Raxol.CLI.Update do
     else
       _ ->
         {:error,
-         "not running as a Burrito binary; reinstall with `npm i -g raxol` or download the latest release"}
+         "not running as a Burrito binary; reinstall with `npm i -g @raxol/cli` or download the latest release"}
     end
   end
 

--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -33,7 +33,7 @@ defmodule RaxolCli.MixProject do
   end
 
   # The `raxol` command. Burrito wraps the release into a self-contained
-  # executable per target; the `raxol` npm package (npm/) ships those binaries.
+  # executable per target; the `@raxol/cli` npm package (npm/) ships those binaries.
   # Build one target with `BURRITO_TARGET=<name> MIX_ENV=prod mix release`.
   defp releases do
     [

--- a/packages/raxol_cli/npm/README.md
+++ b/packages/raxol_cli/npm/README.md
@@ -1,10 +1,10 @@
-# raxol
+# @raxol/cli
 
 Interactive AI agent and TUI toolkit in your terminal, as a self-contained
 binary. No Erlang, Elixir, or Node runtime needed at run time.
 
 ```bash
-npm install -g raxol
+npm install -g @raxol/cli
 raxol            # interactive AI agent
 raxol doctor     # what this install resolves: build, providers, config
 raxol update     # replace this binary with the latest verified release

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "raxol",
+  "name": "@raxol/cli",
   "version": "0.2.7",
-  "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g raxol` puts `raxol` on your PATH -- no Erlang or Elixir required.",
+  "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g @raxol/cli` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"
   },

--- a/packages/raxol_cli/npm/scripts/pack.sh
+++ b/packages/raxol_cli/npm/scripts/pack.sh
@@ -5,7 +5,7 @@
 # (`mise exec -- env BURRITO_TARGET=<t> MIX_ENV=prod mix release`), from any dir.
 #
 # Each platform gets its own package (@raxol/cli-<platform>-<arch>) carrying one
-# binary and declaring `os`/`cpu`. The `raxol` wrapper lists all four as
+# binary and declaring `os`/`cpu`. The `@raxol/cli` wrapper lists all four as
 # optionalDependencies, so npm installs only the one matching the host: an
 # install pulls ~68MB rather than ~270MB. This is the esbuild arrangement.
 #


### PR DESCRIPTION
## Summary

- rename the npm wrapper from rejected unscoped `raxol` to `@raxol/cli`
- preserve the installed executable name as `raxol`
- update install guidance to `npm install -g @raxol/cli`
- make npm publication resumable by skipping versions already present in the registry

The four `@raxol/cli-*` platform packages are already live at 0.2.7. npm rejected only the unscoped wrapper because its name was too similar to `rax`.

## Manual testing

- [x] `npm test` — 2 passed
- [x] `npm pack --dry-run --json` — produced `@raxol/cli@0.2.7`
- [x] `mix test` in `packages/raxol_cli` — 34 passed
- [x] `actionlint .github/workflows/release-raxol-cli.yml`
- [x] no remaining `npm i -g raxol` install instructions
- [ ] Full CI
