### PR TITLE
Harden release publication paths

### DIFF
--- a/.github/workflows/release-hex.yml
+++ b/.github/workflows/release-hex.yml
@@ -113,6 +113,8 @@ jobs:
     if: inputs.publish == true
     environment: release
     runs-on: ubuntu-latest
+    outputs:
+      published_packages: ${{ steps.publish.outputs.published_packages }}
     env:
       MIX_ENV: dev
       RAXOL_DEV_PORT: "4000"
@@ -159,8 +161,10 @@ jobs:
       # PackageCheck owns the public train and its topological order. A failed
       # run is resumable: versions already visible on Hex are skipped.
       - name: Publish packages in dependency order
+        id: publish
         run: |
           set -euo pipefail
+          new_releases=()
 
           while IFS=$'\t' read -r package path; do
             pushd "$path" >/dev/null
@@ -181,6 +185,7 @@ jobs:
             HEX_BUILD=1 mix hex.publish --yes
             curl --fail --silent --show-error --output /dev/null \
               --retry 12 --retry-all-errors --retry-delay 5 "$release_url"
+            new_releases+=("$package@$version")
             echo "::endgroup::"
 
             popd >/dev/null
@@ -191,4 +196,126 @@ jobs:
                 IO.puts("RAXOL_PACKAGE\t#{app}\t#{path}")
               end)
             ' | sed -n 's/^RAXOL_PACKAGE\t//p'
+          )
+
+          (
+            IFS=,
+            echo "published_packages=${new_releases[*]}" >> "$GITHUB_OUTPUT"
+          )
+
+  verify:
+    name: Verify public Hex release
+    needs: publish
+    if: inputs.publish == true
+    runs-on: ubuntu-latest
+    env:
+      MIX_ENV: dev
+      RAXOL_DEV_PORT: "4000"
+      PUBLISHED_PACKAGES: ${{ needs.publish.outputs.published_packages }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.release_ref }}
+          fetch-depth: 0
+
+      - name: Set up Erlang and Elixir
+        id: beam
+        uses: erlef/setup-beam@v1
+        with:
+          version-file: mise.toml
+          version-type: strict
+
+      - name: Cache release dependencies
+        uses: actions/cache@v6
+        with:
+          path: |
+            deps
+            _build
+            packages/*/deps
+            packages/*/_build
+          key: hex-release-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.exs') }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            hex-release-${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-${{ hashFiles('**/mix.exs') }}-
+
+      - name: Install release tooling
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --check-locked
+
+      - name: Verify registry and documentation
+        run: |
+          set -euo pipefail
+
+          while IFS=$'\t' read -r package path; do
+            pushd "$path" >/dev/null
+            version="$(HEX_BUILD=1 mix run --no-start --no-compile --no-deps-check \
+              -e 'IO.write(Mix.Project.config()[:version])')"
+            popd >/dev/null
+
+            curl --fail --silent --show-error --output /dev/null \
+              "https://hex.pm/api/packages/$package/releases/$version"
+            echo "$package $version is visible on Hex"
+          done < <(
+            mix run --no-start -e '
+              Raxol.Release.PackageCheck.public_packages()
+              |> Enum.each(fn %{app: app, path: path} ->
+                IO.puts("RAXOL_PACKAGE\t#{app}\t#{path}")
+              end)
+            ' | sed -n 's/^RAXOL_PACKAGE\t//p'
+          )
+
+          if [[ -n "$PUBLISHED_PACKAGES" ]]; then
+            IFS=',' read -ra releases <<< "$PUBLISHED_PACKAGES"
+            for release in "${releases[@]}"; do
+              package="${release%@*}"
+              version="${release#*@}"
+              docs_url="https://hexdocs.pm/$package/$version/"
+
+              for attempt in {1..60}; do
+                if curl --fail --silent --output /dev/null "$docs_url"; then
+                  echo "$package $version documentation is visible"
+                  break
+                fi
+                if [[ "$attempt" == "60" ]]; then
+                  echo "::error::$package $version documentation is unavailable after 10 minutes"
+                  exit 1
+                fi
+                echo "Waiting for $package $version documentation ($attempt/60)"
+                sleep 10
+              done
+            done
+          fi
+
+      - name: Compile a fresh Hex consumer
+        run: |
+          set -euo pipefail
+          version="$(mix run --no-start --no-compile --no-deps-check \
+            -e 'IO.write(Mix.Project.config()[:version])')"
+          consumer="$(mktemp -d)"
+          trap 'rm -rf "$consumer"' EXIT
+
+          cat > "$consumer/mix.exs" <<EOF
+          defmodule RaxolReleaseConsumer.MixProject do
+            use Mix.Project
+            def project do
+              [
+                app: :raxol_release_consumer,
+                version: "0.0.0",
+                elixir: "~> 1.17",
+                deps: [{:raxol, "== $version"}]
+              ]
+            end
+            def application, do: [extra_applications: [:logger]]
+          end
+          EOF
+
+          (
+            cd "$consumer"
+            MIX_HOME="$consumer/.mix" HEX_HOME="$consumer/.hex" mix local.hex --force
+            MIX_HOME="$consumer/.mix" HEX_HOME="$consumer/.hex" mix local.rebar --force
+            MIX_HOME="$consumer/.mix" HEX_HOME="$consumer/.hex" mix deps.get
+            MIX_HOME="$consumer/.mix" HEX_HOME="$consumer/.hex" \
+              mix compile --warnings-as-errors
           )

--- a/.github/workflows/release-hex.yml
+++ b/.github/workflows/release-hex.yml
@@ -113,8 +113,6 @@ jobs:
     if: inputs.publish == true
     environment: release
     runs-on: ubuntu-latest
-    outputs:
-      published_packages: ${{ steps.publish.outputs.published_packages }}
     env:
       MIX_ENV: dev
       RAXOL_DEV_PORT: "4000"
@@ -164,7 +162,6 @@ jobs:
         id: publish
         run: |
           set -euo pipefail
-          new_releases=()
 
           while IFS=$'\t' read -r package path; do
             pushd "$path" >/dev/null
@@ -185,7 +182,6 @@ jobs:
             HEX_BUILD=1 mix hex.publish --yes
             curl --fail --silent --show-error --output /dev/null \
               --retry 12 --retry-all-errors --retry-delay 5 "$release_url"
-            new_releases+=("$package@$version")
             echo "::endgroup::"
 
             popd >/dev/null
@@ -198,11 +194,6 @@ jobs:
             ' | sed -n 's/^RAXOL_PACKAGE\t//p'
           )
 
-          (
-            IFS=,
-            echo "published_packages=${new_releases[*]}" >> "$GITHUB_OUTPUT"
-          )
-
   verify:
     name: Verify public Hex release
     needs: publish
@@ -211,7 +202,6 @@ jobs:
     env:
       MIX_ENV: dev
       RAXOL_DEV_PORT: "4000"
-      PUBLISHED_PACKAGES: ${{ needs.publish.outputs.published_packages }}
     steps:
       - name: Checkout release tag
         uses: actions/checkout@v7
@@ -257,6 +247,20 @@ jobs:
             curl --fail --silent --show-error --output /dev/null \
               "https://hex.pm/api/packages/$package/releases/$version"
             echo "$package $version is visible on Hex"
+
+            docs_url="https://hexdocs.pm/$package/$version/"
+            for attempt in {1..60}; do
+              if curl --fail --silent --output /dev/null "$docs_url"; then
+                echo "$package $version documentation is visible"
+                break
+              fi
+              if [[ "$attempt" == "60" ]]; then
+                echo "::error::$package $version documentation is unavailable after 10 minutes"
+                exit 1
+              fi
+              echo "Waiting for $package $version documentation ($attempt/60)"
+              sleep 10
+            done
           done < <(
             mix run --no-start -e '
               Raxol.Release.PackageCheck.public_packages()
@@ -265,28 +269,6 @@ jobs:
               end)
             ' | sed -n 's/^RAXOL_PACKAGE\t//p'
           )
-
-          if [[ -n "$PUBLISHED_PACKAGES" ]]; then
-            IFS=',' read -ra releases <<< "$PUBLISHED_PACKAGES"
-            for release in "${releases[@]}"; do
-              package="${release%@*}"
-              version="${release#*@}"
-              docs_url="https://hexdocs.pm/$package/$version/"
-
-              for attempt in {1..60}; do
-                if curl --fail --silent --output /dev/null "$docs_url"; then
-                  echo "$package $version documentation is visible"
-                  break
-                fi
-                if [[ "$attempt" == "60" ]]; then
-                  echo "::error::$package $version documentation is unavailable after 10 minutes"
-                  exit 1
-                fi
-                echo "Waiting for $package $version documentation ($attempt/60)"
-                sleep 10
-              done
-            done
-          fi
 
       - name: Compile a fresh Hex consumer
         run: |

--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -8,8 +8,8 @@ name: Release @raxol/cli npm package
 #
 # Manual runs build downloadable tarballs only. A matching `raxol-cli-v*` tag
 # builds and smokes every native binary, waits for release-environment approval,
-# publishes the npm packages, then attaches the same binaries and checksums to a
-# GitHub Release.
+# publishes the npm packages, proves a fresh registry install, attests the
+# binaries, then publishes immutable release assets and the latest manifest.
 
 on:
   push:
@@ -308,21 +308,62 @@ jobs:
             wait_until_visible "$dir"
           done
           publish_package "."
+          wait_until_visible "."
 
-  # A `raxol-cli-v*` tag attaches the per-arch binaries to a GitHub Release, so
-  # they have stable unauthenticated download URLs. Actions artifacts cannot
-  # serve this: they need a token to fetch and expire after 90 days, and the
-  # T-Bench install script curls them from inside an arbitrary task container.
-  # The root `release.yml` does not cover these tags -- its filter is `v*`,
-  # which does not match `raxol-cli-v*`.
+          version="$(node -p 'require("./package.json").version')"
+          packages=(
+            "@raxol/cli"
+            "@raxol/cli-darwin-arm64"
+            "@raxol/cli-linux-x64"
+            "@raxol/cli-linux-arm64"
+            "@raxol/cli-win32-x64"
+          )
+
+          for package in "${packages[@]}"; do
+            published_version="$(npm view "$package@$version" version)"
+            [[ "$published_version" == "$version" ]] || {
+              echo "::error::$package resolved $published_version instead of $version"
+              exit 1
+            }
+
+            predicate="$(npm view "$package@$version" dist.attestations.provenance.predicateType)"
+            [[ "$predicate" == "https://slsa.dev/provenance/v1" ]] || {
+              echo "::error::$package@$version has no SLSA provenance"
+              exit 1
+            }
+          done
+
+          smoke="$(mktemp -d)"
+          cache="$(mktemp -d)"
+          trap 'rm -rf "$smoke" "$cache"' EXIT
+          printf '{"private":true}\n' > "$smoke/package.json"
+          npm install --prefix "$smoke" --cache "$cache" --include=optional \
+            --prefer-online --no-audit --no-fund "@raxol/cli@$version"
+
+          installed_version="$("$smoke/node_modules/.bin/raxol" --version)"
+          [[ "$installed_version" == "raxol $version+"* ]] || {
+            echo "::error::fresh install reported $installed_version"
+            exit 1
+          }
+
+          (cd "$smoke" && npm audit signatures)
+
+  # Versioned release assets have stable unauthenticated URLs. Actions
+  # artifacts cannot serve installers because they require a token and expire.
+  # The root release workflow does not match the `raxol-cli-v*` tag family.
   release:
-    name: attach release assets
+    name: attach attested release assets
     needs: [linux-build, macos-build, windows-build, publish]
     if: startsWith(github.ref, 'refs/tags/raxol-cli-v')
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       contents: write
+      id-token: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Download built binaries
         uses: actions/download-artifact@v4
         with:
@@ -337,12 +378,83 @@ jobs:
           sha256sum raxol_cli_* > SHA256SUMS
           cat SHA256SUMS
 
