### PR TITLE
Prepare CLI 0.2.8 release

### DIFF
--- a/docs/development/RELEASE_CHECKLIST.md
+++ b/docs/development/RELEASE_CHECKLIST.md
@@ -20,7 +20,7 @@ window, and an npm version cannot be reused.
 | `raxol_watch` | Hex | 0.2.1 |
 | `raxol_payments` | Hex | 0.2.1 |
 | `raxol_telegram` | Hex | 0.2.1 |
-| `@raxol/cli` and four `@raxol/cli-*` binaries | npm | 0.2.7 |
+| `@raxol/cli` and four `@raxol/cli-*` binaries | npm | 0.2.8 |
 
 The following projects remain outside the public Hex train:
 `raxol_agent_client_protocol`, `raxol_gateway`, `raxol_earn`,

--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.7"
+  @version "0.2.8"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raxol/cli",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g @raxol/cli` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"
@@ -12,10 +12,10 @@
     "bin/"
   ],
   "optionalDependencies": {
-    "@raxol/cli-darwin-arm64": "0.2.7",
-    "@raxol/cli-linux-x64": "0.2.7",
-    "@raxol/cli-linux-arm64": "0.2.7",
-    "@raxol/cli-win32-x64": "0.2.7"
+    "@raxol/cli-darwin-arm64": "0.2.8",
+    "@raxol/cli-linux-x64": "0.2.8",
+    "@raxol/cli-linux-arm64": "0.2.8",
+    "@raxol/cli-win32-x64": "0.2.8"
   },
   "keywords": [
     "raxol",


### PR DESCRIPTION
## Summary

- bump the CLI Mix project and npm wrapper to 0.2.8
- pin all four native platform packages to 0.2.8
- record the prepared npm release in the release checklist

This patch release exercises the newly configured npm trusted-publisher path. The tag workflow will build and smoke all four native binaries before protected-environment approval and publication.

## Manual testing

- [x] CLI package tests: 34 passed
- [x] npm launcher tests: 2 passed
- [x] npm wrapper dry-run tarball contains only the expected four files
- [x] CLI Mix and npm versions match
- [x] full CI
