### PR TITLE
Extend npm registry visibility wait

### DIFF
--- a/.github/workflows/release-raxol-cli.yml
+++ b/.github/workflows/release-raxol-cli.yml
@@ -290,16 +290,16 @@ jobs:
             name="$(node -p "require(require('node:path').resolve(process.argv[1])).name" "$manifest")"
             version="$(node -p "require(require('node:path').resolve(process.argv[1])).version" "$manifest")"
 
-            for attempt in {1..60}; do
+            for attempt in {1..180}; do
               if npm view "$name@$version" version >/dev/null 2>&1; then
                 echo "$name@$version is visible in the registry"
                 return 0
               fi
-              echo "Waiting for $name@$version to become visible ($attempt/60)"
+              echo "Waiting for $name@$version to become visible ($attempt/180)"
               sleep 5
             done
 
-            echo "::error::$name@$version was published but is not visible after 5 minutes"
+            echo "::error::$name@$version was published but is not visible after 15 minutes"
             return 1
           }
 


### PR DESCRIPTION
## Problem

npm accepted `@raxol/cli-darwin-arm64@0.2.10` but kept it in registry processing for roughly eight minutes. The five-minute visibility release gate failed even though publication later completed successfully.

## Change

Extend the bounded registry visibility window from five to fifteen minutes. Publication remains resumable and still fails closed if npm never exposes the package.

## Manual testing

- [x] `actionlint .github/workflows/release-raxol-cli.yml`
- [x] observed delayed package become visible before resuming the release
- [x] resumed 0.2.10 release completed successfully