-      - name: Create release
+      - name: Attest release binaries
+        id: attest
+        uses: actions/attest@v4
+        with:
+          subject-checksums: dist/SHA256SUMS
+
+      - name: Save and verify attestation bundle
+        env:
+          ATTESTATION_BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cp "$ATTESTATION_BUNDLE" dist/raxol-cli-attestation.sigstore.json
+
+          for binary in dist/raxol_cli_*; do
+            gh attestation verify "$binary" \
+              --bundle dist/raxol-cli-attestation.sigstore.json \
+              --repo "$GITHUB_REPOSITORY" \
+              --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/release-raxol-cli.yml" \
+              --source-ref "$GITHUB_REF" \
+              --deny-self-hosted-runners
+          done
+
+      - name: Build release manifest
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="${RELEASE_TAG#raxol-cli-v}"
+          RAXOL_RELEASED_AT="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+            node scripts/build_cli_release_manifest.mjs \
+              "$version" dist/SHA256SUMS dist/raxol-cli-manifest.json
+          node -e 'JSON.parse(require("node:fs").readFileSync(process.argv[1]))' \
+            dist/raxol-cli-manifest.json
+
+      - name: Create immutable release
         uses: softprops/action-gh-release@v3
         with:
           generate_release_notes: true
           files: |
             dist/raxol_cli_*
             dist/SHA256SUMS
+            dist/raxol-cli-attestation.sigstore.json
+            dist/raxol-cli-manifest.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  channel:
+    name: update latest CLI manifest
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/raxol-cli-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish latest manifest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          mkdir channel
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --pattern raxol-cli-manifest.json \
+            --dir channel
+          mv channel/raxol-cli-manifest.json channel/latest.json
+
+          if ! gh release view raxol-cli-channel --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh release create raxol-cli-channel \
+              --repo "$GITHUB_REPOSITORY" \
+              --target "$GITHUB_SHA" \
+              --title "Raxol CLI release channel" \
+              --notes "Mutable latest-release metadata. Versioned assets remain immutable." \
+              --prerelease
+          fi
+
+          gh release upload raxol-cli-channel channel/latest.json \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber

--- a/docs/development/RELEASE_CHECKLIST.md
+++ b/docs/development/RELEASE_CHECKLIST.md
@@ -20,7 +20,7 @@ window, and an npm version cannot be reused.
 | `raxol_watch` | Hex | 0.2.1 |
 | `raxol_payments` | Hex | 0.2.1 |
 | `raxol_telegram` | Hex | 0.2.1 |
-| `@raxol/cli` and four `@raxol/cli-*` binaries | npm | 0.2.8 |
+| `@raxol/cli` and four `@raxol/cli-*` binaries | npm | 0.2.9 |
 
 The following projects remain outside the public Hex train:
 `raxol_agent_client_protocol`, `raxol_gateway`, `raxol_earn`,
@@ -39,6 +39,12 @@ manual resumes from `master`.
   All five packages trust `release-raxol-cli.yml` with environment `release`.
 - Every publisher checks the registry first, so a failed train can resume
   without trying to overwrite versions that already exist.
+
+The active `Immutable release tags` repository ruleset blocks updates and
+deletions for `v*` and `raxol-cli-v*` tags, with no bypass actor. It deliberately
+does not block creation. Emergency recovery requires temporarily disabling the
+ruleset in repository settings, performing the audited repair, and immediately
+reactivating it. Never move a published version tag as routine recovery.
 
 ## Prepare the release commit
 
@@ -93,8 +99,10 @@ git push origin v2.8.0
 3. runs `mix raxol.release.check`;
 4. waits for `release` environment approval;
 5. publishes `Raxol.Release.PackageCheck.public_packages/0` in dependency
-   order, skipping versions already on Hex; and
-6. creates the GitHub Release only after publication succeeds.
+   order, skipping versions already on Hex;
+6. verifies every package through the public Hex API, waits for newly published
+   HexDocs, and compiles a clean consumer against the released root package; and
+7. creates the GitHub Release only after consumer verification succeeds.
 
 Validate or resume an existing tag manually:
 
@@ -112,18 +120,21 @@ The npm version in `packages/raxol_cli/npm/package.json` and the CLI Mix project
 version must already agree. Create the matching tag:
 
 ```bash
-git tag -a raxol-cli-v0.2.8 -m "raxol CLI 0.2.8"
-git push origin raxol-cli-v0.2.8
+git tag -a raxol-cli-v0.2.9 -m "raxol CLI 0.2.9"
+git push origin raxol-cli-v0.2.9
 ```
 
 `.github/workflows/release-raxol-cli.yml` rejects a mismatched tag before doing
 native builds. It builds and smokes Linux x64, Linux arm64, macOS arm64, and
 Windows x64; assembles the npm tarballs; waits for `release` approval; publishes
-each platform package and waits for registry visibility before publishing
-`@raxol/cli`; and creates the CLI GitHub Release only after npm succeeds.
+the four platform packages and wrapper; and then proves a fresh, isolated npm
+install with signature auditing. The workflow attests the four binaries, uploads
+the checksums, Sigstore bundle, and release manifest to the immutable GitHub
+Release, then updates the separate `raxol-cli-channel` manifest.
 
 A manual workflow run builds tarball artifacts but does not publish. Re-run a
-failed tag job to resume publication.
+failed tag job to resume publication; already-published npm versions are skipped
+but the registry smoke still runs.
 
 ## Registry verification
 
@@ -131,20 +142,35 @@ After approval and completion:
 
 ```bash
 mix hex.info raxol 2.8.0
-npm view @raxol/cli@0.2.8 version dist.integrity
+npm view @raxol/cli@0.2.9 version dist.integrity
 
 tmp="$(mktemp -d)"
-npm install --prefix "$tmp" @raxol/cli@0.2.8
+npm install --prefix "$tmp" @raxol/cli@0.2.9
 "$tmp/node_modules/.bin/raxol" --version
+(cd "$tmp" && npm audit signatures)
+
+curl -fsSL https://raxol.io/releases/latest.json
 
 install_dir="$(mktemp -d)"
 curl -fsSL https://raxol.io/install |
   RAXOL_INSTALL_DIR="$install_dir" bash
 "$install_dir/raxol" --version
+
+verified_dir="$(mktemp -d)"
+curl -fsSL https://raxol.io/install |
+  RAXOL_INSTALL_DIR="$verified_dir" \
+  RAXOL_VERIFY_PROVENANCE=1 bash
+"$verified_dir/raxol" --version
 ```
 
-Check each Hex package on HexDocs and each npm platform package in the registry.
-The curl installer must report `checksum ok` before installing.
+The default installer always checks SHA-256. Provenance mode additionally
+requires `gh` and verifies the GitHub repository, release workflow, exact tag
+ref, OIDC issuer, and hosted runner before installation.
+
+To roll latest discovery back without changing a version tag, download
+`raxol-cli-manifest.json` from the prior immutable release, rename it
+`latest.json`, and upload it to `raxol-cli-channel` with `gh release upload
+raxol-cli-channel latest.json --clobber`.
 
 ## Package-specific manual gates
 

