### PR TITLE
Accept exact CLI release versions

### DIFF
--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -341,7 +341,9 @@ jobs:
             --prefer-online --no-audit --no-fund "@raxol/cli@$version"
 
           installed_version="$("$smoke/node_modules/.bin/raxol" --version)"
-          [[ "$installed_version" == "raxol $version+"* ]] || {
+          expected_version="raxol $version"
+          [[ "$installed_version" == "$expected_version" ||
+            "$installed_version" == "$expected_version+"* ]] || {
             echo "::error::fresh install reported $installed_version"
             exit 1
           }

--- a/docs/development/RELEASE_CHECKLIST.md
+++ b/docs/development/RELEASE_CHECKLIST.md
@@ -20,7 +20,7 @@ window, and an npm version cannot be reused.
 | `raxol_watch` | Hex | 0.2.1 |
 | `raxol_payments` | Hex | 0.2.1 |
 | `raxol_telegram` | Hex | 0.2.1 |
-| `@raxol/cli` and four `@raxol/cli-*` binaries | npm | 0.2.9 |
+| `@raxol/cli` and four `@raxol/cli-*` binaries | npm | 0.2.10 |
 
 The following projects remain outside the public Hex train:
 `raxol_agent_client_protocol`, `raxol_gateway`, `raxol_earn`,
@@ -120,8 +120,8 @@ The npm version in `packages/raxol_cli/npm/package.json` and the CLI Mix project
 version must already agree. Create the matching tag:
 
 ```bash
-git tag -a raxol-cli-v0.2.9 -m "raxol CLI 0.2.9"
-git push origin raxol-cli-v0.2.9
+git tag -a raxol-cli-v0.2.10 -m "raxol CLI 0.2.10"
+git push origin raxol-cli-v0.2.10
 ```
 
 `.github/workflows/release-raxol-cli.yml` rejects a mismatched tag before doing
@@ -142,10 +142,10 @@ After approval and completion:
 
 ```bash
 mix hex.info raxol 2.8.0
-npm view @raxol/cli@0.2.9 version dist.integrity
+npm view @raxol/cli@0.2.10 version dist.integrity
 
 tmp="$(mktemp -d)"
-npm install --prefix "$tmp" @raxol/cli@0.2.9
+npm install --prefix "$tmp" @raxol/cli@0.2.10
 "$tmp/node_modules/.bin/raxol" --version
 (cd "$tmp" && npm audit signatures)
 

--- a/packages/raxol_cli/mix.exs
+++ b/packages/raxol_cli/mix.exs
@@ -1,7 +1,7 @@
 defmodule RaxolCli.MixProject do
   use Mix.Project
 
-  @version "0.2.9"
+  @version "0.2.10"
   @source_url "https://github.com/DROOdotFOO/raxol"
 
   def project do

--- a/packages/raxol_cli/npm/package.json
+++ b/packages/raxol_cli/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raxol/cli",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Interactive AI agent and TUI toolkit in your terminal. A self-contained binary (via Burrito), so `npm i -g @raxol/cli` puts `raxol` on your PATH -- no Erlang or Elixir required.",
   "bin": {
     "raxol": "bin/launcher.js"
@@ -12,10 +12,10 @@
     "bin/"
   ],
   "optionalDependencies": {
-    "@raxol/cli-darwin-arm64": "0.2.9",
-    "@raxol/cli-linux-x64": "0.2.9",
-    "@raxol/cli-linux-arm64": "0.2.9",
-    "@raxol/cli-win32-x64": "0.2.9"
+    "@raxol/cli-darwin-arm64": "0.2.10",
+    "@raxol/cli-linux-x64": "0.2.10",
+    "@raxol/cli-linux-arm64": "0.2.10",
+    "@raxol/cli-win32-x64": "0.2.10"
   },
   "keywords": [
     "raxol",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,7 +2,7 @@
 # install.sh -- install the `raxol` CLI from an immutable GitHub Release.
 #
 #   curl -fsSL https://raxol.io/install | bash
-#   curl -fsSL https://raxol.io/install | bash -s -- --version 0.2.9
+#   curl -fsSL https://raxol.io/install | bash -s -- --version 0.2.10
 #   curl -fsSL https://raxol.io/install | bash -s -- --verify-provenance
 #
 # The binary is self-contained (Burrito wraps its own ERTS), so this installs


### PR DESCRIPTION
## Problem

The 0.2.9 tag published all five npm packages, then the fresh-install gate rejected the valid output `raxol 0.2.9` because it required build metadata. Release assets and the latest manifest were therefore correctly withheld.

## Change

- accept both exact semver output and semver with build metadata
- bump the CLI package train to 0.2.10 so the immutable tag can complete cleanly
- update release examples to the new version

## Manual testing

- [x] `actionlint .github/workflows/release-raxol-cli.yml`
- [x] exact, metadata-bearing, and mismatched version outputs exercised
- [x] npm wrapper tests pass
- [x] `packages/raxol_cli` tests pass
- [x] release manifest and installer tests pass
- [x] `shellcheck scripts/install.sh`
