### PR TITLE
Automate approved registry releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,8 +9,10 @@ This directory contains GitHub Actions workflows for CI, testing, and releases.
 - **`security.yml`**: Comprehensive security scanning (dependencies, secrets, SAST)
 - **`nightly.yml`**: Nightly regression testing with full test matrix
 - **`regression-testing.yml`**: Unified performance and memory regression testing
-- **`release.yml`**: GitHub release creation for `v*` tags
-- **`release-hex.yml`**: Validated, dependency-ordered Hex publication from an immutable release tag
+- **`release.yml`**: Tag-authorized Hex train plus GitHub release for `v*` tags
+- **`release-hex.yml`**: Reusable, approval-gated, dependency-ordered Hex publication
+- **`release-raxol-cli.yml`**: Native CLI builds, approval-gated npm
+  publication with provenance, and CLI GitHub releases
 
 ### Supporting Workflows
 - **`performance-tracking.yml`**: Performance benchmarking and tracking

--- a/.github/workflows/release-hex.yml
+++ b/.github/workflows/release-hex.yml
@@ -1,6 +1,19 @@
 name: Publish Hex release train
 
 on:
+  workflow_call:
+    inputs:
+      release_ref:
+        description: "Existing v* tag whose exact commit will be published"
+        required: true
+        type: string
+      publish:
+        description: "Publish after preflight"
+        required: true
+        type: boolean
+    secrets:
+      HEX_API_KEY:
+        required: false
   workflow_dispatch:
     inputs:
       release_ref:
@@ -21,8 +34,8 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    name: Validate and publish public packages
+  validate:
+    name: Validate public package train
     runs-on: ubuntu-latest
     env:
       MIX_ENV: dev
@@ -38,6 +51,8 @@ jobs:
         env:
           RELEASE_REF: ${{ inputs.release_ref }}
         run: |
+          set -euo pipefail
+
           if [[ ! "$RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::release_ref must be a vMAJOR.MINOR.PATCH tag"
             exit 1
@@ -45,7 +60,7 @@ jobs:
 
           tag_commit="$(git rev-parse "$RELEASE_REF^{commit}")"
           head_commit="$(git rev-parse HEAD)"
-          if [ "$tag_commit" != "$head_commit" ]; then
+          if [[ "$tag_commit" != "$head_commit" ]]; then
             echo "::error::$RELEASE_REF does not resolve to the checked-out commit"
             exit 1
           fi
@@ -78,40 +93,76 @@ jobs:
       - name: Validate public release train
         run: mix raxol.release.check
 
-      - name: Require noninteractive publishing key
-        if: inputs.publish == true
+      - name: Match root package version to tag
         env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+          RELEASE_REF: ${{ inputs.release_ref }}
         run: |
-          if [ -z "$HEX_API_KEY" ]; then
-            echo "::error::publish=true but the HEX_API_KEY secret is unset or empty."
+          set -euo pipefail
+          version="$(mix run --no-start --no-compile --no-deps-check \
+            -e 'IO.write(Mix.Project.config()[:version])')"
+          expected_ref="v$version"
+
+          if [[ "$RELEASE_REF" != "$expected_ref" ]]; then
+            echo "::error::$RELEASE_REF does not match root package version $version"
             exit 1
           fi
 
-      # One job preserves the topological order. A failed run is resumable:
-      # versions already visible on Hex are skipped before the next publish.
-      - name: Publish packages in dependency order
-        if: inputs.publish == true
-        env:
-          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
-        run: |
-          packages=(
-            "raxol_core:packages/raxol_core"
-            "raxol_sensor:packages/raxol_sensor"
-            "raxol_terminal:packages/raxol_terminal"
-            "raxol_mcp:packages/raxol_mcp"
-            "raxol_liveview:packages/raxol_liveview"
-            "raxol_plugin:packages/raxol_plugin"
-            "raxol_speech:packages/raxol_speech"
-            "raxol_watch:packages/raxol_watch"
-            "raxol:."
-            "raxol_agent:packages/raxol_agent"
-            "raxol_payments:packages/raxol_payments"
-            "raxol_telegram:packages/raxol_telegram"
-          )
+  publish:
+    name: Publish public packages
+    needs: validate
+    if: inputs.publish == true
+    environment: release
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: dev
+      RAXOL_DEV_PORT: "4000"
+      HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_ref }}
+          fetch-depth: 0
 