--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.8"
+  @version "0.2.9"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/README.md
+++ b/packages/raxol_cli/npm/README.md
@@ -20,6 +20,13 @@ curl -fsSL https://raxol.io/install | bash
 brew install droodotfoo/tap/raxol
 ```
 
+To require GitHub Actions provenance as well as the mandatory SHA-256 check,
+install the GitHub CLI first, then run:
+
+```bash
+curl -fsSL https://raxol.io/install | bash -s -- --verify-provenance
+```
+
 ## Connecting a provider
 
 Without a provider the agent replies with mock output. Connect one:

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raxol/cli",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g @raxol/cli` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"
@@ -12,10 +12,10 @@
     "bin/"
   ],
   "optionalDependencies": {
-    "@raxol/cli-darwin-arm64": "0.2.8",
-    "@raxol/cli-linux-x64": "0.2.8",
-    "@raxol/cli-linux-arm64": "0.2.8",
-    "@raxol/cli-win32-x64": "0.2.8"
+    "@raxol/cli-darwin-arm64": "0.2.9",
+    "@raxol/cli-linux-x64": "0.2.9",
+    "@raxol/cli-linux-arm64": "0.2.9",
+    "@raxol/cli-win32-x64": "0.2.9"
   },
   "keywords": [
     "raxol",

--- a/packages/raxol_mcp/test/raxol/mcp/property/functor_laws_test.exs
+++ b/packages/raxol_mcp/test/raxol/mcp/property/functor_laws_test.exs
@@ -81,9 +81,8 @@ defmodule Raxol.MCP.Property.FunctorLawsTest do
     end
   end
 
-  defp button_gen do
+  defp button_gen(id) do
     gen all(
-          id <- widget_id_gen(),
           label <- string(:printable, min_length: 1, max_length: 20),
           disabled <- boolean()
         ) do
@@ -91,20 +90,30 @@ defmodule Raxol.MCP.Property.FunctorLawsTest do
     end
   end
 
-  defp input_gen do
-    gen all(
-          id <- widget_id_gen(),
-          value <- string(:printable, max_length: 30)
-        ) do
+  defp input_gen(id) do
+    gen all(value <- string(:printable, max_length: 30)) do
       %{type: :text_input, id: id, attrs: %{value: value}, children: []}
     end
   end
 
-  defp widget_gen do
+  defp widget_gen(id) do
     frequency([
-      {3, button_gen()},
-      {2, input_gen()}
+      {3, button_gen(id)},
+      {2, input_gen(id)}
     ])
+  end
+
+  defp widget_list_gen(min_length, max_length) do
+    gen all(
+          ids <-
+            uniq_list_of(widget_id_gen(),
+              min_length: min_length,
+              max_length: max_length
+            ),
+          widgets <- fixed_list(Enum.map(ids, &widget_gen/1))
+        ) do
+      widgets
+    end
   end
 
   defp container_type_gen do
@@ -112,7 +121,7 @@ defmodule Raxol.MCP.Property.FunctorLawsTest do
   end
 
   defp flat_tree_gen do
-    gen all(widgets <- list_of(widget_gen(), min_length: 1, max_length: 6)) do
+    gen all(widgets <- widget_list_gen(1, 6)) do
       %{type: :column, children: widgets}
     end
   end
@@ -282,7 +291,7 @@ defmodule Raxol.MCP.Property.FunctorLawsTest do
 
     property "removing a widget removes exactly its tools" do
       check all(
-              widgets <- list_of(widget_gen(), min_length: 2, max_length: 6),
+              widgets <- widget_list_gen(2, 6),
               max_runs: 300
             ) do
         tree = %{type: :column, children: widgets}
@@ -299,15 +308,9 @@ defmodule Raxol.MCP.Property.FunctorLawsTest do
           |> Enum.map(& &1.name)
           |> MapSet.new()
 
-        # The removed tools should not be in the reduced set
-        # (unless another widget has the same ID, which is possible with generated IDs)
-        remaining_ids = MapSet.new(remaining, & &1[:id])
-
-        if removed[:id] not in remaining_ids do
-          for tool_name <- removed_widget_tools do
-            refute MapSet.member?(reduced_tools, tool_name),
-                   "Tool '#{tool_name}' from removed widget still present"
-          end
+        for tool_name <- removed_widget_tools do
+          refute MapSet.member?(reduced_tools, tool_name),
+                 "Tool '#{tool_name}' from removed widget still present"
         end
 
         # Remaining tools should still be present
@@ -322,7 +325,7 @@ defmodule Raxol.MCP.Property.FunctorLawsTest do
   describe "determinism" do
     property "reordering children produces same tool set (as a set)" do
       check all(
-              widgets <- list_of(widget_gen(), min_length: 2, max_length: 6),
+              widgets <- widget_list_gen(2, 6),
               max_runs: 300
             ) do
         tree = %{type: :column, children: widgets}
@@ -338,7 +341,7 @@ defmodule Raxol.MCP.Property.FunctorLawsTest do
 
     property "tool count equals sum of per-widget tool counts" do
       check all(
-              widgets <- list_of(widget_gen(), min_length: 1, max_length: 6),
+              widgets <- widget_list_gen(1, 6),
               max_runs: 300
             ) do
         tree = %{type: :column, children: widgets}

--- a/plans/release-hardening.md
+++ b/plans/release-hardening.md
@@ -1,0 +1,247 @@
+# Release Hardening Implementation Plan
+
+**Source:** Release follow-up after the first OIDC-published `@raxol/cli` release
+**Goal:** Make npm, GitHub Release, Hex, and `curl | bash` releases verifiable, resumable, and independent of unauthenticated GitHub API discovery.
+
+## Context
+
+`@raxol/cli` 0.2.8 proved the end-to-end OIDC publication path and exposed one remaining race: npm accepted packages before they were query-visible. The workflow now waits for platform packages, but it still creates the GitHub Release without proving that a fresh consumer can install and verify the wrapper package. GitHub release tags are also mutable because the repository has no tag ruleset.
+
+The Hex workflow has complete preflight and resumable publishing logic, but it has not yet performed a real automated publication. The shell installer verifies SHA-256 checksums but discovers the latest version through the unauthenticated GitHub Releases API and has no provenance-verification mode.
+
+## Architectural Decisions
+
+1. **Registry state is the release gate.** A CLI GitHub Release is created only after all five npm packages are query-visible and a fresh isolated install of the wrapper succeeds.
+2. **Version tags are immutable.** One active GitHub tag ruleset covers `refs/tags/v*` and `refs/tags/raxol-cli-v*`, blocks update and deletion, permits creation, and has no bypass actors. Emergency recovery changes the audited ruleset; it never silently moves a published version tag.
+3. **Release approval stays solo-maintainer friendly.** The protected `release` environment continues to allow DROOdotFOO to approve their own deployment.
+4. **GitHub artifact attestations are the provenance format.** CLI binaries receive SLSA provenance through `actions/attest@v4`, bound to the release workflow and exact tag ref.
+5. **Checksums remain the default installer trust contract.** The dependency-free install path continues to fail closed on a missing or invalid SHA-256 checksum. Provenance verification is explicit through `--verify-provenance`; that mode requires `gh` and fails closed if verification cannot complete.
+6. **Latest release discovery uses a cached channel manifest, not the GitHub API.** Each immutable CLI release carries its own manifest. A dedicated `raxol-cli-channel` prerelease carries the mutable `latest.json` pointer, updated only after the immutable release and registry smoke pass. `https://raxol.io/releases/latest.json` fetches that fixed asset URL, serves validated JSON with a short shared-cache TTL and stale-on-error window, and therefore needs no web deployment for each CLI release.
+7. **The channel tag is intentionally mutable infrastructure.** It is excluded from the immutable version-tag ruleset. Rollback replaces only the channel manifest with a previously published immutable manifest; binaries and version tags never move.
+8. **Hex publication waits for product value.** The first live automated Hex run ships the next substantive release rather than consuming 2.7.1 solely as an automation canary.
+9. **Registry credentials do not expand.** npm remains OIDC-only. Hex continues to use the API-write-scoped `HEX_API_KEY` behind the protected environment.
+
+## Phase 1: Close the npm Registry Loop
+
+**Classification:** AFK
+
+### What to Build
+
+Extend `.github/workflows/release-raxol-cli.yml` with a post-publication registry smoke gate:
+
+- Wait for `@raxol/cli@<version>` itself to become query-visible after the four platform packages.
+- Install the exact wrapper version using a new temporary prefix and npm cache with online registry resolution forced.
+- Execute the installed `raxol --version` and require the released semantic version.
+- Run `npm audit signatures` with attestation checks against the isolated install.
+- Query every platform package and the wrapper for the expected version and npm provenance metadata.
+- Make GitHub Release creation depend on this gate. A resumed tag run must skip already-published versions and still repeat the consumer smoke.
+
+### User-Visible Outcome
+
+A successful CLI release run proves that a clean npm consumer can install and execute the just-published version before GitHub advertises the release.
+
+### Acceptance Criteria
+
+- [ ] A tag run cannot enter the GitHub Release job until all five exact npm versions are query-visible.
+- [ ] The smoke uses an empty prefix and cache, installs `@raxol/cli@<version>`, and executes the installed Linux x64 binary successfully.
+- [ ] `npm audit signatures` succeeds and all five packuments expose SLSA provenance.
+- [ ] Re-running the same tag skips immutable npm versions but repeats and passes the registry smoke.
+- [ ] Manual workflow dispatch remains build-only and never publishes.
+
+## Phase 2: Make Release Tags Immutable
+
+**Classification:** HITL - repository security policy
+
+### What to Build
+
+Create an active repository ruleset named `Immutable release tags` through the GitHub rulesets API:
+
+- Target tags matching `refs/tags/v*` and `refs/tags/raxol-cli-v*`.
+- Add update and deletion restrictions.
+- Do not add a creation restriction; maintainers must still be able to create a new release tag.
+- Do not add bypass actors. Keep `raxol-cli-channel` outside the include patterns.
+- Record the exact configuration and emergency-disable procedure in `docs/development/RELEASE_CHECKLIST.md`.
+
+GitHub Enterprise-only evaluate mode is not assumed. Validate the request payload before activation, then verify the active configuration through the API without attempting to mutate an existing release tag.
+
+### User-Visible Outcome
+
+Published release identities cannot be retargeted or deleted during normal repository operations.
+
+### Acceptance Criteria
+
+- [ ] The repository exposes one active tag ruleset with the two intended include patterns.
+- [ ] The ruleset contains update and deletion restrictions, no creation restriction, and no bypass actor.
+- [ ] Existing `v*` and `raxol-cli-v*` tags remain unchanged.
+- [ ] `raxol-cli-channel` is not matched by the ruleset.
+- [ ] The protected `release` environment still requires approval and permits self-approval.
+
+## Phase 3: Attest Every CLI Binary
+
+**Classification:** HITL - supply-chain security boundary
+
+### What to Build
+
+Add GitHub artifact attestations to the immutable CLI release job:
+
+- Grant only `id-token: write`, `attestations: write`, and the existing minimal contents permission to the job that assembles final release assets.
+- Generate `SHA256SUMS` first, then use `actions/attest@v4` with that checksum file as the four-binary subject set.
+- Upload the generated Sigstore bundle beside the binaries and checksums in the immutable GitHub Release.
+- Verify the bundle in the workflow before publishing assets, requiring the `DROOdotFOO/raxol` repository, `.github/workflows/release-raxol-cli.yml` signer workflow, exact `refs/tags/raxol-cli-v<version>` source ref, GitHub OIDC issuer, and GitHub-hosted runner.
+- Add the exact consumer verification command to the release checklist.
+
+### User-Visible Outcome
+
+A consumer can download a released binary and its bundle, then prove which workflow and tag produced that exact digest.
+
+### Acceptance Criteria
+
+- [ ] Every released CLI binary digest is present in a SLSA provenance attestation.
+- [ ] The immutable GitHub Release includes the attestation bundle, `SHA256SUMS`, and all four binaries.
+- [ ] `gh attestation verify` succeeds with the repository, signer workflow, source ref, and hosted-runner constraints.
+- [ ] Verification fails when run against a modified copy of a released binary.
+- [ ] No long-lived signing key or new repository secret is introduced.
+
+## Phase 4: Publish a Stable Release Manifest
+
+**Classification:** AFK after the one-time channel release exists
+
+### What to Build
+
+Define a versioned JSON manifest contract and publish it from the CLI release workflow after registry smoke and attestation verification.
+
+Manifest version 1 contains:
+
+- `schema_version`, CLI `version`, immutable `tag`, release timestamp, repository, and signer workflow.
+- One entry per supported platform with asset name, immutable download URL, SHA-256 digest, and attestation bundle URL.
+
+For every release:
+
+1. Generate and validate the manifest from the built assets and `SHA256SUMS`.
+2. Attach it as `raxol-cli-manifest.json` to the immutable version release.
+3. Only after that release succeeds, replace `latest.json` on the dedicated `raxol-cli-channel` prerelease.
+4. Add `GET /releases/latest.json` to the raw Phoenix pipeline. Fetch the fixed channel-asset URL, validate the response, honor upstream validators, and serve JSON with `Cache-Control: public, max-age=60, stale-if-error=300` plus an ETag. Keep the last validated manifest available during a transient upstream failure.
+5. Document rollback as replacing `latest.json` with the manifest downloaded from a prior immutable release.
+
+### User-Visible Outcome
+
+`curl -fsSL https://raxol.io/releases/latest.json` returns current, machine-readable release metadata without consuming the GitHub Releases API quota.
+
+### Acceptance Criteria
+
+- [ ] The manifest validates against one checked-in schema and covers exactly the four supported platforms.
+- [ ] Asset URLs are immutable version-release URLs and every digest matches the downloaded asset.
+- [ ] The immutable release receives its manifest before the channel manifest changes.
+- [ ] The raxol.io endpoint returns cached JSON from the fixed channel URL, emits an ETag and explicit cache policy, survives a transient upstream failure with the last validated manifest, and never calls the GitHub API or requires a web redeploy.
+- [ ] Replacing the channel asset with a prior immutable manifest rolls back discovery without changing a version tag or binary.
+
+## Phase 5: Consume the Manifest and Offer Provenance Verification
+
+**Classification:** HITL - public installer contract
+
+### What to Build
+
+Update `scripts/install.sh` and its public `/install` copy contract:
+
+- Default installs fetch `https://raxol.io/releases/latest.json`; pinned installs fetch `raxol-cli-manifest.json` from the named immutable release.
+- Remove latest-version parsing through `api.github.com/repos/.../releases`.
+- Validate schema version, semantic version, tag/version agreement, supported platform entry, asset host/path, and SHA-256 shape before downloading a binary.
+- Keep checksum verification mandatory and before the atomic install rename.
+- Add `--verify-provenance` and `RAXOL_VERIFY_PROVENANCE=1`. This explicit mode requires `gh`, downloads the published bundle, and runs `gh attestation verify` with repository, signer workflow, exact source ref, and hosted-runner constraints before installation.
+- Do not silently fall back to the GitHub API. On manifest failure, report the failing URL and explain how to request a pinned version.
+
+### User-Visible Outcome
+
+The normal one-command installer remains dependency-free and checksum-safe. Security-sensitive users can opt into exact workflow provenance verification.
+
+### Acceptance Criteria
+
+- [ ] A live default install resolves the latest version without any request to `api.github.com`.
+- [ ] A pinned install resolves only immutable version-release URLs and installs the requested version.
+- [ ] Missing, malformed, mismatched, or unsupported manifest data aborts before binary installation.
+- [ ] A bad checksum always aborts; the default path never weakens checksum enforcement.
+- [ ] Provenance mode fails when `gh` is missing or verification fails, and succeeds for an unmodified attested release binary.
+
+## Phase 6: Add Post-Publish Hex Consumer Verification
+
+**Classification:** AFK
+
+### What to Build
+
+Extend `.github/workflows/release-hex.yml` so GitHub Release creation depends on observable registry consumption, not only successful publish commands:
+
+- Preserve dependency-order publication and skip-if-present resume behavior.
+- After publication, query the Hex API for every public package/version expected by the release train.
+- Build a fresh temporary Mix consumer that resolves the released root package from Hex with no umbrella path dependencies.
+- Poll HexDocs only for newly published package versions, with a bounded timeout and an error naming the package whose docs are unavailable.
+- Make the root GitHub Release depend on this verification result.
+
+### User-Visible Outcome
+
+An automated Hex run is successful only when consumers can resolve the release from Hex and the newly published documentation is reachable.
+
+### Acceptance Criteria
+
+- [ ] Dry-run mode performs all preflight checks without publishing or entering registry verification.
+- [ ] Publish mode verifies every expected package/version through the public Hex API.
+- [ ] A fresh external Mix project resolves and compiles against the released root package.
+- [ ] Newly published package documentation becomes reachable before the GitHub Release is created.
+- [ ] Re-running a partially completed train skips existing versions and verifies the complete final registry state.
+
+## Phase 7: Ship the First Automated Hex Release
+
+**Classification:** HITL - irreversible registry publication
+
+### What to Build
+
+Use the next substantive Raxol change as the first live automated Hex train:
+
+1. Determine package versions from the actual public API changes; do not assume 2.8.0 until the release diff justifies it.
+2. Update every changed package version, changelog date, dependency constraint, documentation source ref, and package metadata together.
+3. Run the full release gates from a clean tree and run the reusable Hex workflow with `publish=false` against the exact release commit.
+4. Create package-scoped tags only for changed independent-version packages and verify every tag targets the release commit.
+5. Create the root `vMAJOR.MINOR.PATCH` tag, approve the protected `release` deployment, and let the workflow publish and verify the train.
+6. Confirm the public package pages, HexDocs, fresh consumer project, and GitHub Release. Record the actual versions in the checklist.
+
+### User-Visible Outcome
+
+The next meaningful Raxol release is published to Hex entirely through the protected, resumable workflow and is proven consumable before GitHub announces it.
+
+### Acceptance Criteria
+
+- [ ] Release versions follow SemVer for the actual changes; no automation-only package version is consumed.
+- [ ] All changed independent-package tags and the root tag point to the same reviewed release commit.
+- [ ] The protected environment approval is recorded before registry writes begin.
+- [ ] Every changed public package is visible on Hex and HexDocs, and a fresh consumer compiles successfully.
+- [ ] The GitHub Release exists only after the complete Hex registry verification gate passes.
+
+## Rollout Order
+
+```text
+Phase 1 npm registry gate ───────────────┐
+Phase 2 immutable tags ─────────────────┤
+Phase 3 binary attestations ──> Phase 4 manifest publisher ──> Phase 5 installer
+Phase 6 Hex consumer gate ───────────────────────────────────> Phase 7 live Hex release
+```
+
+Phases 1, 2, 3, and 6 are independent implementation slices. Phase 4 requires the attestation asset contract from Phase 3. Phase 5 requires the public manifest from Phase 4. Phase 7 waits for both Phase 6 and a substantive package change.
+
+## Verification Matrix
+
+| Surface | Proof |
+| --- | --- |
+| npm | Fresh isolated install, executed version, signature audit, five provenance-bearing packuments |
+| Git tags | Active ruleset returned by GitHub API with immutable version patterns and no bypass |
+| CLI binaries | `gh attestation verify` constrained to repository, workflow, exact tag ref, and hosted runner |
+| Manifest | Schema validation, four digest-matching assets, live raxol.io resolution, rollback exercise |
+| Installer | Live latest install, pinned install, checksum failure, provenance success and failure |
+| Hex | Public API visibility, fresh external Mix resolution, HexDocs reachability, GitHub Release dependency |
+
+## Explicit Non-Goals
+
+- No second human reviewer requirement.
+- No automatic version calculation or automatic release-tag creation.
+- No long-lived npm token, signing key, or new package-registry credential.
+- No attempt to bootstrap `gh` or Cosign inside the zero-dependency installer.
+- No immutable rule for the intentionally mutable `raxol-cli-channel` tag.
+- No automation-only Hex version published solely to test the workflow.

--- a/plans/release-hardening.md
+++ b/plans/release-hardening.md
@@ -173,19 +173,19 @@ Extend `.github/workflows/release-hex.yml` so GitHub Release creation depends on
 - Preserve dependency-order publication and skip-if-present resume behavior.
 - After publication, query the Hex API for every public package/version expected by the release train.
 - Build a fresh temporary Mix consumer that resolves the released root package from Hex with no umbrella path dependencies.
-- Poll HexDocs only for newly published package versions, with a bounded timeout and an error naming the package whose docs are unavailable.
+- Poll HexDocs for every package/version in the release train, with a bounded timeout and an error naming the package whose docs are unavailable. Checking the complete train keeps resumed partial releases safe.
 - Make the root GitHub Release depend on this verification result.
 
 ### User-Visible Outcome
 
-An automated Hex run is successful only when consumers can resolve the release from Hex and the newly published documentation is reachable.
+An automated Hex run is successful only when consumers can resolve the release from Hex and the complete train's documentation is reachable.
 
 ### Acceptance Criteria
 
 - [ ] Dry-run mode performs all preflight checks without publishing or entering registry verification.
 - [ ] Publish mode verifies every expected package/version through the public Hex API.
 - [ ] A fresh external Mix project resolves and compiles against the released root package.
-- [ ] Newly published package documentation becomes reachable before the GitHub Release is created.
+- [ ] Every package's versioned documentation is reachable before the GitHub Release is created.
 - [ ] Re-running a partially completed train skips existing versions and verifies the complete final registry state.
 
 ## Phase 7: Ship the First Automated Hex Release

--- a/priv/raxol_cli_release_manifest.schema.json
+++ b/priv/raxol_cli_release_manifest.schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raxol.io/schemas/cli-release-manifest-v1.json",
+  "title": "Raxol CLI release manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "version",
+    "tag",
+    "published_at",
+    "repository",
+    "signer_workflow",
+    "assets"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "version": {"type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "tag": {"type": "string", "pattern": "^raxol-cli-v[0-9]+\\.[0-9]+\\.[0-9]+$"},
+    "published_at": {"type": "string", "format": "date-time"},
+    "repository": {"const": "DROOdotFOO/raxol"},
+    "signer_workflow": {
+      "const": "DROOdotFOO/raxol/.github/workflows/release-raxol-cli.yml"
+    },
+    "assets": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["darwin-arm64", "linux-x64", "linux-arm64", "win32-x64"],
+      "properties": {
+        "darwin-arm64": {"$ref": "#/$defs/asset"},
+        "linux-x64": {"$ref": "#/$defs/asset"},
+        "linux-arm64": {"$ref": "#/$defs/asset"},
+        "win32-x64": {"$ref": "#/$defs/asset"}
+      }
+    }
+  },
+  "$defs": {
+    "asset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "url", "sha256", "attestation_url"],
+      "properties": {
+        "name": {"type": "string"},
+        "url": {"type": "string", "format": "uri", "pattern": "^https://github\\.com/"},
+        "sha256": {"type": "string", "pattern": "^[a-f0-9]{64}$"},
+        "attestation_url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^https://github\\.com/"
+        }
+      }
+    }
+  }
+}

