### PR TITLE
Remove npm publish token fallback

### DIFF
--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -229,8 +229,7 @@ jobs:
 
   # Publishing is a separate job so validation and native builds finish before
   # the protected release environment asks for approval. npm CLI 11.5.1+ uses
-  # OIDC when trusted publishers are configured, then falls back to NPM_TOKEN
-  # during the migration. Provenance is emitted on either path.
+  # the configured trusted publishers and emits provenance.
   publish:
     name: publish npm packages
     needs: package
@@ -265,8 +264,6 @@ jobs:
       # failed run is resumable because published versions are skipped.
       - name: Publish to npm
         working-directory: packages/raxol_cli/npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -285,8 +282,30 @@ jobs:
             fi
           }
 
+          wait_until_visible() {
+            local directory="$1"
+            local manifest="$directory/package.json"
+            local name
+            local version
+            name="$(node -p "require(require('node:path').resolve(process.argv[1])).name" "$manifest")"
+            version="$(node -p "require(require('node:path').resolve(process.argv[1])).version" "$manifest")"
+
+            for attempt in {1..60}; do
+              if npm view "$name@$version" version >/dev/null 2>&1; then
+                echo "$name@$version is visible in the registry"
+                return 0
+              fi
+              echo "Waiting for $name@$version to become visible ($attempt/60)"
+              sleep 5
+            done
+
+            echo "::error::$name@$version was published but is not visible after 5 minutes"
+            return 1
+          }
+
           for dir in platforms/*/; do
             publish_package "$dir"
+            wait_until_visible "$dir"
           done
           publish_package "."
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,8 +525,8 @@ Publishing is tag-authorized and resumable:
   `.github/workflows/release-raxol-cli.yml`. It verifies the npm manifest
   version, builds and smokes every native binary, waits for the same environment
   approval, publishes the platform packages and `@raxol/cli`, then attaches the
-  binaries and checksums to the GitHub Release. npm trusted publishing uses OIDC
-  and emits provenance; `NPM_TOKEN` remains a migration fallback only.
+  binaries and checksums to the GitHub Release. npm publishing uses OIDC-only
+  trusted publishing and emits provenance.
 - Re-running either publisher skips versions already visible in the registry.
 
 Validate a Hex tag without publishing:

--- a/docs/development/RELEASE_CHECKLIST.md
+++ b/docs/development/RELEASE_CHECKLIST.md
@@ -35,9 +35,8 @@ That environment accepts the root `v*` tags, `raxol-cli-v*` tags, and approved
 manual resumes from `master`.
 
 - Hex uses the repository `HEX_API_KEY`; keep it scoped to API write.
-- npm uses GitHub Actions OIDC trusted publishing and emits provenance.
-  `NPM_TOKEN` is a migration fallback and should be removed after all five npm
-  packages trust `release-raxol-cli.yml`.
+- npm uses OIDC-only GitHub Actions trusted publishing and emits provenance.
+  All five packages trust `release-raxol-cli.yml` with environment `release`.
 - Every publisher checks the registry first, so a failed train can resume
   without trying to overwrite versions that already exist.
 
@@ -120,8 +119,8 @@ git push origin raxol-cli-v0.2.8
 `.github/workflows/release-raxol-cli.yml` rejects a mismatched tag before doing
 native builds. It builds and smokes Linux x64, Linux arm64, macOS arm64, and
 Windows x64; assembles the npm tarballs; waits for `release` approval; publishes
-the four platform packages before `@raxol/cli`; and creates the CLI GitHub
-Release only after npm succeeds.
+each platform package and waits for registry visibility before publishing
+`@raxol/cli`; and creates the CLI GitHub Release only after npm succeeds.
 
 A manual workflow run builds tarball artifacts but does not publish. Re-run a
 failed tag job to resume publication.


### PR DESCRIPTION
## Summary

- remove `NPM_TOKEN` from the CLI publisher after the successful OIDC release
- make the workflow wait until every platform package is registry-visible before publishing the wrapper
- document the OIDC-only trust boundary

The visibility wait closes the brief install failure observed while npm was still processing two platform packages after accepting their publishes.

## Manual testing

- [x] `@raxol/cli` 0.2.8 published through the trusted workflow
- [x] all five packages expose SLSA provenance attestations
- [x] all five versions are visible in the npm registry
- [x] fresh macOS install runs `raxol 0.2.8+135f46f`
- [x] npm verifies signatures and attestations for both installed packages
- [x] `actionlint` passes
- [x] full CI