-          for entry in "${packages[@]}"; do
-            IFS=: read -r package path <<< "$entry"
+      - name: Set up Erlang and Elixir
+        id: beam
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: mise.toml
+          version-type: strict
+
+      - name: Cache release dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            deps
+            _build
+            packages/*/deps
+            packages/*/_build
+          key: hex-release-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.exs') }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            hex-release-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.exs') }}-
+
+      - name: Install release tooling
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --check-locked
+
+      - name: Require noninteractive publishing key
+        run: |
+          if [[ -z "${HEX_API_KEY:-}" ]]; then
+            echo "::error::HEX_API_KEY is unset or empty."
+            exit 1
+          fi
+
+      # PackageCheck owns the public train and its topological order. A failed
+      # run is resumable: versions already visible on Hex are skipped.
+      - name: Publish packages in dependency order
+        run: |
+          set -euo pipefail
+
+          while IFS=$'\t' read -r package path; do
             pushd "$path" >/dev/null
 
             HEX_BUILD=1 mix deps.get
@@ -133,4 +184,11 @@ jobs:
             echo "::endgroup::"
 
             popd >/dev/null
-          done
+          done < <(
+            mix run --no-start -e '
+              Raxol.Release.PackageCheck.public_packages()
+              |> Enum.each(fn %{app: app, path: path} ->
+                IO.puts("RAXOL_PACKAGE\t#{app}\t#{path}")
+              end)
+            ' | sed -n 's/^RAXOL_PACKAGE\t//p'
+          )

--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -6,22 +6,16 @@ name: Release @raxol/cli npm package
 # their own runners, macOS arm64 on a macOS runner (native builds avoid the
 # termbox NIF cross-compile hazard -- see docker/Dockerfile.raxol-cli).
 #
-# The npm tarball is always produced as an artifact. The two ship paths are
-# independent: a `raxol-cli-v*` tag attaches the binaries + checksums to a
-# GitHub Release (stable public URLs for the T-Bench installer), while npm
-# publishing happens only on a manual run with `publish: true` and an
-# `NPM_TOKEN`.
+# Manual runs build downloadable tarballs only. A matching `raxol-cli-v*` tag
+# builds and smokes every native binary, waits for release-environment approval,
+# publishes the npm packages, then attaches the same binaries and checksums to a
+# GitHub Release.
 
 on:
   push:
     tags:
       - 'raxol-cli-v*'
   workflow_dispatch:
-    inputs:
-      publish:
-        description: 'Publish to npm (off = build the tarball artifact only)'
-        type: boolean
-        default: false
 
 concurrency:
   group: release-raxol-cli-${{ github.ref }}
@@ -31,8 +25,30 @@ permissions:
   contents: read
 
 jobs:
+  validate:
+    name: validate release ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Match package version to tag
+        if: startsWith(github.ref, 'refs/tags/raxol-cli-v')
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="$(node -p 'require("./packages/raxol_cli/npm/package.json").version')"
+          expected_tag="raxol-cli-v$version"
+
+          if [[ "$RELEASE_TAG" != "$expected_tag" ]]; then
+            echo "::error::$RELEASE_TAG does not match npm package version $version"
+            exit 1
+          fi
+
   linux-build:
     name: linux-${{ matrix.arch }}
+    needs: validate
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -86,6 +102,7 @@ jobs:
 
   macos-build:
     name: macos-arm64
+    needs: validate
     runs-on: macos-14
     steps:
       - name: Checkout
@@ -124,6 +141,7 @@ jobs:
 
   windows-build:
     name: windows-x86_64
+    needs: validate
     runs-on: windows-2022
     steps:
       - name: Checkout