--- a/scripts/build_cli_release_manifest.mjs
+++ b/scripts/build_cli_release_manifest.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+import {readFile, writeFile} from "node:fs/promises";
+
+const repository = "DROOdotFOO/raxol";
+const signerWorkflow =
+  "DROOdotFOO/raxol/.github/workflows/release-raxol-cli.yml";
+const assets = {
+  "darwin-arm64": "raxol_cli_macos",
+  "linux-x64": "raxol_cli_linux",
+  "linux-arm64": "raxol_cli_linux_arm",
+  "win32-x64": "raxol_cli_windows.exe",
+};
+
+function fail(message) {
+  throw new Error(`release manifest: ${message}`);
+}
+
+function parseChecksums(contents) {
+  const checksums = new Map();
+
+  for (const line of contents.trim().split("\n")) {
+    const match = line.match(/^([a-f0-9]{64})\s+\*?(\S+)$/);
+    if (!match) fail(`invalid checksum line: ${line}`);
+
+    const [, checksum, name] = match;
+    if (checksums.has(name)) fail(`duplicate checksum for ${name}`);
+    checksums.set(name, checksum);
+  }
+
+  const expectedNames = new Set(Object.values(assets));
+  for (const name of checksums.keys()) {
+    if (!expectedNames.has(name)) fail(`unexpected release asset ${name}`);
+  }
+  for (const name of expectedNames) {
+    if (!checksums.has(name)) fail(`missing checksum for ${name}`);
+  }
+
+  return checksums;
+}
+
+async function main() {
+  const [version, checksumsPath, outputPath] = process.argv.slice(2);
+  if (!version || !checksumsPath || !outputPath) {
+    fail("usage: build_cli_release_manifest.mjs VERSION SHA256SUMS OUTPUT");
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(version)) fail(`invalid version ${version}`);
+
+  const publishedAt = process.env.RAXOL_RELEASED_AT || new Date().toISOString();
+  if (Number.isNaN(Date.parse(publishedAt))) {
+    fail(`invalid RAXOL_RELEASED_AT ${publishedAt}`);
+  }
+
+  const tag = `raxol-cli-v${version}`;
+  const base = `https://github.com/${repository}/releases/download/${tag}`;
+  const bundleUrl = `${base}/raxol-cli-attestation.sigstore.json`;
+  const checksums = parseChecksums(await readFile(checksumsPath, "utf8"));
+
+  const manifest = {
+    schema_version: 1,
+    version,
+    tag,
+    published_at: publishedAt,
+    repository,
+    signer_workflow: signerWorkflow,
+    assets: Object.fromEntries(
+      Object.entries(assets).map(([platform, name]) => [
+        platform,
+        {
+          name,
+          url: `${base}/${name}`,
+          sha256: checksums.get(name),
+          attestation_url: bundleUrl,
+        },
+      ]),
+    ),
+  };
+
+  await writeFile(outputPath, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,28 +1,30 @@
 #!/usr/bin/env bash
-# install.sh -- install the `raxol` CLI from GitHub Releases.
+# install.sh -- install the `raxol` CLI from an immutable GitHub Release.
 #
 #   curl -fsSL https://raxol.io/install | bash
-#   curl -fsSL https://raxol.io/install | bash -s -- --version 0.2.6
+#   curl -fsSL https://raxol.io/install | bash -s -- --version 0.2.9
+#   curl -fsSL https://raxol.io/install | bash -s -- --verify-provenance
 #
 # The binary is self-contained (Burrito wraps its own ERTS), so this installs
-# one file and needs no Erlang, Elixir, or Node. npm remains an option; this
-# exists so Node is not a prerequisite for a terminal tool that does not
-# otherwise need it.
+# one file and needs no Erlang, Elixir, or Node. npm remains an option.
 #
-# Every download is checksum-verified against the release's SHA256SUMS. The
-# installer fails closed when either the checksum file or a SHA-256 utility is
-# unavailable.
+# Every download is verified against the release manifest's SHA-256 digest.
+# `--verify-provenance` additionally requires GitHub CLI and proves the binary
+# was produced by the tagged Raxol release workflow. Verification fails closed.
 #
 # Environment:
-#   RAXOL_VERSION       version to install (default: latest release)
-#   RAXOL_INSTALL_DIR   install directory (default: ~/.local/bin)
-
+#   RAXOL_VERSION             version to install (default: latest release)
+#   RAXOL_INSTALL_DIR         install directory (default: ~/.local/bin)
+#   RAXOL_VERIFY_PROVENANCE   1 to require GitHub artifact verification
 set -euo pipefail
 
 REPO="DROOdotFOO/raxol"
 TAG_PREFIX="raxol-cli-v"
+LATEST_MANIFEST_URL="https://raxol.io/releases/latest.json"
+EXPECTED_SIGNER="$REPO/.github/workflows/release-raxol-cli.yml"
 VERSION="${RAXOL_VERSION:-}"
 INSTALL_DIR="${RAXOL_INSTALL_DIR:-$HOME/.local/bin}"
+VERIFY_PROVENANCE="${RAXOL_VERIFY_PROVENANCE:-0}"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -34,9 +36,11 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 && -n "$2" ]] || { printf 'install: --dir requires a value\n' >&2; exit 64; }
       INSTALL_DIR="$2"; shift 2
       ;;
+    --verify-provenance)
+      VERIFY_PROVENANCE=1; shift
+      ;;
     -h|--help)
       # Print the header comment, stopping at the first line that is not one.
-      # A fixed line range goes stale the moment the header is edited.
       awk 'NR == 1 { next } /^#/ { sub(/^# ?/, ""); print; next } { exit }' "$0"
       exit 0
       ;;
@@ -44,10 +48,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+case "$VERIFY_PROVENANCE" in
+  0|1) ;;
+  *) printf 'install: RAXOL_VERIFY_PROVENANCE must be 0 or 1\n' >&2; exit 64 ;;
+esac
+
 die() { printf 'install: %s\n' "$1" >&2; exit 1; }
 note() { printf '%s\n' "$1"; }
 
-for tool in curl uname mktemp; do
+for tool in curl uname mktemp sed; do
   command -v "$tool" >/dev/null 2>&1 || die "$tool is required"
 done
 
@@ -57,9 +66,9 @@ os=$(uname -s)
 arch=$(uname -m)
 
 case "$os-$arch" in
-  Darwin-arm64)          binary="raxol_cli_macos" ;;
-  Linux-x86_64)          binary="raxol_cli_linux" ;;
-  Linux-aarch64|Linux-arm64) binary="raxol_cli_linux_arm" ;;
+  Darwin-arm64)             platform="darwin-arm64"; binary="raxol_cli_macos" ;;
+  Linux-x86_64)             platform="linux-x64"; binary="raxol_cli_linux" ;;
+  Linux-aarch64|Linux-arm64) platform="linux-arm64"; binary="raxol_cli_linux_arm" ;;
   Darwin-x86_64)
     die "macOS on Intel is not published; build from source or use an arm64 machine"
     ;;
@@ -68,36 +77,89 @@ case "$os-$arch" in
     ;;
 esac
 
-# -- version -----------------------------------------------------------------
-
-if [[ -z "$VERSION" ]]; then
-  # Resolve the newest raxol-cli-v* tag. The releases list is used rather than
-  # /releases/latest, which reports the newest release of ANY tag family in the
-  # repo and would happily hand back a non-CLI tag.
-  VERSION=$(
-    curl -fsSL "https://api.github.com/repos/$REPO/releases?per_page=100" |
-      grep '"tag_name"' |
-      sed -n "s/.*\"${TAG_PREFIX}\([^\"]*\)\".*/\1/p" |
-      head -n 1
-  ) || true
-  [[ -n "$VERSION" ]] || die "could not resolve the latest ${TAG_PREFIX}* release; pass --version"
-fi
-
-tag="${TAG_PREFIX}${VERSION}"
-base="https://github.com/$REPO/releases/download/$tag"
-
-note "raxol: installing $VERSION ($binary)"
-
-# -- download + verify -------------------------------------------------------
+# -- manifest + verification -------------------------------------------------
 
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
+manifest="$tmp/manifest.json"
+requested_version="$VERSION"
 
-curl -fsSL "$base/$binary" -o "$tmp/$binary" ||
-  die "download failed: $base/$binary (is $tag a published release?)"
+if [[ -n "$requested_version" ]]; then
+  [[ "$requested_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+    die "invalid version $requested_version (expected MAJOR.MINOR.PATCH)"
+  requested_tag="${TAG_PREFIX}${requested_version}"
+  manifest_url="https://github.com/$REPO/releases/download/$requested_tag/raxol-cli-manifest.json"
+else
+  manifest_url="$LATEST_MANIFEST_URL"
+fi
 
-curl -fsSL "$base/SHA256SUMS" -o "$tmp/SHA256SUMS" 2>/dev/null ||
-  die "no SHA256SUMS for $tag; refusing an unverified install"
+if ! curl -fsSL "$manifest_url" -o "$manifest"; then
+  if [[ -n "$requested_version" ]]; then
+    die "release manifest unavailable: $manifest_url"
+  else
+    die "latest release manifest unavailable: $manifest_url; pass --version"
+  fi
+fi
+
+manifest_string() {
+  local key="$1"
+  local value
+  value=$(sed -n "s/^[[:space:]]*\"${key}\":[[:space:]]*\"\\([^\"]*\\)\"[,]*[[:space:]]*$/\\1/p" "$manifest")
+  [[ -n "$value" && "$value" != *$'\n'* ]] ||
+    die "manifest has invalid or duplicate $key"
+  printf '%s' "$value"
+}
+
+schema_version=$(sed -n 's/^[[:space:]]*"schema_version":[[:space:]]*\([0-9][0-9]*\),*[[:space:]]*$/\1/p' "$manifest")
+[[ "$schema_version" == "1" ]] || die "unsupported release manifest schema"
+
+VERSION=$(manifest_string version)
+tag=$(manifest_string tag)
+repository=$(manifest_string repository)
+signer_workflow=$(manifest_string signer_workflow)
+
+[[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+  die "manifest contains invalid version $VERSION"
+[[ "$tag" == "${TAG_PREFIX}${VERSION}" ]] ||
+  die "manifest tag $tag does not match version $VERSION"
+[[ "$repository" == "$REPO" ]] || die "manifest repository is not $REPO"
+[[ "$signer_workflow" == "$EXPECTED_SIGNER" ]] ||
+  die "manifest signer workflow is not $EXPECTED_SIGNER"
+[[ -z "$requested_version" || "$VERSION" == "$requested_version" ]] ||
+  die "manifest version $VERSION does not match requested version $requested_version"
+
+asset_block=$(sed -n \
+  "/^[[:space:]]*\"${platform}\":[[:space:]]*{[[:space:]]*$/,/^[[:space:]]*}[,]*[[:space:]]*$/p" \
+  "$manifest")
+[[ -n "$asset_block" ]] || die "manifest has no asset for $platform"
+
+asset_string() {
+  local key="$1"
+  local value
+  value=$(printf '%s\n' "$asset_block" |
+    sed -n "s/^[[:space:]]*\"${key}\":[[:space:]]*\"\\([^\"]*\\)\"[,]*[[:space:]]*$/\\1/p")
+  [[ -n "$value" && "$value" != *$'\n'* ]] ||
+    die "manifest asset has invalid or duplicate $key"
+  printf '%s' "$value"
+}
+
+asset_name=$(asset_string name)
+asset_url=$(asset_string url)
+expected=$(asset_string sha256)
+attestation_url=$(asset_string attestation_url)
+base="https://github.com/$REPO/releases/download/$tag"
+
+[[ "$asset_name" == "$binary" ]] ||
+  die "manifest asset $asset_name does not match platform binary $binary"
+[[ "$asset_url" == "$base/$binary" ]] || die "manifest contains an invalid asset URL"
+[[ "$expected" =~ ^[a-f0-9]{64}$ ]] || die "manifest contains an invalid SHA-256 digest"
+[[ "$attestation_url" == "$base/raxol-cli-attestation.sigstore.json" ]] ||
+  die "manifest contains an invalid attestation URL"
+
+note "raxol: installing $VERSION ($binary)"
+
+curl -fsSL "$asset_url" -o "$tmp/$binary" ||
+  die "download failed: $asset_url (is $tag a published release?)"
 
 if command -v sha256sum >/dev/null 2>&1; then
   actual=$(sha256sum "$tmp/$binary" | awk '{print $1}')
@@ -107,11 +169,25 @@ else
   die "sha256sum or shasum is required; refusing an unverified install"
 fi
 
-expected=$(awk -v b="$binary" '$2 == b || $2 == "*" b {print $1}' "$tmp/SHA256SUMS" | head -n 1)
-[[ -n "$expected" ]] || die "no checksum for $binary in SHA256SUMS"
 [[ "$actual" == "$expected" ]] ||
   die "checksum mismatch for $binary (expected $expected, got $actual)"
 note "raxol: checksum ok"
+
+if [[ "$VERIFY_PROVENANCE" == "1" ]]; then
+  command -v gh >/dev/null 2>&1 ||
+    die "gh is required by --verify-provenance; refusing installation"
+  curl -fsSL "$attestation_url" -o "$tmp/attestation.sigstore.json" ||
+    die "attestation unavailable for $tag; refusing installation"
+  gh attestation verify "$tmp/$binary" \
+    --bundle "$tmp/attestation.sigstore.json" \
+    --repo "$REPO" \
+    --signer-workflow "$signer_workflow" \
+    --source-ref "refs/tags/$tag" \
+    --cert-oidc-issuer "https://token.actions.githubusercontent.com" \
+    --deny-self-hosted-runners >/dev/null ||
+    die "provenance verification failed for $binary"
+  note "raxol: provenance ok"
+fi
 
 # -- install -----------------------------------------------------------------
 

--- a/test/scripts/install_script_test.exs
+++ b/test/scripts/install_script_test.exs
@@ -17,27 +17,14 @@ defmodule Raxol.InstallScriptTest do
     end
   end
 
-  test "refuses to install when the release checksum file is unavailable" do
+  test "refuses to install when the release manifest is unavailable" do
     fake_bin = tmp_dir("fake-bin")
     install_dir = tmp_dir("install")
     curl = Path.join(fake_bin, "curl")
 
     File.write!(curl, """
     #!/usr/bin/env bash
-    set -euo pipefail
-    output=""
-    url=""
-    while [[ $# -gt 0 ]]; do
-      case "$1" in
-        -o) output="$2"; shift 2 ;;
-        http*) url="$1"; shift ;;
-        *) shift ;;
-      esac
-    done
-    if [[ "$url" == *SHA256SUMS ]]; then
-      exit 22
-    fi
-    printf 'fake binary' > "$output"
+    exit 22
     """)
 
     File.chmod!(curl, 0o755)
@@ -53,8 +40,19 @@ defmodule Raxol.InstallScriptTest do
       )
 
     assert status == 1
-    assert output =~ "refusing an unverified install"
+    assert output =~ "release manifest unavailable"
     refute File.exists?(Path.join(install_dir, "raxol"))
+  end
+
+  test "provenance environment accepts only explicit boolean values" do
+    {output, status} =
+      System.cmd("bash", [@script],
+        env: [{"RAXOL_VERIFY_PROVENANCE", "sometimes"}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 64
+    assert output =~ "RAXOL_VERIFY_PROVENANCE must be 0 or 1"
   end
 
   defp tmp_dir(label) do

--- a/test/scripts/release_manifest_test.exs
+++ b/test/scripts/release_manifest_test.exs
@@ -1,0 +1,77 @@
+defmodule Raxol.ReleaseManifestTest do
+  use ExUnit.Case, async: true
+
+  @script Path.expand("../../scripts/build_cli_release_manifest.mjs", __DIR__)
+  @assets [
+    "raxol_cli_macos",
+    "raxol_cli_linux",
+    "raxol_cli_linux_arm",
+    "raxol_cli_windows.exe"
+  ]
+
+  test "builds exact immutable URLs from the release checksums" do
+    dir = tmp_dir()
+    checksums = Path.join(dir, "SHA256SUMS")
+    manifest = Path.join(dir, "manifest.json")
+
+    checksums_body =
+      @assets
+      |> Enum.with_index(1)
+      |> Enum.map_join("", fn {name, index} ->
+        "#{String.duplicate(Integer.to_string(index), 64)}  #{name}\n"
+      end)
+
+    File.write!(checksums, checksums_body)
+
+    {output, status} =
+      System.cmd("node", [@script, "0.3.0", checksums, manifest],
+        env: [{"RAXOL_RELEASED_AT", "2026-09-10T12:00:00Z"}],
+        stderr_to_stdout: true
+      )
+
+    assert status == 0, output
+
+    decoded = manifest |> File.read!() |> Jason.decode!()
+    assert decoded["schema_version"] == 1
+    assert decoded["version"] == "0.3.0"
+    assert decoded["tag"] == "raxol-cli-v0.3.0"
+    assert map_size(decoded["assets"]) == 4
+
+    assert decoded["assets"]["linux-x64"] == %{
+             "name" => "raxol_cli_linux",
+             "url" =>
+               "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol_cli_linux",
+             "sha256" => String.duplicate("2", 64),
+             "attestation_url" =>
+               "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol-cli-attestation.sigstore.json"
+           }
+  end
+
+  test "rejects incomplete checksum sets" do
+    dir = tmp_dir()
+    checksums = Path.join(dir, "SHA256SUMS")
+    manifest = Path.join(dir, "manifest.json")
+    File.write!(checksums, "#{String.duplicate("a", 64)}  raxol_cli_linux\n")
+
+    {output, status} =
+      System.cmd("node", [@script, "0.3.0", checksums, manifest],
+        stderr_to_stdout: true
+      )
+
+    assert status == 1
+    assert output =~ "missing checksum for raxol_cli_macos"
+    refute File.exists?(manifest)
+  end
+
+  defp tmp_dir do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "raxol_release_manifest_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+    on_exit(fn -> File.rm_rf!(dir) end)
+    dir
+  end
+end

--- a/web/lib/raxol_playground/application.ex
+++ b/web/lib/raxol_playground/application.ex
@@ -13,12 +13,12 @@ defmodule RaxolPlayground.Application do
       [
         RaxolPlaygroundWeb.Telemetry,
         {DNSCluster,
-         query:
-           Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
+         query: Application.get_env(:raxol_playground, :dns_cluster_query) || :ignore},
         {Phoenix.PubSub, name: RaxolPlayground.PubSub}
       ] ++
         maybe_raxol_pubsub() ++
         [
+          RaxolPlayground.ReleaseManifestCache,
           RaxolPlaygroundWeb.Presence,
           RaxolPlaygroundWeb.Endpoint
         ]
@@ -70,14 +70,12 @@ defmodule RaxolPlayground.Application do
             # the public internet on one env var.
             app_module: Raxol.Playground.App,
             port: ssh_port(),
-            host_keys_dir:
-              System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys",
+            host_keys_dir: System.get_env("RAXOL_SSH_HOST_KEYS_DIR") || "/app/ssh_keys",
             allow_anonymous: true,
             max_connections: ssh_max_connections(),
             max_per_ip: env_int("RAXOL_SSH_MAX_PER_IP", 10),
             idle_timeout: :timer.seconds(env_int("RAXOL_SSH_IDLE_SECONDS", 300)),
-            max_session_duration:
-              :timer.seconds(env_int("RAXOL_SSH_MAX_SESSION_SECONDS", 3600))
+            max_session_duration: :timer.seconds(env_int("RAXOL_SSH_MAX_SESSION_SECONDS", 3600))
           },
           restart: :temporary
         )

--- a/web/lib/raxol_playground/application.ex
+++ b/web/lib/raxol_playground/application.ex
@@ -18,7 +18,6 @@ defmodule RaxolPlayground.Application do
       ] ++
         maybe_raxol_pubsub() ++
         [
-          RaxolPlayground.ReleaseManifestCache,
           RaxolPlaygroundWeb.Presence,
           RaxolPlaygroundWeb.Endpoint
         ]

--- a/web/lib/raxol_playground/release_manifest.ex
+++ b/web/lib/raxol_playground/release_manifest.ex
@@ -12,7 +12,18 @@ defmodule RaxolPlayground.ReleaseManifest do
 
   @spec validate(binary()) :: :ok | {:error, :invalid_manifest}
   def validate(body) when is_binary(body) do
-    with {:ok, manifest} <- Jason.decode(body),
+    case Jason.decode(body) do
+      {:ok, manifest} ->
+        if valid_manifest?(manifest), do: :ok, else: {:error, :invalid_manifest}
+
+      {:error, _reason} ->
+        {:error, :invalid_manifest}
+    end
+  end
+
+  def validate(_body), do: {:error, :invalid_manifest}
+
+  defp valid_manifest?(
          %{
            "schema_version" => 1,
            "version" => version,
@@ -21,21 +32,21 @@ defmodule RaxolPlayground.ReleaseManifest do
            "repository" => @repository,
            "signer_workflow" => @signer_workflow,
            "assets" => assets
-         } <- manifest,
-         true <- map_size(manifest) == 7,
-         true <- is_binary(version),
-         true <- is_binary(published_at),
-         true <- Regex.match?(~r/^\d+\.\d+\.\d+$/, version),
-         true <- tag == "raxol-cli-v#{version}",
-         {:ok, _, _} <- DateTime.from_iso8601(published_at),
-         true <- valid_assets?(assets, tag) do
-      :ok
-    else
-      _ -> {:error, :invalid_manifest}
-    end
+         } = manifest
+       )
+       when is_binary(version) and is_binary(tag) and is_binary(published_at) do
+    map_size(manifest) == 7 and
+      Regex.match?(~r/^\d+\.\d+\.\d+$/, version) and
+      tag == "raxol-cli-v#{version}" and
+      valid_timestamp?(published_at) and
+      valid_assets?(assets, tag)
   end
 
-  def validate(_body), do: {:error, :invalid_manifest}
+  defp valid_manifest?(_manifest), do: false
+
+  defp valid_timestamp?(published_at) do
+    match?({:ok, _, _}, DateTime.from_iso8601(published_at))
+  end
 
   defp valid_assets?(assets, tag) when is_map(assets) do
     MapSet.new(Map.keys(assets)) == MapSet.new(Map.keys(@assets)) and

--- a/web/lib/raxol_playground/release_manifest.ex
+++ b/web/lib/raxol_playground/release_manifest.ex
@@ -1,0 +1,63 @@
+defmodule RaxolPlayground.ReleaseManifest do
+  @moduledoc false
+
+  @repository "DROOdotFOO/raxol"
+  @signer_workflow "DROOdotFOO/raxol/.github/workflows/release-raxol-cli.yml"
+  @assets %{
+    "darwin-arm64" => "raxol_cli_macos",
+    "linux-x64" => "raxol_cli_linux",
+    "linux-arm64" => "raxol_cli_linux_arm",
+    "win32-x64" => "raxol_cli_windows.exe"
+  }
+
+  @spec validate(binary()) :: :ok | {:error, :invalid_manifest}
+  def validate(body) when is_binary(body) do
+    with {:ok, manifest} <- Jason.decode(body),
+         %{
+           "schema_version" => 1,
+           "version" => version,
+           "tag" => tag,
+           "published_at" => published_at,
+           "repository" => @repository,
+           "signer_workflow" => @signer_workflow,
+           "assets" => assets
+         } <- manifest,
+         true <- map_size(manifest) == 7,
+         true <- is_binary(version),
+         true <- is_binary(published_at),
+         true <- Regex.match?(~r/^\d+\.\d+\.\d+$/, version),
+         true <- tag == "raxol-cli-v#{version}",
+         {:ok, _, _} <- DateTime.from_iso8601(published_at),
+         true <- valid_assets?(assets, tag) do
+      :ok
+    else
+      _ -> {:error, :invalid_manifest}
+    end
+  end
+
+  def validate(_body), do: {:error, :invalid_manifest}
+
+  defp valid_assets?(assets, tag) when is_map(assets) do
+    MapSet.new(Map.keys(assets)) == MapSet.new(Map.keys(@assets)) and
+      Enum.all?(@assets, fn {platform, expected_name} ->
+        valid_asset?(assets[platform], expected_name, tag)
+      end)
+  end
+
+  defp valid_assets?(_assets, _tag), do: false
+
+  defp valid_asset?(asset, expected_name, tag) when is_map(asset) do
+    base = "https://github.com/#{@repository}/releases/download/#{tag}"
+    sha256 = asset["sha256"]
+
+    is_binary(sha256) and
+      asset == %{
+        "name" => expected_name,
+        "url" => "#{base}/#{expected_name}",
+        "sha256" => sha256,
+        "attestation_url" => "#{base}/raxol-cli-attestation.sigstore.json"
+      } and Regex.match?(~r/^[a-f0-9]{64}$/, sha256)
+  end
+
+  defp valid_asset?(_asset, _expected_name, _tag), do: false
+end

--- a/web/lib/raxol_playground/release_manifest_cache.ex
+++ b/web/lib/raxol_playground/release_manifest_cache.ex
@@ -1,0 +1,119 @@
+defmodule RaxolPlayground.ReleaseManifestCache do
+  @moduledoc false
+
+  use GenServer
+
+  require Logger
+
+  alias RaxolPlayground.ReleaseManifest
+
+  @default_url "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-channel/latest.json"
+  @fresh_ms :timer.seconds(60)
+  @stale_ms :timer.minutes(5)
+
+  @type entry :: %{body: binary(), etag: binary(), stale?: boolean()}
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @spec get(GenServer.server()) :: {:ok, entry()} | {:error, term()}
+  def get(server \\ __MODULE__) do
+    GenServer.call(server, :get, 10_000)
+  end
+
+  @impl true
+  def init(opts) do
+    {:ok,
+     %{
+       url: Keyword.get(opts, :url, @default_url),
+       body: nil,
+       etag: nil,
+       fresh_ms: Keyword.get(opts, :fresh_ms, @fresh_ms),
+       stale_ms: Keyword.get(opts, :stale_ms, @stale_ms),
+       fresh_until: 0,
+       stale_until: 0
+     }}
+  end
+
+  @impl true
+  def handle_call(:get, _from, state) do
+    now = System.monotonic_time(:millisecond)
+
+    if state.body && now < state.fresh_until do
+      {:reply, {:ok, entry(state, false)}, state}
+    else
+      refresh(state, now)
+    end
+  end
+
+  defp refresh(state, now) do
+    headers = if state.etag, do: [{"if-none-match", state.etag}], else: []
+
+    result =
+      Req.get(state.url,
+        headers: headers,
+        retry: false,
+        decode_body: false,
+        receive_timeout: 5_000,
+        connect_options: [timeout: 3_000]
+      )
+
+    case result do
+      {:ok, %Req.Response{status: 304}} when is_binary(state.body) ->
+        state = refresh_deadlines(state, now)
+        {:reply, {:ok, entry(state, false)}, state}
+
+      {:ok, %Req.Response{status: 200, body: body, headers: response_headers}}
+      when is_binary(body) ->
+        case ReleaseManifest.validate(body) do
+          :ok ->
+            etag = response_headers |> Map.get("etag", []) |> List.first() || etag(body)
+
+            state =
+              state
+              |> Map.merge(%{body: body, etag: etag})
+              |> refresh_deadlines(now)
+
+            {:reply, {:ok, entry(state, false)}, state}
+
+          {:error, reason} ->
+            stale_or_error(state, now, reason)
+        end
+
+      {:ok, %Req.Response{status: status}} ->
+        stale_or_error(state, now, {:http_status, status})
+
+      {:error, reason} ->
+        stale_or_error(state, now, reason)
+    end
+  end
+
+  defp stale_or_error(state, now, reason) do
+    if state.body && now < state.stale_until do
+      Logger.warning("Serving stale CLI release manifest: #{inspect(reason)}")
+      {:reply, {:ok, entry(state, true)}, state}
+    else
+      {:reply, {:error, reason}, state}
+    end
+  end
+
+  defp refresh_deadlines(state, now) do
+    %{
+      state
+      | fresh_until: now + state.fresh_ms,
+        stale_until: now + state.fresh_ms + state.stale_ms
+    }
+  end
+
+  defp entry(state, stale?) do
+    %{body: state.body, etag: state.etag, stale?: stale?}
+  end
+
+  defp etag(body) do
+    digest = :crypto.hash(:sha256, body) |> Base.encode16(case: :lower)
+    ~s("#{digest}")
+  end
+end

--- a/web/lib/raxol_playground/release_manifest_cache.ex
+++ b/web/lib/raxol_playground/release_manifest_cache.ex
@@ -1,115 +1,123 @@
 defmodule RaxolPlayground.ReleaseManifestCache do
   @moduledoc false
 
-  use GenServer
-
   require Logger
 
   alias RaxolPlayground.ReleaseManifest
 
-  @default_url "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-channel/latest.json"
+  @table __MODULE__
+  @url "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-channel/latest.json"
   @fresh_ms :timer.seconds(60)
   @stale_ms :timer.minutes(5)
 
   @type entry :: %{body: binary(), etag: binary(), stale?: boolean()}
 
-  @spec start_link(keyword()) :: GenServer.on_start()
-  def start_link(opts \\ []) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
-  end
-
-  @spec get(GenServer.server()) :: {:ok, entry()} | {:error, term()}
-  def get(server \\ __MODULE__) do
-    GenServer.call(server, :get, 10_000)
-  end
-
-  @impl true
-  def init(opts) do
-    {:ok,
-     %{
-       url: Keyword.get(opts, :url, @default_url),
-       body: nil,
-       etag: nil,
-       fresh_ms: Keyword.get(opts, :fresh_ms, @fresh_ms),
-       stale_ms: Keyword.get(opts, :stale_ms, @stale_ms),
-       fresh_until: 0,
-       stale_until: 0
-     }}
-  end
-
-  @impl true
-  def handle_call(:get, _from, state) do
+  @spec get(keyword()) :: {:ok, entry()} | {:error, term()}
+  def get(opts \\ []) do
+    fresh_ms = Keyword.get(opts, :fresh_ms, @fresh_ms)
+    stale_ms = Keyword.get(opts, :stale_ms, @stale_ms)
     now = System.monotonic_time(:millisecond)
 
-    if state.body && now < state.fresh_until do
-      {:reply, {:ok, entry(state, false)}, state}
-    else
-      refresh(state, now)
+    case lookup() do
+      {:ok, entry, fetched_at} when now - fetched_at < fresh_ms ->
+        {:ok, Map.put(entry, :stale?, false)}
+
+      stale ->
+        refresh(opts, stale, now, fresh_ms + stale_ms)
     end
   end
 
-  defp refresh(state, now) do
-    headers = if state.etag, do: [{"if-none-match", state.etag}], else: []
+  @spec reset() :: :ok
+  def reset do
+    ensure_table()
+    :ets.delete(@table, :manifest)
+    :ok
+  end
 
-    result =
-      Req.get(state.url,
+  defp refresh(opts, stale, now, stale_limit_ms) do
+    headers =
+      case stale do
+        {:ok, %{etag: etag}, _fetched_at} -> [{"if-none-match", etag}]
+        :miss -> []
+      end
+
+    request_options =
+      [
+        url: @url,
         headers: headers,
         retry: false,
         decode_body: false,
         receive_timeout: 5_000,
         connect_options: [timeout: 3_000]
-      )
+      ]
+      |> Keyword.merge(Keyword.get(opts, :req_options, []))
 
-    case result do
-      {:ok, %Req.Response{status: 304}} when is_binary(state.body) ->
-        state = refresh_deadlines(state, now)
-        {:reply, {:ok, entry(state, false)}, state}
+    case Req.get(request_options) do
+      {:ok, %Req.Response{status: 304}} ->
+        refresh_stale(stale, now)
 
-      {:ok, %Req.Response{status: 200, body: body, headers: response_headers}}
-      when is_binary(body) ->
+      {:ok, %Req.Response{status: 200, body: body} = response} when is_binary(body) ->
         case ReleaseManifest.validate(body) do
           :ok ->
-            etag = response_headers |> Map.get("etag", []) |> List.first() || etag(body)
-
-            state =
-              state
-              |> Map.merge(%{body: body, etag: etag})
-              |> refresh_deadlines(now)
-
-            {:reply, {:ok, entry(state, false)}, state}
+            etag = response.headers |> Map.get("etag", []) |> List.first() || etag(body)
+            entry = %{body: body, etag: etag}
+            store(entry, now)
+            {:ok, Map.put(entry, :stale?, false)}
 
           {:error, reason} ->
-            stale_or_error(state, now, reason)
+            stale_or_error(stale, now, stale_limit_ms, reason)
         end
 
       {:ok, %Req.Response{status: status}} ->
-        stale_or_error(state, now, {:http_status, status})
+        stale_or_error(stale, now, stale_limit_ms, {:http_status, status})
 
       {:error, reason} ->
-        stale_or_error(state, now, reason)
+        stale_or_error(stale, now, stale_limit_ms, reason)
     end
   end
 
-  defp stale_or_error(state, now, reason) do
-    if state.body && now < state.stale_until do
-      Logger.warning("Serving stale CLI release manifest: #{inspect(reason)}")
-      {:reply, {:ok, entry(state, true)}, state}
-    else
-      {:reply, {:error, reason}, state}
+  defp refresh_stale({:ok, entry, _fetched_at}, now) do
+    store(entry, now)
+    {:ok, Map.put(entry, :stale?, false)}
+  end
+
+  defp refresh_stale(:miss, _now), do: {:error, :unexpected_not_modified}
+
+  defp stale_or_error({:ok, entry, fetched_at}, now, stale_limit_ms, reason)
+       when now - fetched_at < stale_limit_ms do
+    Logger.warning("Serving stale CLI release manifest: #{inspect(reason)}")
+    {:ok, Map.put(entry, :stale?, true)}
+  end
+
+  defp stale_or_error(_stale, _now, _stale_limit_ms, reason), do: {:error, reason}
+
+  defp lookup do
+    ensure_table()
+
+    case :ets.lookup(@table, :manifest) do
+      [{:manifest, entry, fetched_at}] -> {:ok, entry, fetched_at}
+      [] -> :miss
     end
   end
 
-  defp refresh_deadlines(state, now) do
-    %{
-      state
-      | fresh_until: now + state.fresh_ms,
-        stale_until: now + state.fresh_ms + state.stale_ms
-    }
+  defp store(entry, fetched_at) do
+    ensure_table()
+    :ets.insert(@table, {:manifest, entry, fetched_at})
+    :ok
   end
 
-  defp entry(state, stale?) do
-    %{body: state.body, etag: state.etag, stale?: stale?}
+  defp ensure_table do
+    case :ets.whereis(@table) do
+      :undefined ->
+        try do
+          :ets.new(@table, [:set, :public, :named_table, read_concurrency: true])
+        rescue
+          ArgumentError -> @table
+        end
+
+      _ref ->
+        @table
+    end
   end
 
   defp etag(body) do

--- a/web/lib/raxol_playground/release_manifest_cache.ex
+++ b/web/lib/raxol_playground/release_manifest_cache.ex
@@ -35,45 +35,69 @@ defmodule RaxolPlayground.ReleaseManifestCache do
   end
 
   defp refresh(opts, stale, now, stale_limit_ms) do
-    headers =
-      case stale do
-        {:ok, %{etag: etag}, _fetched_at} -> [{"if-none-match", etag}]
-        :miss -> []
-      end
-
     request_options =
-      [
-        url: @url,
-        headers: headers,
-        retry: false,
-        decode_body: false,
-        receive_timeout: 5_000,
-        connect_options: [timeout: 3_000]
-      ]
-      |> Keyword.merge(Keyword.get(opts, :req_options, []))
+      opts
+      |> request_options(stale)
+      |> Req.new()
 
-    case Req.get(request_options) do
-      {:ok, %Req.Response{status: 304}} ->
-        refresh_stale(stale, now)
+    request_options
+    |> Req.get()
+    |> handle_response(stale, now, stale_limit_ms)
+  end
 
-      {:ok, %Req.Response{status: 200, body: body} = response} when is_binary(body) ->
-        case ReleaseManifest.validate(body) do
-          :ok ->
-            etag = response.headers |> Map.get("etag", []) |> List.first() || etag(body)
-            entry = %{body: body, etag: etag}
-            store(entry, now)
-            {:ok, Map.put(entry, :stale?, false)}
+  defp request_options(opts, stale) do
+    base = [
+      url: @url,
+      headers: conditional_headers(stale),
+      retry: false,
+      decode_body: false,
+      receive_timeout: 5_000,
+      connect_options: [timeout: 3_000]
+    ]
 
-          {:error, reason} ->
-            stale_or_error(stale, now, stale_limit_ms, reason)
-        end
+    Keyword.merge(base, Keyword.get(opts, :req_options, []))
+  end
 
-      {:ok, %Req.Response{status: status}} ->
-        stale_or_error(stale, now, stale_limit_ms, {:http_status, status})
+  defp conditional_headers({:ok, %{etag: etag}, _fetched_at}),
+    do: [{"if-none-match", etag}]
 
-      {:error, reason} ->
-        stale_or_error(stale, now, stale_limit_ms, reason)
+  defp conditional_headers(:miss), do: []
+
+  defp handle_response({:ok, %Req.Response{status: 304}}, stale, now, _stale_limit_ms) do
+    refresh_stale(stale, now)
+  end
+
+  defp handle_response(
+         {:ok, %Req.Response{status: 200, body: body} = response},
+         stale,
+         now,
+         stale_limit_ms
+       )
+       when is_binary(body) do
+    case ReleaseManifest.validate(body) do
+      :ok -> store_response(response, body, now)
+      {:error, reason} -> stale_or_error(stale, now, stale_limit_ms, reason)
     end
+  end
+
+  defp handle_response(
+         {:ok, %Req.Response{status: status}},
+         stale,
+         now,
+         stale_limit_ms
+       ) do
+    stale_or_error(stale, now, stale_limit_ms, {:http_status, status})
+  end
+
+  defp handle_response({:error, reason}, stale, now, stale_limit_ms) do
+    stale_or_error(stale, now, stale_limit_ms, reason)
+  end
+
+  defp store_response(response, body, now) do
+    etag = response.headers |> Map.get("etag", []) |> List.first() || etag(body)
+    entry = %{body: body, etag: etag}
+    store(entry, now)
+    {:ok, Map.put(entry, :stale?, false)}
   end
 
   defp refresh_stale({:ok, entry, _fetched_at}, now) do

--- a/web/lib/raxol_playground_web/controllers/release_manifest_controller.ex
+++ b/web/lib/raxol_playground_web/controllers/release_manifest_controller.ex
@@ -1,0 +1,44 @@
+defmodule RaxolPlaygroundWeb.ReleaseManifestController do
+  use RaxolPlaygroundWeb, :controller
+
+  require Logger
+
+  alias RaxolPlayground.ReleaseManifestCache
+
+  @cache_control "public, max-age=60, stale-if-error=300"
+
+  def show(conn, _params) do
+    case ReleaseManifestCache.get() do
+      {:ok, entry} ->
+        send_manifest(conn, entry)
+
+      {:error, reason} ->
+        Logger.error("CLI release manifest unavailable: #{inspect(reason)}")
+
+        conn
+        |> put_resp_content_type("application/json")
+        |> put_resp_header("cache-control", "no-store")
+        |> send_resp(502, Jason.encode!(%{error: "release_manifest_unavailable"}))
+    end
+  end
+
+  defp send_manifest(conn, entry) do
+    conn =
+      conn
+      |> put_resp_content_type("application/json")
+      |> put_resp_header("cache-control", @cache_control)
+      |> put_resp_header("etag", entry.etag)
+      |> maybe_mark_stale(entry.stale?)
+
+    if entry.etag in get_req_header(conn, "if-none-match") do
+      send_resp(conn, 304, "")
+    else
+      send_resp(conn, 200, entry.body)
+    end
+  end
+
+  defp maybe_mark_stale(conn, true),
+    do: put_resp_header(conn, "warning", ~s(110 - "Response is stale"))
+
+  defp maybe_mark_stale(conn, false), do: conn
+end

--- a/web/lib/raxol_playground_web/router.ex
+++ b/web/lib/raxol_playground_web/router.ex
@@ -14,6 +14,7 @@ defmodule RaxolPlaygroundWeb.Router do
   scope "/", RaxolPlaygroundWeb do
     get("/health", HealthController, :check)
     get("/install", InstallController, :show)
+    get("/releases/latest.json", ReleaseManifestController, :show)
     get("/skill.md", SkillController, :show)
     # The landing hero's four examples, as files that run. The whole segment
     # is the param because Phoenix allows no suffix after one; the controller

--- a/web/test/fixtures/release_manifest.json
+++ b/web/test/fixtures/release_manifest.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": 1,
+  "version": "0.3.0",
+  "tag": "raxol-cli-v0.3.0",
+  "published_at": "2026-09-10T12:00:00Z",
+  "repository": "DROOdotFOO/raxol",
+  "signer_workflow": "DROOdotFOO/raxol/.github/workflows/release-raxol-cli.yml",
+  "assets": {
+    "darwin-arm64": {
+      "name": "raxol_cli_macos",
+      "url": "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol_cli_macos",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "attestation_url": "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol-cli-attestation.sigstore.json"
+    },
+    "linux-x64": {
+      "name": "raxol_cli_linux",
+      "url": "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol_cli_linux",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "attestation_url": "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol-cli-attestation.sigstore.json"
+    },
+    "linux-arm64": {
+      "name": "raxol_cli_linux_arm",
+      "url": "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol_cli_linux_arm",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "attestation_url": "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol-cli-attestation.sigstore.json"
+    },
+    "win32-x64": {
+      "name": "raxol_cli_windows.exe",
+      "url": "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol_cli_windows.exe",
+      "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "attestation_url": "https://github.com/DROOdotFOO/raxol/releases/download/raxol-cli-v0.3.0/raxol-cli-attestation.sigstore.json"
+    }
+  }
+}