@@ -208,24 +226,49 @@ jobs:
           path: packages/raxol_cli/npm/*.tgz
           if-no-files-found: error
 
-      # npm publish is deliberately NOT wired to the tag. A `raxol-cli-v*` tag
-      # ships the release binaries (see the `release` job); publishing the
-      # `@raxol/cli` wrapper is a separate, deliberate act. Publish with:
-      #   gh workflow run release-raxol-cli.yml -f publish=true
-      #
-      # Order matters: the platform packages go first. The wrapper pins them by
-      # exact version, so publishing it against a registry that does not yet
-      # have them leaves a window where `npm i -g @raxol/cli` resolves nothing.
+
+  # Publishing is a separate job so validation and native builds finish before
+  # the protected release environment asks for approval. npm CLI 11.5.1+ uses
+  # OIDC when trusted publishers are configured, then falls back to NPM_TOKEN
+  # during the migration. Provenance is emitted on either path.
+  publish:
+    name: publish npm packages
+    needs: package
+    if: startsWith(github.ref, 'refs/tags/raxol-cli-v')
+    environment: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Download built binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: cli-*
+          merge-multiple: true
+          path: packages/raxol_cli/burrito_out
+
+      - name: Build platform packages
+        run: packages/raxol_cli/npm/scripts/pack.sh
+
+      # Order matters: the wrapper pins every platform package exactly. A
+      # failed run is resumable because published versions are skipped.
       - name: Publish to npm
-        if: inputs.publish == true
         working-directory: packages/raxol_cli/npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
-
-          if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
-            echo "::error::publish=true but the NPM_TOKEN secret is unset or empty." >&2
-            exit 1
-          fi
 
           publish_package() {
             local directory="$1"
@@ -238,7 +281,7 @@ jobs:
             if npm view "$name@$version" version >/dev/null 2>&1; then
               echo "$name@$version is already published; skipping"
             else
-              (cd "$directory" && npm publish --access public)
+              (cd "$directory" && npm publish --provenance --access public)
             fi
           }
 
@@ -246,8 +289,6 @@ jobs:
             publish_package "$dir"
           done
           publish_package "."
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   # A `raxol-cli-v*` tag attaches the per-arch binaries to a GitHub Release, so
   # they have stable unauthenticated download URLs. Actions artifacts cannot
@@ -257,7 +298,7 @@ jobs:
   # which does not match `raxol-cli-v*`.
   release:
     name: attach release assets
-    needs: [linux-build, macos-build, windows-build]
+    needs: [linux-build, macos-build, windows-build, publish]
     if: startsWith(github.ref, 'refs/tags/raxol-cli-v')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release
 
-# Creates a GitHub Release with auto-generated notes when a version tag is
-# pushed. Hex publishing is a separate, explicitly confirmed workflow in
-# release-hex.yml; the raxol_earn sidecar has release-raxol-earn.yml, and the
-# web app deploys via docker/Dockerfile.web. There is no root binary release.
+# A root v* tag is the release authorization boundary. The reusable Hex
+# workflow validates the immutable tag, waits for release-environment approval,
+# and publishes the dependency-ordered train before the GitHub Release appears.
 
 permissions:
   contents: write
@@ -14,8 +13,17 @@ on:
       - "v*"
 
 jobs:
+  publish-hex:
+    name: Publish Hex packages
+    uses: ./.github/workflows/release-hex.yml
+    with:
+      release_ref: ${{ github.ref_name }}
+      publish: true
+    secrets: inherit
+
   release:
     name: Create GitHub Release
+    needs: publish-hex
     runs-on: ubuntu-latest
     steps:
       - name: Create GitHub Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -514,36 +514,35 @@ than degrading. `mix raxol.check` runs the metadata half with
 gate; CI runs without that flag, where an untracked packaged file means the
 tarball would carry content that is not in the repo.
 
-Publish order matters (dependency chain):
+Publishing is tag-authorized and resumable:
+
+- A `vMAJOR.MINOR.PATCH` tag runs `.github/workflows/release.yml`. It calls the
+  reusable Hex workflow with the immutable tag, verifies that the tag matches
+  the root package version, waits for approval in the `release` environment,
+  publishes `Raxol.Release.PackageCheck.public_packages/0` in dependency order,
+  and creates the GitHub Release only after Hex succeeds.
+- A `raxol-cli-vMAJOR.MINOR.PATCH` tag runs
+  `.github/workflows/release-raxol-cli.yml`. It verifies the npm manifest
+  version, builds and smokes every native binary, waits for the same environment
+  approval, publishes the platform packages and `@raxol/cli`, then attaches the
+  binaries and checksums to the GitHub Release. npm trusted publishing uses OIDC
+  and emits provenance; `NPM_TOKEN` remains a migration fallback only.
+- Re-running either publisher skips versions already visible in the registry.
+
+Validate a Hex tag without publishing:
 
 ```bash
-# 1. No raxol deps (parallel)
-cd packages/raxol_sensor && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-cd packages/raxol_core && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-
-# 2. Depend on raxol_core (parallel)
-cd packages/raxol_terminal && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-cd packages/raxol_mcp && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-cd packages/raxol_plugin && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-cd packages/raxol_liveview && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-cd packages/raxol_speech && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-cd packages/raxol_watch && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-
-# 3. Main (depends on all above)
-HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-
-# 4. Depend on main raxol (parallel)
-cd packages/raxol_agent && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-cd packages/raxol_telegram && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-
-# 5. Depends on raxol_agent
-cd packages/raxol_payments && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
-
-# 6. Depends on raxol_payments (raxol_earn, not yet published)
-# cd packages/raxol_earn && HEX_BUILD=1 mix deps.get && HEX_BUILD=1 mix hex.publish
+gh workflow run release-hex.yml \
+  -f release_ref=v2.7.0 \
+  -f publish=false
 ```
 
-`HEX_BUILD=1` strips `path:` and `override:` from deps so `mix hex.build` sees only Hex packages. Without it, local path deps are used for development.
+The same command with `publish=true` resumes a partially published train after
+`release` environment approval.
+
+`HEX_BUILD=1` strips `path:` and `override:` from deps so `mix hex.build` sees
+only Hex packages. The release workflow sets it per package; do not export it
+globally.
 
 ## Project notes
 

--- a/docs/development/RELEASE_CHECKLIST.md
+++ b/docs/development/RELEASE_CHECKLIST.md
@@ -1,223 +1,169 @@
 # Release checklist
 
-The ordered sequence for publishing a Raxol package to Hex. Written for someone
-who holds the Hex credentials and the wallet, and who has no other context on
-this repo.
+Release process for the public Hex train and the `@raxol/cli` npm package.
+Publishing is close to irreversible: a new Hex version has a one-hour update
+window, and an npm version cannot be reused.
 
-Everything here is copy-pasteable and runs from the repository root unless a
-step says otherwise. Steps marked **OPERATOR** need a credential, a live
-network, or a chain transaction, and cannot be automated or rehearsed offline.
+## Published surfaces
 
-Publishing is close to irreversible. A brand new package can be reverted within
-24 hours of its first publish; a new version of an existing package only within
-one hour (`mix hex.publish --revert VERSION`). After that the version is
-permanent. Read the whole of the section for the package you are publishing
-before you run anything.
+| Package | Registry | Current version |
+| --- | --- | --- |
+| `raxol` | Hex | 2.7.0 |
+| `raxol_core` | Hex | 2.7.0 |
+| `raxol_sensor` | Hex | 2.7.0 |
+| `raxol_terminal` | Hex | 2.7.0 |
+| `raxol_mcp` | Hex | 2.7.0 |
+| `raxol_liveview` | Hex | 2.7.0 |
+| `raxol_plugin` | Hex | 2.7.0 |
+| `raxol_agent` | Hex | 2.7.0 |
+| `raxol_speech` | Hex | 0.2.1 |
+| `raxol_watch` | Hex | 0.2.1 |
+| `raxol_payments` | Hex | 0.2.1 |
+| `raxol_telegram` | Hex | 0.2.1 |
+| `@raxol/cli` and four `@raxol/cli-*` binaries | npm | 0.2.7 |
 
-## What is published today
+The following projects remain outside the public Hex train:
+`raxol_agent_client_protocol`, `raxol_gateway`, `raxol_earn`,
+`raxol_symphony`, `raxol_cli`, and `raxol_console`. Package-specific gates for
+the candidates closest to publication remain below.
 
-Twelve packages are on Hex. Six are not. Verified against `mix.exs` in the tree
-and the Hex API, not against prose.
+## Authorization model
 
-| Package                        | In tree      | On Hex | State                                |
-| ------------------------------ | ------------ | ------ | ------------------------------------ |
-| `raxol`                        | 2.6.1        | 2.6.1  | published, current                   |
-| `raxol_core`                   | 2.6.0        | 2.6.0  | published, current                   |
-| `raxol_terminal`               | 2.6.1        | 2.6.1  | published, current                   |
-| `raxol_agent`                  | 2.6.0        | 2.6.0  | published, current                   |
-| `raxol_mcp`                    | 2.6.0        | 2.6.0  | published, current                   |
-| `raxol_liveview`               | 2.6.0        | 2.6.0  | published, current                   |
-| `raxol_plugin`                 | 2.6.0        | 2.6.0  | published, current                   |
-| `raxol_sensor`                 | 2.6.0        | 2.6.0  | published, current                   |
-| `raxol_payments`               | 0.2.0        | 0.2.0  | published, current                   |
-| `raxol_speech`                 | 0.2.0        | 0.1.0  | published, 0.2.0 pending             |
-| `raxol_telegram`               | 0.2.0        | 0.1.0  | published, 0.2.0 pending             |
-| `raxol_watch`                  | 0.2.0        | 0.1.0  | published, 0.2.0 pending             |
-| `raxol_gateway`                | 0.1.0        | none   | unpublished, ready                   |
-| `raxol_symphony`               | 0.2.0        | none   | unpublished, blocked on a live run   |
-| `raxol_earn`                   | 0.2.0        | none   | unpublished, blocked on Base mainnet |
-| `raxol_cli`                    | 0.2.6        | none   | unpublished, not scheduled           |
-| `raxol_console`                | 0.1.0        | none   | unpublished, not scheduled           |
-| `raxol_agent_client_protocol`  | 0.1.0-rc.0   | none   | unpublished, not scheduled           |
+The release commit and immutable version tag define what can ship. Registry
+jobs run only after approval in the protected GitHub `release` environment.
+That environment accepts the root `v*` tags, `raxol-cli-v*` tags, and approved
+manual resumes from `master`.
 
-Two version lines run in parallel: the framework packages on 2.6.x, and the
-payment and surface packages on independent 0.x lines. They are not released
-together, so a 0.x publish does not require touching the 2.6.x line.
+- Hex uses the repository `HEX_API_KEY`; keep it scoped to API write.
+- npm uses GitHub Actions OIDC trusted publishing and emits provenance.
+  `NPM_TOKEN` is a migration fallback and should be removed after all five npm
+  packages trust `release-raxol-cli.yml`.
+- Every publisher checks the registry first, so a failed train can resume
+  without trying to overwrite versions that already exist.
 
-## Publish order is a hard gate, not advice
+## Prepare the release commit
 
-Read this before you publish anything. Order is forced by inter-package
-requirements. Three of the packages below name a version of a sibling that Hex
-does not carry yet, so publishing out of order does not degrade gracefully: the
-publish aborts, because `HEX_BUILD=1 mix deps.get` cannot resolve the
-requirement.
-
-**The three blocking prerequisites.** `raxol_speech`, `raxol_telegram`, and
-`raxol_watch` are all 0.2.0 in this tree and 0.1.0 on Hex. Two packages
-graduating now declare them at `"~> 0.2"`:
-
-| Publishing        | Requires on Hex first                    | Declared in `mix.exs`                            | If you skip it                              |
-| ----------------- | ---------------------------------------- | ------------------------------------------------ | ------------------------------------------- |
-| `raxol_gateway`   | `raxol_speech` 0.2.0                     | `raxol_speech "~> 0.2"`, optional                | `HEX_BUILD=1 mix deps.get` cannot resolve   |
-| `raxol_symphony`  | `raxol_telegram` 0.2.0, `raxol_watch` 0.2.0 | both `"~> 0.2"`, optional                     | `HEX_BUILD=1 mix deps.get` cannot resolve   |
-
-Optional does not help here. An optional requirement still has to name a
-version that exists in the registry.
-
-**The order, top to bottom.** Do not reorder it.
-
-1. **`raxol_speech` 0.2.0**. Prerequisite for `raxol_gateway`. Requires only
-   `raxol_core "~> 2.6"`, already on Hex.
-2. **`raxol_watch` 0.2.0** and **`raxol_telegram` 0.2.0**. Prerequisites for
-   `raxol_symphony`. Independent of each other.
-3. **`raxol_gateway` 0.1.0**. Nothing external blocks it once step 1 is done.
-4. **`raxol_symphony` 0.2.0**, after step 2 and after its live run
-   (see [`raxol_symphony` 0.2.0](#raxol_symphony-020)).
-5. **`raxol_earn` 0.2.0**, after its Base mainnet offering
-   (see [`raxol_earn` 0.2.0](#raxol_earn-020)). Independent of the other four:
-   its only published requirements are `raxol_payments "~> 0.2"`,
-   `raxol_core "~> 2.6"`, and `raxol_mcp "~> 2.6"`, all already on Hex at
-   satisfying versions. It can go out at any point in this sequence.
-
-**Framework line.** The authoritative order for the 2.6.x packages is the
-`@public_packages` list in
-[`lib/raxol/release/package_check.ex`](../../lib/raxol/release/package_check.ex):
-`raxol_core`, `raxol_sensor`, `raxol_terminal`, `raxol_mcp`, `raxol_liveview`,
-`raxol_plugin`, `raxol_speech`, `raxol_watch`, `raxol`, `raxol_agent`,
-`raxol_payments`, `raxol_telegram`. `raxol_core` and `raxol_sensor` go first
-because they have no raxol requirements. Nothing on that line needs republishing
-for this release; every 2.6.x package in the tree matches what is on Hex.
-
-**One requirement is dropped rather than ordered.** `raxol_telegram` also
-declares `raxol_gateway`, but its `gateway_dep/0` returns `[]` under
-`HEX_BUILD`, so the requirement never reaches the tarball and `raxol_telegram`
-does not wait on `raxol_gateway`. That drop becomes unnecessary once
-`raxol_gateway` is on Hex; see [after publishing](#after-publishing).
-
-## Gates that must be green first
-
-Run these once, from the repository root, on the commit you intend to publish.
-
-```bash
-mix compile --warnings-as-errors
-mix format --check-formatted
-mix credo
-mix raxol.check_docs
-mix raxol.release.check --all
-SKIP_TERMBOX2_TESTS=true MIX_ENV=test mix test
-```
-
-`mix raxol.release.check --all` is the release-specific gate. It validates
-package metadata, confirms every file a tarball would ship is tracked by git,
-and builds each tarball with `HEX_BUILD=1 mix hex.build --unpack` to compare the
-generated `hex_metadata.config` against the source project config. It must be
-run on a clean tree: `mix hex.build` packages the working tree rather than the
-commit, so a green run on a dirty tree says nothing about what would ship. Do
-not pass `--allow-untracked` here, which is exactly the check it relaxes.
-
-Two warnings are expected and are not failures:
-
-- `raxol_agent` drops `raxol_agent_client_protocol` from its tarball.
-- `raxol_telegram` drops `raxol_gateway` from its tarball.
-
-Both are unpublished packages that cannot appear as a requirement in a public
-tarball. The second clears once `raxol_gateway` is on Hex.
-
-Never set `HEX_BUILD` in your shell. The release check refuses to run with an
-ambient `HEX_BUILD`, because it sets the variable per subprocess itself, and an
-ambient one makes the project config publish-shaped on both sides of its
-dependency audit, so the audit compares the tarball against itself and reports
-nothing.
-
-## Per-release bookkeeping
-
-For each package you are about to publish, in its directory:
-
-1. **Date the CHANGELOG entry.** An unreleased entry is headed
-   `## [X.Y.Z] - unreleased`. Replace `unreleased` with the publish date in
-   `YYYY-MM-DD`. This is deliberate: a dated heading for a version that was
-   never pushed is a false claim, so the date is written at publish time. If an
-   entry already carries a date from an earlier packaging pass and was never
-   published, that date is wrong too; replace it.
-2. **Tag the commit.** Tags are package-scoped, because the bare `vX.Y.Z` tags
-   belong to the root `raxol` version line. `v0.2.0` already exists there and
-   points at raxol from 2025. Six packages set `:source_ref` to
-   `<package>-v<version>` in their `docs` config and expect that tag:
-   `raxol_speech`, `raxol_telegram`, `raxol_watch`, `raxol_gateway`,
-   `raxol_earn`, `raxol_symphony`.
+1. Bump the package versions that are changing.
+2. Date each released package's changelog entry.
+3. Run the release gates from a clean tree:
 
    ```bash
-   git tag -a raxol_gateway-v0.1.0 -m "raxol_gateway 0.1.0"
-   git push origin raxol_gateway-v0.1.0
+   mix compile --warnings-as-errors
+   mix format --check-formatted
+   mix credo
+   mix raxol.check_docs
+   mix raxol.release.check
+   SKIP_TERMBOX2_TESTS=true MIX_ENV=test mix test
    ```
 
-   Tag before publishing. The published docs link every module back to this
-   tag, and a tag pushed afterwards leaves those links broken in between.
-
-   **Known defect, already shipped.** `raxol_payments` 0.2.0 was published with
-   `source_ref: "v0.2.0"`, so every source link in
-   `https://raxol-payments.hexdocs.pm/0.2.0` points at the root `raxol` v0.2.0
-   tag from 2025 instead of at the payments code. The version itself cannot be
-   changed, but Hex documentation has no update window, so the docs are
-   repairable: correct `:source_ref` in `packages/raxol_payments/mix.exs`, push
-   a `raxol_payments-v0.2.0` tag, then `HEX_BUILD=1 mix hex.publish docs`. It is
-   recorded here so nobody re-diagnoses it. The 2.6.x packages share the
-   pattern without the symptom: their bare tags (`v2.6.0`, `v2.6.1`) are real
-   commits on the same release line as the code they document.
-3. **Confirm the docs build.** `mix hex.publish` runs `mix docs` and uploads the
-   result, so a docs failure aborts a publish halfway:
+   `mix raxol.release.check` validates the public train, proves every packaged
+   file is tracked, runs each `HEX_BUILD=1 mix hex.build --unpack`, and compares
+   the generated package metadata with the source project configuration.
+4. Push package-scoped documentation tags for changed independent-version
+   packages. They must point at the release commit:
 
    ```bash
-   cd packages/<package>
-   HEX_BUILD=1 mix deps.get
-   HEX_BUILD=1 mix docs
+   git tag -a raxol_speech-v0.2.2 -m "raxol_speech 0.2.2"
+   git tag -a raxol_watch-v0.2.2 -m "raxol_watch 0.2.2"
+   git tag -a raxol_payments-v0.2.2 -m "raxol_payments 0.2.2"
+   git tag -a raxol_telegram-v0.2.2 -m "raxol_telegram 0.2.2"
+   git push origin raxol_speech-v0.2.2 raxol_watch-v0.2.2 \
+     raxol_payments-v0.2.2 raxol_telegram-v0.2.2
    ```
 
-## Publishing one package
+   Create only the tags for packages whose version changed. Framework packages
+   use the root `vMAJOR.MINOR.PATCH` source ref.
 
-**OPERATOR.** Authenticate once per machine with `mix hex.user auth`, or export
-`HEX_API_KEY`. Then, from the package directory:
+Never export `HEX_BUILD` globally. The release check and publisher set it only
+for package subprocesses; an ambient value strips root path dependencies before
+the checker can compare development and publish configurations.
 
-```bash
-cd packages/<package>
-HEX_BUILD=1 mix deps.get
-HEX_BUILD=1 mix hex.publish --dry-run
-HEX_BUILD=1 mix hex.publish
-```
+## Publish the public Hex train
 
-`HEX_BUILD=1` is required for every one of those commands. Each package's
-`mix.exs` resolves its sibling raxol dependencies as local `path:` deps by
-default; `HEX_BUILD=1` switches them to Hex requirements, which is what a
-consumer will actually resolve. Without it you publish a tarball whose
-requirements point at directories that exist only in this repo.
-
-Inspect what you are about to ship before the real publish:
+Create and push the root tag after the release commit is on `master`:
 
 ```bash
-HEX_BUILD=1 mix hex.build --unpack
+git tag -a v2.8.0 -m "Raxol 2.8.0"
+git push origin v2.8.0
 ```
 
-That writes the unpacked tarball next to the package and touches no network.
+`.github/workflows/release.yml` then:
+
+1. calls the reusable `release-hex.yml` preflight on the exact tag;
+2. verifies `v2.8.0` matches the root Mix project version;
+3. runs `mix raxol.release.check`;
+4. waits for `release` environment approval;
+5. publishes `Raxol.Release.PackageCheck.public_packages/0` in dependency
+   order, skipping versions already on Hex; and
+6. creates the GitHub Release only after publication succeeds.
+
+Validate or resume an existing tag manually:
+
+```bash
+gh workflow run release-hex.yml \
+  -f release_ref=v2.8.0 \
+  -f publish=false
+
+# Set publish=true only to resume a failed train. Approval is still required.
+```
+
+## Publish the npm CLI
+
+The npm version in `packages/raxol_cli/npm/package.json` and the CLI Mix project
+version must already agree. Create the matching tag:
+
+```bash
+git tag -a raxol-cli-v0.2.8 -m "raxol CLI 0.2.8"
+git push origin raxol-cli-v0.2.8
+```
+
+`.github/workflows/release-raxol-cli.yml` rejects a mismatched tag before doing
+native builds. It builds and smokes Linux x64, Linux arm64, macOS arm64, and
+Windows x64; assembles the npm tarballs; waits for `release` approval; publishes
+the four platform packages before `@raxol/cli`; and creates the CLI GitHub
+Release only after npm succeeds.
+
+A manual workflow run builds tarball artifacts but does not publish. Re-run a
+failed tag job to resume publication.
+
+## Registry verification
+
+After approval and completion:
+
+```bash
+mix hex.info raxol 2.8.0
+npm view @raxol/cli@0.2.8 version dist.integrity
+
+tmp="$(mktemp -d)"
+npm install --prefix "$tmp" @raxol/cli@0.2.8
+"$tmp/node_modules/.bin/raxol" --version
+
+install_dir="$(mktemp -d)"
+curl -fsSL https://raxol.io/install |
+  RAXOL_INSTALL_DIR="$install_dir" bash
+"$install_dir/raxol" --version
+```
+
+Check each Hex package on HexDocs and each npm platform package in the registry.
+The curl installer must report `checksum ok` before installing.
 
 ## Package-specific manual gates
 
-### `raxol_gateway` 0.1.0
+### `raxol_gateway` 0.1.1
 
-Nothing external blocks it. It needs `raxol_speech` 0.2.0 on Hex first (see
-[publish order is a hard gate](#publish-order-is-a-hard-gate-not-advice)), then
-the generic sequence above.
+Nothing external blocks it. `raxol_speech` 0.2.1 and the 2.7 framework line are
+already on Hex, so its registry requirements resolve.
 
-Metadata, license, changelog, docs entry point, and the tarball are all in
-place: `HEX_BUILD=1 mix hex.build` produces `raxol_gateway-0.1.0.tar` carrying
-`lib/`, `.formatter.exs`, `mix.exs`, `README.md`, `LICENSE.md`, and
-`CHANGELOG.md`.
+Metadata, license, changelog, docs entry point, and the tarball are in place:
+`HEX_BUILD=1 mix hex.build` produces `raxol_gateway-0.1.1.tar` carrying `lib/`,
+`.formatter.exs`, `mix.exs`, `README.md`, `LICENSE.md`, and `CHANGELOG.md`.
 
-Its only required dependencies are `raxol_core "~> 2.6"`, `telemetry`, and
+Its only required dependencies are `raxol_core "~> 2.7"`, `telemetry`, and
 `jason`. Everything else (`raxol`, `raxol_agent`, `raxol_speech`, `gen_smtp`,
 `mint_web_socket`, `req`) is optional and gated at runtime, so a consumer who
 wants only the Telegram or in-memory adapter pulls nothing extra.
 
-### `raxol_symphony` 0.2.0
+### `raxol_symphony` 0.2.1
 
 **OPERATOR.** Blocked on driving at least one real tracker issue to a pull
 request and capturing the evidence. The full procedure is
@@ -243,7 +189,7 @@ test suite covers all of it. What only a live run can pin is the tracker's real
 field names and phase encoding, and that a paused run resumes against a real
 repository rather than a fixture.
 
-### `raxol_earn` 0.2.0
+### `raxol_earn` 0.2.1
 
 **OPERATOR.** Blocked on a live offering on Base mainnet. The full procedure is
 [`packages/raxol_earn/RUNBOOK.md`](../../packages/raxol_earn/RUNBOOK.md), which
@@ -296,8 +242,7 @@ planes.
 
 Before publishing, confirm the version claims in
 `packages/raxol_earn/README.md` still agree with `mix.exs`: the status line
-should read `0.2.0` and the installation snippet `{:raxol_earn, "~> 0.2"}`.
-Both previously described a release candidate that was never cut.
+should read `0.2.1` and the installation snippet `{:raxol_earn, "~> 0.2"}`.
 
 ## After publishing
 


### PR DESCRIPTION
## Summary

- make a root `v*` tag run the validated Hex train before creating its GitHub Release
- make a matching `raxol-cli-v*` tag build, smoke, publish, and release the CLI
- require approval through the protected `release` GitHub Environment before either registry changes
- reject root and CLI tags that do not match their package versions
- publish npm through OIDC-compatible npm 11 with provenance, retaining `NPM_TOKEN` only as a migration fallback
- derive the Hex publish order from `Raxol.Release.PackageCheck` and keep both publishers resumable
- replace stale release instructions with the tag-authorized process

The repository environment is configured with `DROOdotFOO` as required reviewer and allows `v*`, `raxol-cli-v*`, and approved manual resumes from `master`.

## Manual testing

- [x] live installer is byte-identical to `scripts/install.sh`
- [x] latest and pinned macOS installs verify checksums and run `--version`, `help`, and `doctor`
- [x] missing release fails before creating an install directory
- [x] `raxol update --check` reports 0.2.7 current
- [x] installer failure tests: 2 passed
- [x] CLI/update tests: 34 passed
- [x] generated Hex order contains all 12 public packages in dependency order
- [x] root `v2.7.0` and CLI `raxol-cli-v0.2.7` parity checks pass
- [x] `actionlint` passes for all changed workflows
- [x] branch workflow-dispatch Hex preflight
- [x] four-platform CLI build, smoke, and npm tarball assembly
- [x] full CI

## npm trusted publisher setup

For `@raxol/cli` and each of its four platform packages, configure GitHub Actions trusted publishing with:

- owner: `DROOdotFOO`
- repository: `raxol`
- workflow: `release-raxol-cli.yml`
- environment: `release`
- allowed action: `npm publish`

After one OIDC release succeeds, revoke the bypass token and delete `NPM_TOKEN`.