--- a/web/test/raxol_playground/release_manifest_cache_test.exs
+++ b/web/test/raxol_playground/release_manifest_cache_test.exs
@@ -1,62 +1,45 @@
 defmodule RaxolPlayground.ReleaseManifestCacheTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias RaxolPlayground.ReleaseManifestCache
 
+  setup do
+    ReleaseManifestCache.reset()
+    on_exit(fn -> ReleaseManifestCache.reset() end)
+    :ok
+  end
+
   test "revalidates upstream and serves a bounded stale manifest on failure" do
     body = Jason.encode!(manifest())
-    {url, server} = serve_responses([{200, body, ~s("fixture")}, {503, "", nil}])
-    cache = Module.concat(__MODULE__, "Cache#{System.unique_integer([:positive])}")
-
-    start_supervised!(
-      {ReleaseManifestCache, name: cache, url: url, fresh_ms: 0, stale_ms: :timer.minutes(5)}
-    )
 
     assert {:ok, %{body: ^body, etag: ~s("fixture"), stale?: false}} =
-             ReleaseManifestCache.get(cache)
+             ReleaseManifestCache.get(
+               fresh_ms: 0,
+               req_options: [plug: response_plug(200, body, ~s("fixture"))]
+             )
 
     assert {:ok, %{body: ^body, etag: ~s("fixture"), stale?: true}} =
-             ReleaseManifestCache.get(cache)
+             ReleaseManifestCache.get(
+               fresh_ms: 0,
+               req_options: [plug: response_plug(503, "", nil)]
+             )
 
-    refute Process.alive?(server)
+    assert {:error, {:http_status, 503}} =
+             ReleaseManifestCache.get(
+               fresh_ms: 0,
+               stale_ms: -1,
+               req_options: [plug: response_plug(503, "", nil)]
+             )
   end
 
-  defp serve_responses(responses) do
-    {:ok, listener} =
-      :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true, ip: {127, 0, 0, 1}])
+  defp response_plug(status, body, etag) do
+    fn conn ->
+      conn = if etag, do: Plug.Conn.put_resp_header(conn, "etag", etag), else: conn
 
-    {:ok, {_address, port}} = :inet.sockname(listener)
-
-    server =
-      spawn_link(fn ->
-        Enum.each(responses, fn {status, body, etag} ->
-          {:ok, socket} = :gen_tcp.accept(listener)
-          {:ok, _request} = :gen_tcp.recv(socket, 0, 2_000)
-          :ok = :gen_tcp.send(socket, response(status, body, etag))
-          :gen_tcp.close(socket)
-        end)
-
-        :gen_tcp.close(listener)
-      end)
-
-    on_exit(fn ->
-      if Process.alive?(server), do: Process.exit(server, :kill)
-      :gen_tcp.close(listener)
-    end)
-
-    {"http://127.0.0.1:#{port}/latest.json", server}
-  end
-
-  defp response(status, body, etag) do
-    reason = if status == 200, do: "OK", else: "Service Unavailable"
-    etag_header = if etag, do: "ETag: #{etag}\r\n", else: ""
-
-    "HTTP/1.1 #{status} #{reason}\r\n" <>
-      "Content-Type: application/json\r\n" <>
-      etag_header <>
-      "Content-Length: #{byte_size(body)}\r\n" <>
-      "Connection: close\r\n\r\n" <>
-      body
+      conn
+      |> Plug.Conn.put_resp_content_type("application/json")
+      |> Plug.Conn.send_resp(status, body)
+    end
   end
 
   defp manifest do

--- a/web/test/raxol_playground/release_manifest_cache_test.exs
+++ b/web/test/raxol_playground/release_manifest_cache_test.exs
@@ -1,0 +1,94 @@
+defmodule RaxolPlayground.ReleaseManifestCacheTest do
+  use ExUnit.Case, async: true
+
+  alias RaxolPlayground.ReleaseManifestCache
+
+  test "revalidates upstream and serves a bounded stale manifest on failure" do
+    body = Jason.encode!(manifest())
+    {url, server} = serve_responses([{200, body, ~s("fixture")}, {503, "", nil}])
+    cache = Module.concat(__MODULE__, "Cache#{System.unique_integer([:positive])}")
+
+    start_supervised!(
+      {ReleaseManifestCache, name: cache, url: url, fresh_ms: 0, stale_ms: :timer.minutes(5)}
+    )
+
+    assert {:ok, %{body: ^body, etag: ~s("fixture"), stale?: false}} =
+             ReleaseManifestCache.get(cache)
+
+    assert {:ok, %{body: ^body, etag: ~s("fixture"), stale?: true}} =
+             ReleaseManifestCache.get(cache)
+
+    refute Process.alive?(server)
+  end
+
+  defp serve_responses(responses) do
+    {:ok, listener} =
+      :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true, ip: {127, 0, 0, 1}])
+
+    {:ok, {_address, port}} = :inet.sockname(listener)
+
+    server =
+      spawn_link(fn ->
+        Enum.each(responses, fn {status, body, etag} ->
+          {:ok, socket} = :gen_tcp.accept(listener)
+          {:ok, _request} = :gen_tcp.recv(socket, 0, 2_000)
+          :ok = :gen_tcp.send(socket, response(status, body, etag))
+          :gen_tcp.close(socket)
+        end)
+
+        :gen_tcp.close(listener)
+      end)
+
+    on_exit(fn ->
+      if Process.alive?(server), do: Process.exit(server, :kill)
+      :gen_tcp.close(listener)
+    end)
+
+    {"http://127.0.0.1:#{port}/latest.json", server}
+  end
+
+  defp response(status, body, etag) do
+    reason = if status == 200, do: "OK", else: "Service Unavailable"
+    etag_header = if etag, do: "ETag: #{etag}\r\n", else: ""
+
+    "HTTP/1.1 #{status} #{reason}\r\n" <>
+      "Content-Type: application/json\r\n" <>
+      etag_header <>
+      "Content-Length: #{byte_size(body)}\r\n" <>
+      "Connection: close\r\n\r\n" <>
+      body
+  end
+
+  defp manifest do
+    version = "0.3.0"
+    tag = "raxol-cli-v#{version}"
+    base = "https://github.com/DROOdotFOO/raxol/releases/download/#{tag}"
+    attestation_url = "#{base}/raxol-cli-attestation.sigstore.json"
+
+    assets = %{
+      "darwin-arm64" => "raxol_cli_macos",
+      "linux-x64" => "raxol_cli_linux",
+      "linux-arm64" => "raxol_cli_linux_arm",
+      "win32-x64" => "raxol_cli_windows.exe"
+    }
+
+    %{
+      "schema_version" => 1,
+      "version" => version,
+      "tag" => tag,
+      "published_at" => "2026-09-10T12:00:00Z",
+      "repository" => "DROOdotFOO/raxol",
+      "signer_workflow" => "DROOdotFOO/raxol/.github/workflows/release-raxol-cli.yml",
+      "assets" =>
+        Map.new(assets, fn {platform, name} ->
+          {platform,
+           %{
+             "name" => name,
+             "url" => "#{base}/#{name}",
+             "sha256" => String.duplicate("a", 64),
+             "attestation_url" => attestation_url
+           }}
+        end)
+    }
+  end
+end

--- a/web/test/raxol_playground/release_manifest_cache_test.exs
+++ b/web/test/raxol_playground/release_manifest_cache_test.exs
@@ -2,6 +2,7 @@ defmodule RaxolPlayground.ReleaseManifestCacheTest do
   use ExUnit.Case, async: false
 
   alias RaxolPlayground.ReleaseManifestCache
+  @fixture Path.expand("../fixtures/release_manifest.json", __DIR__)
 
   setup do
     ReleaseManifestCache.reset()
@@ -10,7 +11,7 @@ defmodule RaxolPlayground.ReleaseManifestCacheTest do
   end
 
   test "revalidates upstream and serves a bounded stale manifest on failure" do
-    body = Jason.encode!(manifest())
+    body = File.read!(@fixture)
 
     assert {:ok, %{body: ^body, etag: ~s("fixture"), stale?: false}} =
              ReleaseManifestCache.get(
@@ -40,38 +41,5 @@ defmodule RaxolPlayground.ReleaseManifestCacheTest do
       |> Plug.Conn.put_resp_content_type("application/json")
       |> Plug.Conn.send_resp(status, body)
     end
-  end
-
-  defp manifest do
-    version = "0.3.0"
-    tag = "raxol-cli-v#{version}"
-    base = "https://github.com/DROOdotFOO/raxol/releases/download/#{tag}"
-    attestation_url = "#{base}/raxol-cli-attestation.sigstore.json"
-
-    assets = %{
-      "darwin-arm64" => "raxol_cli_macos",
-      "linux-x64" => "raxol_cli_linux",
-      "linux-arm64" => "raxol_cli_linux_arm",
-      "win32-x64" => "raxol_cli_windows.exe"
-    }
-
-    %{
-      "schema_version" => 1,
-      "version" => version,
-      "tag" => tag,
-      "published_at" => "2026-09-10T12:00:00Z",
-      "repository" => "DROOdotFOO/raxol",
-      "signer_workflow" => "DROOdotFOO/raxol/.github/workflows/release-raxol-cli.yml",
-      "assets" =>
-        Map.new(assets, fn {platform, name} ->
-          {platform,
-           %{
-             "name" => name,
-             "url" => "#{base}/#{name}",
-             "sha256" => String.duplicate("a", 64),
-             "attestation_url" => attestation_url
-           }}
-        end)
-    }
   end
 end

--- a/web/test/raxol_playground/release_manifest_test.exs
+++ b/web/test/raxol_playground/release_manifest_test.exs
@@ -2,9 +2,10 @@ defmodule RaxolPlayground.ReleaseManifestTest do
   use ExUnit.Case, async: true
 
   alias RaxolPlayground.ReleaseManifest
+  @fixture Path.expand("../fixtures/release_manifest.json", __DIR__)
 
   test "accepts only immutable assets from the declared release" do
-    manifest = manifest()
+    manifest = @fixture |> File.read!() |> Jason.decode!()
 
     assert :ok = ReleaseManifest.validate(Jason.encode!(manifest))
 
@@ -13,7 +14,7 @@ defmodule RaxolPlayground.ReleaseManifestTest do
   end
 
   test "rejects version, digest, and platform-set mismatches" do
-    manifest = manifest()
+    manifest = @fixture |> File.read!() |> Jason.decode!()
 
     assert {:error, :invalid_manifest} =
              manifest
@@ -32,38 +33,5 @@ defmodule RaxolPlayground.ReleaseManifestTest do
              |> update_in(["assets"], &Map.delete(&1, "win32-x64"))
              |> Jason.encode!()
              |> ReleaseManifest.validate()
-  end
-
-  defp manifest do
-    version = "0.3.0"
-    tag = "raxol-cli-v#{version}"
-    base = "https://github.com/DROOdotFOO/raxol/releases/download/#{tag}"
-    attestation_url = "#{base}/raxol-cli-attestation.sigstore.json"
-
-    assets = %{
-      "darwin-arm64" => "raxol_cli_macos",
-      "linux-x64" => "raxol_cli_linux",
-      "linux-arm64" => "raxol_cli_linux_arm",
-      "win32-x64" => "raxol_cli_windows.exe"
-    }
-
-    %{
-      "schema_version" => 1,
-      "version" => version,
-      "tag" => tag,
-      "published_at" => "2026-09-10T12:00:00Z",
-      "repository" => "DROOdotFOO/raxol",
-      "signer_workflow" => "DROOdotFOO/raxol/.github/workflows/release-raxol-cli.yml",
-      "assets" =>
-        Map.new(assets, fn {platform, name} ->
-          {platform,
-           %{
-             "name" => name,
-             "url" => "#{base}/#{name}",
-             "sha256" => String.duplicate("a", 64),
-             "attestation_url" => attestation_url
-           }}
-        end)
-    }
   end
 end

--- a/web/test/raxol_playground/release_manifest_test.exs
+++ b/web/test/raxol_playground/release_manifest_test.exs
@@ -1,0 +1,69 @@
+defmodule RaxolPlayground.ReleaseManifestTest do
+  use ExUnit.Case, async: true
+
+  alias RaxolPlayground.ReleaseManifest
+
+  test "accepts only immutable assets from the declared release" do
+    manifest = manifest()
+
+    assert :ok = ReleaseManifest.validate(Jason.encode!(manifest))
+
+    tampered = put_in(manifest, ["assets", "linux-x64", "url"], "https://example.com/raxol")
+    assert {:error, :invalid_manifest} = ReleaseManifest.validate(Jason.encode!(tampered))
+  end
+
+  test "rejects version, digest, and platform-set mismatches" do
+    manifest = manifest()
+
+    assert {:error, :invalid_manifest} =
+             manifest
+             |> Map.put("tag", "raxol-cli-v9.9.9")
+             |> Jason.encode!()
+             |> ReleaseManifest.validate()
+
+    assert {:error, :invalid_manifest} =
+             manifest
+             |> put_in(["assets", "darwin-arm64", "sha256"], "not-a-digest")
+             |> Jason.encode!()
+             |> ReleaseManifest.validate()
+
+    assert {:error, :invalid_manifest} =
+             manifest
+             |> update_in(["assets"], &Map.delete(&1, "win32-x64"))
+             |> Jason.encode!()
+             |> ReleaseManifest.validate()
+  end
+
+  defp manifest do
+    version = "0.3.0"
+    tag = "raxol-cli-v#{version}"
+    base = "https://github.com/DROOdotFOO/raxol/releases/download/#{tag}"
+    attestation_url = "#{base}/raxol-cli-attestation.sigstore.json"
+
+    assets = %{
+      "darwin-arm64" => "raxol_cli_macos",
+      "linux-x64" => "raxol_cli_linux",
+      "linux-arm64" => "raxol_cli_linux_arm",
+      "win32-x64" => "raxol_cli_windows.exe"
+    }
+
+    %{
+      "schema_version" => 1,
+      "version" => version,
+      "tag" => tag,
+      "published_at" => "2026-09-10T12:00:00Z",
+      "repository" => "DROOdotFOO/raxol",
+      "signer_workflow" => "DROOdotFOO/raxol/.github/workflows/release-raxol-cli.yml",
+      "assets" =>
+        Map.new(assets, fn {platform, name} ->
+          {platform,
+           %{
+             "name" => name,
+             "url" => "#{base}/#{name}",
+             "sha256" => String.duplicate("a", 64),
+             "attestation_url" => attestation_url
+           }}
+        end)
+    }
+  end
+end


### PR DESCRIPTION
## Summary

- gate CLI GitHub Releases on a clean npm registry install and provenance audit
- attest native binaries and publish immutable/version-channel release manifests
- serve a cached manifest at raxol.io and make the shell installer consume it
- add explicit GitHub provenance verification to the installer
- verify Hex registry consumption and HexDocs before creating root releases
- bump the CLI patch release to 0.2.9

## Security decisions

- SHA-256 remains mandatory for every shell install
- provenance verification is opt-in and fails closed when requested
- npm remains OIDC-only; no signing secret is added
- version release tags are protected by the repository ruleset

## Manual testing

- [x] `actionlint` passes for all release workflows
- [x] `shellcheck scripts/install.sh`
- [x] focused installer and manifest tests pass
- [x] focused web manifest validation/cache tests pass
- [x] root and web compilation pass with warnings as errors
- [x] isolated install of published `@raxol/cli@0.2.8` passes signature audit
- [ ] tag `raxol-cli-v0.2.9` and verify the live attestation/manifest/install path after merge
